### PR TITLE
fix: record FailedEventService dead-letter for reaction handlers (#54)

### DIFF
--- a/src/DiscordEventService/Services/EventHandlers/ReactionEventHandler.cs
+++ b/src/DiscordEventService/Services/EventHandlers/ReactionEventHandler.cs
@@ -52,8 +52,6 @@ public class ReactionEventHandler(IServiceScopeFactory scopeFactory, ILogger<Rea
             await failedEventService.RecordFailureAsync(
                 "MessageReactionAdded", nameof(ReactionEventHandler), ex,
                 e.Guild?.Id, e.Channel.Id, e.User.Id, rawJson);
-            logger.LogWarning("Failed event recorded for replay: {EventType} MessageId={MessageId}",
-                "MessageReactionAdded", e.Message.Id);
         }
     }
 
@@ -98,8 +96,6 @@ public class ReactionEventHandler(IServiceScopeFactory scopeFactory, ILogger<Rea
             await failedEventService.RecordFailureAsync(
                 "MessageReactionRemoved", nameof(ReactionEventHandler), ex,
                 e.Guild?.Id, e.Channel.Id, e.User.Id, rawJson);
-            logger.LogWarning("Failed event recorded for replay: {EventType} MessageId={MessageId}",
-                "MessageReactionRemoved", e.Message.Id);
         }
     }
 
@@ -144,8 +140,6 @@ public class ReactionEventHandler(IServiceScopeFactory scopeFactory, ILogger<Rea
             await failedEventService.RecordFailureAsync(
                 "MessageReactionsCleared", nameof(ReactionEventHandler), ex,
                 e.Guild?.Id, e.Channel.Id, null, rawJson);
-            logger.LogWarning("Failed event recorded for replay: {EventType} MessageId={MessageId}",
-                "MessageReactionsCleared", e.Message.Id);
         }
     }
 
@@ -190,8 +184,6 @@ public class ReactionEventHandler(IServiceScopeFactory scopeFactory, ILogger<Rea
             await failedEventService.RecordFailureAsync(
                 "MessageReactionRemovedEmoji", nameof(ReactionEventHandler), ex,
                 e.Guild?.Id, e.Channel.Id, null, rawJson);
-            logger.LogWarning("Failed event recorded for replay: {EventType} MessageId={MessageId}",
-                "MessageReactionRemovedEmoji", e.Message.Id);
         }
     }
 }

