### PR TITLE
fix: record FailedEventService dead-letter for Guild-family handlers (#56)

### DIFF
--- a/src/DiscordEventService/Services/EventHandlers/GuildEventHandler.cs
+++ b/src/DiscordEventService/Services/EventHandlers/GuildEventHandler.cs
@@ -132,6 +132,11 @@ public class GuildEventHandler(IServiceScopeFactory scopeFactory, ILogger<GuildE
         catch (Exception ex)
         {
             logger.LogError(ex, "Error handling guild created for GuildId={GuildId}", e.Guild.Id);
+            using var failureScope = scopeFactory.CreateScope();
+            var failedEventService = failureScope.ServiceProvider.GetRequiredService<FailedEventService>();
+            await failedEventService.RecordFailureAsync(
+                "GuildCreated", nameof(GuildEventHandler), ex,
+                e.Guild?.Id, null, null);
         }
     }
 
@@ -163,6 +168,11 @@ public class GuildEventHandler(IServiceScopeFactory scopeFactory, ILogger<GuildE
         catch (Exception ex)
         {
             logger.LogError(ex, "Error handling guild updated for GuildId={GuildId}", e.GuildAfter.Id);
+            using var failureScope = scopeFactory.CreateScope();
+            var failedEventService = failureScope.ServiceProvider.GetRequiredService<FailedEventService>();
+            await failedEventService.RecordFailureAsync(
+                "GuildUpdated", nameof(GuildEventHandler), ex,
+                e.GuildAfter?.Id, null, null);
         }
     }
 
@@ -185,6 +195,11 @@ public class GuildEventHandler(IServiceScopeFactory scopeFactory, ILogger<GuildE
         catch (Exception ex)
         {
             logger.LogError(ex, "Error handling guild deleted for GuildId={GuildId}", e.Guild.Id);
+            using var failureScope = scopeFactory.CreateScope();
+            var failedEventService = failureScope.ServiceProvider.GetRequiredService<FailedEventService>();
+            await failedEventService.RecordFailureAsync(
+                "GuildDeleted", nameof(GuildEventHandler), ex,
+                e.Guild?.Id, null, null);
         }
     }
 
@@ -245,6 +260,11 @@ public class GuildEventHandler(IServiceScopeFactory scopeFactory, ILogger<GuildE
         catch (Exception ex)
         {
             logger.LogError(ex, "Error handling guild emojis updated for GuildId={GuildId}", e.Guild.Id);
+            using var failureScope = scopeFactory.CreateScope();
+            var failedEventService = failureScope.ServiceProvider.GetRequiredService<FailedEventService>();
+            await failedEventService.RecordFailureAsync(
+                "GuildEmojisUpdated", nameof(GuildEventHandler), ex,
+                e.Guild?.Id, null, null);
         }
     }
 

--- a/src/DiscordEventService/Services/EventHandlers/GuildMembersChunkHandler.cs
+++ b/src/DiscordEventService/Services/EventHandlers/GuildMembersChunkHandler.cs
@@ -17,6 +17,7 @@ public class GuildMembersChunkHandler(IServiceScopeFactory scopeFactory, ILogger
 
     public async Task HandleEventAsync(DiscordClient sender, GuildMembersChunkedEventArgs args)
     {
+        string? rawJson = null;
         try
         {
             var now = DateTime.UtcNow;
@@ -26,7 +27,7 @@ public class GuildMembersChunkHandler(IServiceScopeFactory scopeFactory, ILogger
             var userService = scope.ServiceProvider.GetRequiredService<UserService>();
             var rawEventService = scope.ServiceProvider.GetRequiredService<RawEventLogService>();
 
-            var rawJson = await rawEventService.SerializeAndLogAsync(
+            rawJson = await rawEventService.SerializeAndLogAsync(
                 args, "GuildMembersChunked", args.Guild.Id, null, null);
 
             // Upsert all members received in this chunk
@@ -68,6 +69,11 @@ public class GuildMembersChunkHandler(IServiceScopeFactory scopeFactory, ILogger
         catch (Exception ex)
         {
             logger.LogError(ex, "Error handling guild members chunk for guild {GuildId}", args.Guild.Id);
+            using var failureScope = scopeFactory.CreateScope();
+            var failedEventService = failureScope.ServiceProvider.GetRequiredService<FailedEventService>();
+            await failedEventService.RecordFailureAsync(
+                "GuildMembersChunked", nameof(GuildMembersChunkHandler), ex,
+                args.Guild?.Id, null, null, rawJson);
         }
     }
 }

--- a/src/DiscordEventService/Services/EventHandlers/GuildUpdateEventHandler.cs
+++ b/src/DiscordEventService/Services/EventHandlers/GuildUpdateEventHandler.cs
@@ -10,6 +10,7 @@ public class GuildUpdateEventHandler(IServiceScopeFactory scopeFactory, ILogger<
 {
     public async Task HandleEventAsync(DiscordClient sender, GuildUpdatedEventArgs e)
     {
+        string? rawJson = null;
         try
         {
             var now = DateTime.UtcNow;
@@ -17,7 +18,7 @@ public class GuildUpdateEventHandler(IServiceScopeFactory scopeFactory, ILogger<
             var db = scope.ServiceProvider.GetRequiredService<DiscordDbContext>();
             var rawEventService = scope.ServiceProvider.GetRequiredService<RawEventLogService>();
 
-            var rawJson = await rawEventService.SerializeAndLogAsync(
+            rawJson = await rawEventService.SerializeAndLogAsync(
                 e, "GuildUpdatedEvent", e.GuildAfter.Id, null, null);
 
             var guildEvent = new GuildEventEntity
@@ -53,6 +54,11 @@ public class GuildUpdateEventHandler(IServiceScopeFactory scopeFactory, ILogger<
         catch (Exception ex)
         {
             logger.LogError(ex, "Error handling guild updated for GuildId={GuildId}", e.GuildAfter.Id);
+            using var failureScope = scopeFactory.CreateScope();
+            var failedEventService = failureScope.ServiceProvider.GetRequiredService<FailedEventService>();
+            await failedEventService.RecordFailureAsync(
+                "GuildUpdatedEvent", nameof(GuildUpdateEventHandler), ex,
+                e.GuildAfter?.Id, null, null, rawJson);
         }
     }
 }


### PR DESCRIPTION
## Summary
- Wire `FailedEventService.RecordFailureAsync` into all 6 catch blocks across `GuildEventHandler.cs` (4: Created/Updated/Deleted/EmojisUpdated), `GuildMembersChunkHandler.cs` (1), `GuildUpdateEventHandler.cs` (1). Mirrors the canonical pattern at `MessageEventHandler.cs:83-91`.
- For the 2 handlers that already capture `rawJson` via `RawEventLogService.SerializeAndLogAsync`, hoist the declaration out of `try` so it's reachable from `catch`. For `GuildEventHandler` (no rawJson capture exists), `eventJson` arg is omitted.
- Closes #56. Part of §P1.1 in #53.

## Notes
- `GuildEventHandler` does not currently call `RawEventLogService.SerializeAndLogAsync`, so `failed_events.event_json` will be NULL for failures from those 4 catches. Adding raw event logging there would be scope creep beyond §P1.1 — leaving as a follow-up.
- `GuildEventHandler.cs:144` and `GuildUpdateEventHandler.cs:11` both subscribe to `GuildUpdatedEventArgs`. They emit different `event_type` strings to `failed_events` (`"GuildUpdated"` vs `"GuildUpdatedEvent"`) so they're disambiguated by both event_type and handler_name.

## Test plan
- [x] `dotnet build` — green (4 pre-existing unrelated warnings in `AutoModRuleEventHandler.cs`).
- [x] `grep -c RecordFailureAsync` per file: GuildEventHandler=4, GuildMembersChunkHandler=1, GuildUpdateEventHandler=1.
- [ ] Post-deploy probe: trigger guild emoji update with DB unreachable → row in `failed_events` with `handler_name='GuildEventHandler'`, `event_type='GuildEmojisUpdated'`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)