### PR TITLE
fix: record FailedEventService dead-letter for Channel/Role/Member handlers (#55)

### DIFF
--- a/src/DiscordEventService/Services/EventHandlers/ChannelEventHandler.cs
+++ b/src/DiscordEventService/Services/EventHandlers/ChannelEventHandler.cs
@@ -16,13 +16,14 @@ public class ChannelEventHandler(IServiceScopeFactory scopeFactory, ILogger<Chan
 {
     public async Task HandleEventAsync(DiscordClient sender, ChannelCreatedEventArgs e)
     {
+        string? rawJson = null;
         try
         {
             using var scope = scopeFactory.CreateScope();
             var db = scope.ServiceProvider.GetRequiredService<DiscordDbContext>();
             var rawEventService = scope.ServiceProvider.GetRequiredService<RawEventLogService>();
 
-            var rawJson = await rawEventService.SerializeAndLogAsync(
+            rawJson = await rawEventService.SerializeAndLogAsync(
                 e, "ChannelCreated", e.Guild.Id, e.Channel.Id, null);
 
             // Look up Guild Guid
@@ -63,18 +64,24 @@ public class ChannelEventHandler(IServiceScopeFactory scopeFactory, ILogger<Chan
         catch (Exception ex)
         {
             logger.LogError(ex, "Error handling channel created for ChannelId={ChannelId}", e.Channel.Id);
+            using var failureScope = scopeFactory.CreateScope();
+            var failedEventService = failureScope.ServiceProvider.GetRequiredService<FailedEventService>();
+            await failedEventService.RecordFailureAsync(
+                "ChannelCreated", nameof(ChannelEventHandler), ex,
+                e.Guild?.Id, e.Channel.Id, null, rawJson);
         }
     }
 
     public async Task HandleEventAsync(DiscordClient sender, ChannelUpdatedEventArgs e)
     {
+        string? rawJson = null;
         try
         {
             using var scope = scopeFactory.CreateScope();
             var db = scope.ServiceProvider.GetRequiredService<DiscordDbContext>();
             var rawEventService = scope.ServiceProvider.GetRequiredService<RawEventLogService>();
 
-            var rawJson = await rawEventService.SerializeAndLogAsync(
+            rawJson = await rawEventService.SerializeAndLogAsync(
                 e, "ChannelUpdated", e.ChannelAfter.Guild.Id, e.ChannelAfter.Id, null);
 
             var channelEntity = await db.Channels
@@ -120,18 +127,24 @@ public class ChannelEventHandler(IServiceScopeFactory scopeFactory, ILogger<Chan
         catch (Exception ex)
         {
             logger.LogError(ex, "Error handling channel updated for ChannelId={ChannelId}", e.ChannelAfter.Id);
+            using var failureScope = scopeFactory.CreateScope();
+            var failedEventService = failureScope.ServiceProvider.GetRequiredService<FailedEventService>();
+            await failedEventService.RecordFailureAsync(
+                "ChannelUpdated", nameof(ChannelEventHandler), ex,
+                e.ChannelAfter.Guild?.Id, e.ChannelAfter.Id, null, rawJson);
         }
     }
 
     public async Task HandleEventAsync(DiscordClient sender, ChannelDeletedEventArgs e)
     {
+        string? rawJson = null;
         try
         {
             using var scope = scopeFactory.CreateScope();
             var db = scope.ServiceProvider.GetRequiredService<DiscordDbContext>();
             var rawEventService = scope.ServiceProvider.GetRequiredService<RawEventLogService>();
 
-            var rawJson = await rawEventService.SerializeAndLogAsync(
+            rawJson = await rawEventService.SerializeAndLogAsync(
                 e, "ChannelDeleted", e.Guild.Id, e.Channel.Id, null);
 
             var channelEntity = await db.Channels
@@ -162,18 +175,24 @@ public class ChannelEventHandler(IServiceScopeFactory scopeFactory, ILogger<Chan
         catch (Exception ex)
         {
             logger.LogError(ex, "Error handling channel deleted for ChannelId={ChannelId}", e.Channel.Id);
+            using var failureScope = scopeFactory.CreateScope();
+            var failedEventService = failureScope.ServiceProvider.GetRequiredService<FailedEventService>();
+            await failedEventService.RecordFailureAsync(
+                "ChannelDeleted", nameof(ChannelEventHandler), ex,
+                e.Guild?.Id, e.Channel.Id, null, rawJson);
         }
     }
 
     public async Task HandleEventAsync(DiscordClient sender, ChannelPinsUpdatedEventArgs e)
     {
+        string? rawJson = null;
         try
         {
             using var scope = scopeFactory.CreateScope();
             var db = scope.ServiceProvider.GetRequiredService<DiscordDbContext>();
             var rawEventService = scope.ServiceProvider.GetRequiredService<RawEventLogService>();
 
-            var rawJson = await rawEventService.SerializeAndLogAsync(
+            rawJson = await rawEventService.SerializeAndLogAsync(
                 e, "ChannelPinsUpdatedChannel", e.Guild?.Id ?? 0, e.Channel.Id, null);
 
             var channelEvent = new ChannelEventEntity
@@ -193,6 +212,11 @@ public class ChannelEventHandler(IServiceScopeFactory scopeFactory, ILogger<Chan
         catch (Exception ex)
         {
             logger.LogError(ex, "Error handling channel pins updated for ChannelId={ChannelId}", e.Channel.Id);
+            using var failureScope = scopeFactory.CreateScope();
+            var failedEventService = failureScope.ServiceProvider.GetRequiredService<FailedEventService>();
+            await failedEventService.RecordFailureAsync(
+                "ChannelPinsUpdatedChannel", nameof(ChannelEventHandler), ex,
+                e.Guild?.Id, e.Channel.Id, null, rawJson);
         }
     }
 

--- a/src/DiscordEventService/Services/EventHandlers/MemberEventHandler.cs
+++ b/src/DiscordEventService/Services/EventHandlers/MemberEventHandler.cs
@@ -15,6 +15,7 @@ public class MemberEventHandler(IServiceScopeFactory scopeFactory, ILogger<Membe
 {
     public async Task HandleEventAsync(DiscordClient sender, GuildMemberAddedEventArgs e)
     {
+        string? rawJson = null;
         try
         {
             using var scope = scopeFactory.CreateScope();
@@ -22,7 +23,7 @@ public class MemberEventHandler(IServiceScopeFactory scopeFactory, ILogger<Membe
             var userService = scope.ServiceProvider.GetRequiredService<UserService>();
             var rawEventService = scope.ServiceProvider.GetRequiredService<RawEventLogService>();
 
-            var rawJson = await rawEventService.SerializeAndLogAsync(
+            rawJson = await rawEventService.SerializeAndLogAsync(
                 e, "GuildMemberAdded", e.Guild.Id, null, e.Member.Id);
 
             await userService.UpsertMemberAsync(e.Member);
@@ -47,18 +48,24 @@ public class MemberEventHandler(IServiceScopeFactory scopeFactory, ILogger<Membe
         catch (Exception ex)
         {
             logger.LogError(ex, "Error handling member added for UserId={UserId} GuildId={GuildId}", e.Member.Id, e.Guild.Id);
+            using var failureScope = scopeFactory.CreateScope();
+            var failedEventService = failureScope.ServiceProvider.GetRequiredService<FailedEventService>();
+            await failedEventService.RecordFailureAsync(
+                "GuildMemberAdded", nameof(MemberEventHandler), ex,
+                e.Guild?.Id, null, e.Member.Id, rawJson);
         }
     }
 
     public async Task HandleEventAsync(DiscordClient sender, GuildMemberRemovedEventArgs e)
     {
+        string? rawJson = null;
         try
         {
             using var scope = scopeFactory.CreateScope();
             var db = scope.ServiceProvider.GetRequiredService<DiscordDbContext>();
             var rawEventService = scope.ServiceProvider.GetRequiredService<RawEventLogService>();
 
-            var rawJson = await rawEventService.SerializeAndLogAsync(
+            rawJson = await rawEventService.SerializeAndLogAsync(
                 e, "GuildMemberRemoved", e.Guild.Id, null, e.Member.Id);
 
             var memberEvent = new MemberEventEntity
@@ -81,11 +88,17 @@ public class MemberEventHandler(IServiceScopeFactory scopeFactory, ILogger<Membe
         catch (Exception ex)
         {
             logger.LogError(ex, "Error handling member removed for UserId={UserId} GuildId={GuildId}", e.Member.Id, e.Guild.Id);
+            using var failureScope = scopeFactory.CreateScope();
+            var failedEventService = failureScope.ServiceProvider.GetRequiredService<FailedEventService>();
+            await failedEventService.RecordFailureAsync(
+                "GuildMemberRemoved", nameof(MemberEventHandler), ex,
+                e.Guild?.Id, null, e.Member.Id, rawJson);
         }
     }
 
     public async Task HandleEventAsync(DiscordClient sender, GuildMemberUpdatedEventArgs e)
     {
+        string? rawJson = null;
         try
         {
             using var scope = scopeFactory.CreateScope();
@@ -93,7 +106,7 @@ public class MemberEventHandler(IServiceScopeFactory scopeFactory, ILogger<Membe
             var userService = scope.ServiceProvider.GetRequiredService<UserService>();
             var rawEventService = scope.ServiceProvider.GetRequiredService<RawEventLogService>();
 
-            var rawJson = await rawEventService.SerializeAndLogAsync(
+            rawJson = await rawEventService.SerializeAndLogAsync(
                 e, "GuildMemberUpdated", e.Guild.Id, null, e.Member.Id);
 
             await userService.UpsertMemberAsync(e.Member);
@@ -138,11 +151,17 @@ public class MemberEventHandler(IServiceScopeFactory scopeFactory, ILogger<Membe
         catch (Exception ex)
         {
             logger.LogError(ex, "Error handling member updated for UserId={UserId} GuildId={GuildId}", e.Member.Id, e.Guild.Id);
+            using var failureScope = scopeFactory.CreateScope();
+            var failedEventService = failureScope.ServiceProvider.GetRequiredService<FailedEventService>();
+            await failedEventService.RecordFailureAsync(
+                "GuildMemberUpdated", nameof(MemberEventHandler), ex,
+                e.Guild?.Id, null, e.Member.Id, rawJson);
         }
     }
 
     public async Task HandleEventAsync(DiscordClient sender, GuildBanAddedEventArgs e)
     {
+        string? rawJson = null;
         try
         {
             using var scope = scopeFactory.CreateScope();
@@ -150,7 +169,7 @@ public class MemberEventHandler(IServiceScopeFactory scopeFactory, ILogger<Membe
             var userService = scope.ServiceProvider.GetRequiredService<UserService>();
             var rawEventService = scope.ServiceProvider.GetRequiredService<RawEventLogService>();
 
-            var rawJson = await rawEventService.SerializeAndLogAsync(
+            rawJson = await rawEventService.SerializeAndLogAsync(
                 e, "GuildBanAddedMember", e.Guild.Id, null, e.Member.Id);
 
             await userService.UpsertUserAsync(e.Member);
@@ -171,11 +190,17 @@ public class MemberEventHandler(IServiceScopeFactory scopeFactory, ILogger<Membe
         catch (Exception ex)
         {
             logger.LogError(ex, "Error handling ban added for UserId={UserId} GuildId={GuildId}", e.Member.Id, e.Guild.Id);
+            using var failureScope = scopeFactory.CreateScope();
+            var failedEventService = failureScope.ServiceProvider.GetRequiredService<FailedEventService>();
+            await failedEventService.RecordFailureAsync(
+                "GuildBanAddedMember", nameof(MemberEventHandler), ex,
+                e.Guild?.Id, null, e.Member.Id, rawJson);
         }
     }
 
     public async Task HandleEventAsync(DiscordClient sender, GuildBanRemovedEventArgs e)
     {
+        string? rawJson = null;
         try
         {
             using var scope = scopeFactory.CreateScope();
@@ -183,7 +208,7 @@ public class MemberEventHandler(IServiceScopeFactory scopeFactory, ILogger<Membe
             var userService = scope.ServiceProvider.GetRequiredService<UserService>();
             var rawEventService = scope.ServiceProvider.GetRequiredService<RawEventLogService>();
 
-            var rawJson = await rawEventService.SerializeAndLogAsync(
+            rawJson = await rawEventService.SerializeAndLogAsync(
                 e, "GuildBanRemovedMember", e.Guild.Id, null, e.Member.Id);
 
             await userService.UpsertUserAsync(e.Member);
@@ -204,6 +229,11 @@ public class MemberEventHandler(IServiceScopeFactory scopeFactory, ILogger<Membe
         catch (Exception ex)
         {
             logger.LogError(ex, "Error handling ban removed for UserId={UserId} GuildId={GuildId}", e.Member.Id, e.Guild.Id);
+            using var failureScope = scopeFactory.CreateScope();
+            var failedEventService = failureScope.ServiceProvider.GetRequiredService<FailedEventService>();
+            await failedEventService.RecordFailureAsync(
+                "GuildBanRemovedMember", nameof(MemberEventHandler), ex,
+                e.Guild?.Id, null, e.Member.Id, rawJson);
         }
     }
 }

--- a/src/DiscordEventService/Services/EventHandlers/RoleEventHandler.cs
+++ b/src/DiscordEventService/Services/EventHandlers/RoleEventHandler.cs
@@ -15,13 +15,14 @@ public class RoleEventHandler(IServiceScopeFactory scopeFactory, ILogger<RoleEve
 {
     public async Task HandleEventAsync(DiscordClient sender, GuildRoleCreatedEventArgs e)
     {
+        string? rawJson = null;
         try
         {
             using var scope = scopeFactory.CreateScope();
             var db = scope.ServiceProvider.GetRequiredService<DiscordDbContext>();
             var rawEventService = scope.ServiceProvider.GetRequiredService<RawEventLogService>();
 
-            var rawJson = await rawEventService.SerializeAndLogAsync(
+            rawJson = await rawEventService.SerializeAndLogAsync(
                 e, "GuildRoleCreated", e.Guild.Id, null, null);
 
             // Look up Guild Guid
@@ -60,18 +61,24 @@ public class RoleEventHandler(IServiceScopeFactory scopeFactory, ILogger<RoleEve
         catch (Exception ex)
         {
             logger.LogError(ex, "Error handling role created for RoleId={RoleId}", e.Role.Id);
+            using var failureScope = scopeFactory.CreateScope();
+            var failedEventService = failureScope.ServiceProvider.GetRequiredService<FailedEventService>();
+            await failedEventService.RecordFailureAsync(
+                "GuildRoleCreated", nameof(RoleEventHandler), ex,
+                e.Guild?.Id, null, null, rawJson);
         }
     }
 
     public async Task HandleEventAsync(DiscordClient sender, GuildRoleUpdatedEventArgs e)
     {
+        string? rawJson = null;
         try
         {
             using var scope = scopeFactory.CreateScope();
             var db = scope.ServiceProvider.GetRequiredService<DiscordDbContext>();
             var rawEventService = scope.ServiceProvider.GetRequiredService<RawEventLogService>();
 
-            var rawJson = await rawEventService.SerializeAndLogAsync(
+            rawJson = await rawEventService.SerializeAndLogAsync(
                 e, "GuildRoleUpdated", e.Guild.Id, null, null);
 
             var roleEntity = await db.Roles
@@ -110,18 +117,24 @@ public class RoleEventHandler(IServiceScopeFactory scopeFactory, ILogger<RoleEve
         catch (Exception ex)
         {
             logger.LogError(ex, "Error handling role updated for RoleId={RoleId}", e.RoleAfter.Id);
+            using var failureScope = scopeFactory.CreateScope();
+            var failedEventService = failureScope.ServiceProvider.GetRequiredService<FailedEventService>();
+            await failedEventService.RecordFailureAsync(
+                "GuildRoleUpdated", nameof(RoleEventHandler), ex,
+                e.Guild?.Id, null, null, rawJson);
         }
     }
 
     public async Task HandleEventAsync(DiscordClient sender, GuildRoleDeletedEventArgs e)
     {
+        string? rawJson = null;
         try
         {
             using var scope = scopeFactory.CreateScope();
             var db = scope.ServiceProvider.GetRequiredService<DiscordDbContext>();
             var rawEventService = scope.ServiceProvider.GetRequiredService<RawEventLogService>();
 
-            var rawJson = await rawEventService.SerializeAndLogAsync(
+            rawJson = await rawEventService.SerializeAndLogAsync(
                 e, "GuildRoleDeleted", e.Guild.Id, null, null);
 
             var roleEntity = await db.Roles
@@ -150,6 +163,11 @@ public class RoleEventHandler(IServiceScopeFactory scopeFactory, ILogger<RoleEve
         catch (Exception ex)
         {
             logger.LogError(ex, "Error handling role deleted for RoleId={RoleId}", e.Role.Id);
+            using var failureScope = scopeFactory.CreateScope();
+            var failedEventService = failureScope.ServiceProvider.GetRequiredService<FailedEventService>();
+            await failedEventService.RecordFailureAsync(
+                "GuildRoleDeleted", nameof(RoleEventHandler), ex,
+                e.Guild?.Id, null, null, rawJson);
         }
     }
 


### PR DESCRIPTION
## Summary
- Wire `FailedEventService.RecordFailureAsync` into all catch blocks across `ChannelEventHandler.cs` (4), `RoleEventHandler.cs` (3), and `MemberEventHandler.cs` (5) — 12 in total. Mirrors the canonical pattern at `MessageEventHandler.cs:83-91`. `rawJson` is hoisted out of each `try` so it's reachable from `catch` (null when failure precedes serialization — `RecordFailureAsync` accepts null).
- No `LogWarning` wrapper added; `FailedEventService.RecordFailureAsync` already emits a strictly-more-informative `LogWarning` at `FailedEventService.cs:38-40`. (Lesson from PR #87 review.)
- Closes #55. Part of §P1.1 in #53. Stops silent data loss for Channel, Role, and Member events — including the Member-Updated path that has 9 known orphan raw events without matching `member_events` rows.

## Coverage note vs. issue body
Issue #55 enumerates 9 catch-block line refs, but the actual catch count is 12 (issue body undercounts ChannelEventHandler by 2 — Deleted + PinsUpdated — and RoleEventHandler by 1 — Deleted). This PR addresses the full 12 per the issue's acceptance criterion: \"All catch blocks in the three files call \`FailedEventService.RecordFailureAsync\`.\"

## Test plan
- [x] `dotnet build` — green (4 pre-existing unrelated warnings in `AutoModRuleEventHandler.cs`).
- [x] `grep -c RecordFailureAsync` per file: Channel=4, Role=3, Member=5.
- [x] `grep -c \"string? rawJson = null;\"` per file: Channel=4, Role=3, Member=5.
- [x] `grep -L FailedEventService …/{Channel,Role,Member}EventHandler.cs` returns nothing (acceptance criterion).
- [ ] Post-deploy probe: trigger a member-update with DB unreachable → row appears in `failed_events` with `handler_name='MemberEventHandler'` and `event_type='GuildMemberUpdated'`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)