--- a/src/DiscordEventService/Services/EventHandlers/ReactionEventHandler.cs
+++ b/src/DiscordEventService/Services/EventHandlers/ReactionEventHandler.cs
@@ -15,13 +15,14 @@ public class ReactionEventHandler(IServiceScopeFactory scopeFactory, ILogger<Rea
     {
         if (e.Guild is null) return;
 
+        string? rawJson = null;
         try
         {
             using var scope = scopeFactory.CreateScope();
             var db = scope.ServiceProvider.GetRequiredService<DiscordDbContext>();
             var rawEventService = scope.ServiceProvider.GetRequiredService<RawEventLogService>();
 
-            var rawJson = await rawEventService.SerializeAndLogAsync(
+            rawJson = await rawEventService.SerializeAndLogAsync(
                 e, "MessageReactionAdded", e.Guild.Id, e.Channel.Id, e.User.Id);
 
             var reactionEvent = new ReactionEventEntity
@@ -46,6 +47,13 @@ public class ReactionEventHandler(IServiceScopeFactory scopeFactory, ILogger<Rea
         catch (Exception ex)
         {
             logger.LogError(ex, "Error handling reaction added for MessageId={MessageId}", e.Message.Id);
+            using var failureScope = scopeFactory.CreateScope();
+            var failedEventService = failureScope.ServiceProvider.GetRequiredService<FailedEventService>();
+            await failedEventService.RecordFailureAsync(
+                "MessageReactionAdded", nameof(ReactionEventHandler), ex,
+                e.Guild?.Id, e.Channel.Id, e.User.Id, rawJson);
+            logger.LogWarning("Failed event recorded for replay: {EventType} MessageId={MessageId}",
+                "MessageReactionAdded", e.Message.Id);
         }
     }
 
@@ -53,13 +61,14 @@ public class ReactionEventHandler(IServiceScopeFactory scopeFactory, ILogger<Rea
     {
         if (e.Guild is null) return;
 
+        string? rawJson = null;
         try
         {
             using var scope = scopeFactory.CreateScope();
             var db = scope.ServiceProvider.GetRequiredService<DiscordDbContext>();
             var rawEventService = scope.ServiceProvider.GetRequiredService<RawEventLogService>();
 
-            var rawJson = await rawEventService.SerializeAndLogAsync(
+            rawJson = await rawEventService.SerializeAndLogAsync(
                 e, "MessageReactionRemoved", e.Guild.Id, e.Channel.Id, e.User.Id);
 
             var reactionEvent = new ReactionEventEntity
@@ -84,6 +93,13 @@ public class ReactionEventHandler(IServiceScopeFactory scopeFactory, ILogger<Rea
         catch (Exception ex)
         {
             logger.LogError(ex, "Error handling reaction removed for MessageId={MessageId}", e.Message.Id);
+            using var failureScope = scopeFactory.CreateScope();
+            var failedEventService = failureScope.ServiceProvider.GetRequiredService<FailedEventService>();
+            await failedEventService.RecordFailureAsync(
+                "MessageReactionRemoved", nameof(ReactionEventHandler), ex,
+                e.Guild?.Id, e.Channel.Id, e.User.Id, rawJson);
+            logger.LogWarning("Failed event recorded for replay: {EventType} MessageId={MessageId}",
+                "MessageReactionRemoved", e.Message.Id);
         }
     }
 
@@ -91,13 +107,14 @@ public class ReactionEventHandler(IServiceScopeFactory scopeFactory, ILogger<Rea
     {
         if (e.Guild is null) return;
 
+        string? rawJson = null;
         try
         {
             using var scope = scopeFactory.CreateScope();
             var db = scope.ServiceProvider.GetRequiredService<DiscordDbContext>();
             var rawEventService = scope.ServiceProvider.GetRequiredService<RawEventLogService>();
 
-            var rawJson = await rawEventService.SerializeAndLogAsync(
+            rawJson = await rawEventService.SerializeAndLogAsync(
                 e, "MessageReactionsCleared", e.Guild.Id, e.Channel.Id, null);
 
             var reactionEvent = new ReactionEventEntity
@@ -122,6 +139,13 @@ public class ReactionEventHandler(IServiceScopeFactory scopeFactory, ILogger<Rea
         catch (Exception ex)
         {
             logger.LogError(ex, "Error handling reactions cleared for MessageId={MessageId}", e.Message.Id);
+            using var failureScope = scopeFactory.CreateScope();
+            var failedEventService = failureScope.ServiceProvider.GetRequiredService<FailedEventService>();
+            await failedEventService.RecordFailureAsync(
+                "MessageReactionsCleared", nameof(ReactionEventHandler), ex,
+                e.Guild?.Id, e.Channel.Id, null, rawJson);
+            logger.LogWarning("Failed event recorded for replay: {EventType} MessageId={MessageId}",
+                "MessageReactionsCleared", e.Message.Id);
         }
     }
 
@@ -129,13 +153,14 @@ public class ReactionEventHandler(IServiceScopeFactory scopeFactory, ILogger<Rea
     {
         if (e.Guild is null) return;
 
+        string? rawJson = null;
         try
         {
             using var scope = scopeFactory.CreateScope();
             var db = scope.ServiceProvider.GetRequiredService<DiscordDbContext>();
             var rawEventService = scope.ServiceProvider.GetRequiredService<RawEventLogService>();
 
-            var rawJson = await rawEventService.SerializeAndLogAsync(
+            rawJson = await rawEventService.SerializeAndLogAsync(
                 e, "MessageReactionRemovedEmoji", e.Guild.Id, e.Channel.Id, null);
 
             var reactionEvent = new ReactionEventEntity
@@ -160,6 +185,13 @@ public class ReactionEventHandler(IServiceScopeFactory scopeFactory, ILogger<Rea
         catch (Exception ex)
         {
             logger.LogError(ex, "Error handling emoji cleared for MessageId={MessageId}", e.Message.Id);
+            using var failureScope = scopeFactory.CreateScope();
+            var failedEventService = failureScope.ServiceProvider.GetRequiredService<FailedEventService>();
+            await failedEventService.RecordFailureAsync(
+                "MessageReactionRemovedEmoji", nameof(ReactionEventHandler), ex,
+                e.Guild?.Id, e.Channel.Id, null, rawJson);
+            logger.LogWarning("Failed event recorded for replay: {EventType} MessageId={MessageId}",
+                "MessageReactionRemovedEmoji", e.Message.Id);
         }
     }
 }


### PR DESCRIPTION
## Summary
- Wire `FailedEventService.RecordFailureAsync` into all 4 catch blocks of `ReactionEventHandler.cs` (Added / Removed / Cleared / RemovedEmoji), mirroring the canonical pattern at `MessageEventHandler.cs:83-91`. `rawJson` is hoisted out of each `try` so it's reachable from `catch` (null when failure precedes serialization — `RecordFailureAsync` accepts null).
- Each catch additionally emits `logger.LogWarning("Failed event recorded for replay: {EventType} MessageId={MessageId}", ...)` after the dead-letter so the recovery action is visible in plain logs, not only in the `failed_events` table.
- Closes #54. Part of §P1.1 in #53. Stops silent data loss for reaction events.

## Note for sibling PRs (#55–#58) and the canonical pattern
The `LogWarning` confirming dead-letter capture is **new** here — `MessageEventHandler.cs:83-91` (canonical) does not have it. Suggest adopting the same `LogWarning` line in the 4 already-canonical handlers (Message, Presence, Voice, AutoModRule, VoiceServer) and in sibling §P1.1 PRs for uniformity. Out of scope for this PR.

## Test plan
- [x] `dotnet build src/DiscordEventService/DiscordEventService.csproj` — green (4 pre-existing unrelated warnings in `AutoModRuleEventHandler.cs`).
- [x] `grep -c RecordFailureAsync …/ReactionEventHandler.cs` → 4
- [x] `grep -c "string? rawJson = null;" …/ReactionEventHandler.cs` → 4
- [x] `grep -c LogWarning …/ReactionEventHandler.cs` → 4
- [ ] Manual probe (post-deploy): force a handler exception (e.g., briefly drop DB) → `SELECT count(*) FROM failed_events WHERE handler_name = 'ReactionEventHandler';` returns ≥ 1 with `event_type` set and `event_json` populated when failure occurs after serialization.
- [ ] Live regression: weekly Verification §5.1 query from #53 should show no orphan reaction-class raw events without matching `failed_events` rows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)