### PR TITLE
fix: record FailedEventService dead-letter for AutoMod/Audit/Ban handlers (#57)

### DIFF
--- a/src/DiscordEventService/Services/EventHandlers/AuditLogEventHandler.cs
+++ b/src/DiscordEventService/Services/EventHandlers/AuditLogEventHandler.cs
@@ -10,6 +10,7 @@ public class AuditLogEventHandler(IServiceScopeFactory scopeFactory, ILogger<Aud
 {
     public async Task HandleEventAsync(DiscordClient sender, GuildAuditLogCreatedEventArgs e)
     {
+        string? rawJson = null;
         try
         {
             var now = DateTime.UtcNow;
@@ -17,7 +18,7 @@ public class AuditLogEventHandler(IServiceScopeFactory scopeFactory, ILogger<Aud
             var db = scope.ServiceProvider.GetRequiredService<DiscordDbContext>();
             var rawEventService = scope.ServiceProvider.GetRequiredService<RawEventLogService>();
 
-            var rawJson = await rawEventService.SerializeAndLogAsync(
+            rawJson = await rawEventService.SerializeAndLogAsync(
                 e, "GuildAuditLogCreated", e.Guild.Id, null, e.AuditLogEntry.UserResponsible?.Id);
 
             db.AuditLogEvents.Add(new AuditLogEventEntity
@@ -40,6 +41,11 @@ public class AuditLogEventHandler(IServiceScopeFactory scopeFactory, ILogger<Aud
         catch (Exception ex)
         {
             logger.LogError(ex, "Error handling audit log entry");
+            using var failureScope = scopeFactory.CreateScope();
+            var failedEventService = failureScope.ServiceProvider.GetRequiredService<FailedEventService>();
+            await failedEventService.RecordFailureAsync(
+                "GuildAuditLogCreated", nameof(AuditLogEventHandler), ex,
+                e.Guild?.Id, null, e.AuditLogEntry?.UserResponsible?.Id, rawJson);
         }
     }
 }

--- a/src/DiscordEventService/Services/EventHandlers/AutoModEventHandler.cs
+++ b/src/DiscordEventService/Services/EventHandlers/AutoModEventHandler.cs
@@ -13,6 +13,7 @@ public class AutoModEventHandler(IServiceScopeFactory scopeFactory, ILogger<Auto
 {
     public async Task HandleEventAsync(DiscordClient sender, AutoModerationRuleCreatedEventArgs e)
     {
+        string? rawJson = null;
         try
         {
             if (e.Rule?.Guild is null) return;
@@ -22,7 +23,7 @@ public class AutoModEventHandler(IServiceScopeFactory scopeFactory, ILogger<Auto
             var db = scope.ServiceProvider.GetRequiredService<DiscordDbContext>();
             var rawEventService = scope.ServiceProvider.GetRequiredService<RawEventLogService>();
 
-            var rawJson = await rawEventService.SerializeAndLogAsync(
+            rawJson = await rawEventService.SerializeAndLogAsync(
                 e, "AutoModRuleCreated", e.Rule.Guild.Id, null, e.Rule.Creator?.Id);
 
             var entity = new AutoModEventEntity
@@ -43,11 +44,17 @@ public class AutoModEventHandler(IServiceScopeFactory scopeFactory, ILogger<Auto
         catch (Exception ex)
         {
             logger.LogError(ex, "Error handling automod rule created");
+            using var failureScope = scopeFactory.CreateScope();
+            var failedEventService = failureScope.ServiceProvider.GetRequiredService<FailedEventService>();
+            await failedEventService.RecordFailureAsync(
+                "AutoModRuleCreated", nameof(AutoModEventHandler), ex,
+                e.Rule?.Guild?.Id, null, e.Rule?.Creator?.Id, rawJson);
         }
     }
 
     public async Task HandleEventAsync(DiscordClient sender, AutoModerationRuleUpdatedEventArgs e)
     {
+        string? rawJson = null;
         try
         {
             if (e.Rule?.Guild is null) return;
@@ -57,7 +64,7 @@ public class AutoModEventHandler(IServiceScopeFactory scopeFactory, ILogger<Auto
             var db = scope.ServiceProvider.GetRequiredService<DiscordDbContext>();
             var rawEventService = scope.ServiceProvider.GetRequiredService<RawEventLogService>();
 
-            var rawJson = await rawEventService.SerializeAndLogAsync(
+            rawJson = await rawEventService.SerializeAndLogAsync(
                 e, "AutoModRuleUpdated", e.Rule.Guild.Id, null, e.Rule.Creator?.Id);
 
             var entity = new AutoModEventEntity
@@ -78,11 +85,17 @@ public class AutoModEventHandler(IServiceScopeFactory scopeFactory, ILogger<Auto
         catch (Exception ex)
         {
             logger.LogError(ex, "Error handling automod rule updated");
+            using var failureScope = scopeFactory.CreateScope();
+            var failedEventService = failureScope.ServiceProvider.GetRequiredService<FailedEventService>();
+            await failedEventService.RecordFailureAsync(
+                "AutoModRuleUpdated", nameof(AutoModEventHandler), ex,
+                e.Rule?.Guild?.Id, null, e.Rule?.Creator?.Id, rawJson);
         }
     }
 
     public async Task HandleEventAsync(DiscordClient sender, AutoModerationRuleDeletedEventArgs e)
     {
+        string? rawJson = null;
         try
         {
             if (e.Rule?.Guild is null) return;
@@ -92,7 +105,7 @@ public class AutoModEventHandler(IServiceScopeFactory scopeFactory, ILogger<Auto
             var db = scope.ServiceProvider.GetRequiredService<DiscordDbContext>();
             var rawEventService = scope.ServiceProvider.GetRequiredService<RawEventLogService>();
 
-            var rawJson = await rawEventService.SerializeAndLogAsync(
+            rawJson = await rawEventService.SerializeAndLogAsync(
                 e, "AutoModRuleDeleted", e.Rule.Guild.Id, null, e.Rule.Creator?.Id);
 
             var entity = new AutoModEventEntity
@@ -113,11 +126,17 @@ public class AutoModEventHandler(IServiceScopeFactory scopeFactory, ILogger<Auto
         catch (Exception ex)
         {
             logger.LogError(ex, "Error handling automod rule deleted");
+            using var failureScope = scopeFactory.CreateScope();
+            var failedEventService = failureScope.ServiceProvider.GetRequiredService<FailedEventService>();
+            await failedEventService.RecordFailureAsync(
+                "AutoModRuleDeleted", nameof(AutoModEventHandler), ex,
+                e.Rule?.Guild?.Id, null, e.Rule?.Creator?.Id, rawJson);
         }
     }
 
     public async Task HandleEventAsync(DiscordClient sender, AutoModerationRuleExecutedEventArgs e)
     {
+        string? rawJson = null;
         try
         {
             var now = DateTime.UtcNow;
@@ -125,7 +144,7 @@ public class AutoModEventHandler(IServiceScopeFactory scopeFactory, ILogger<Auto
             var db = scope.ServiceProvider.GetRequiredService<DiscordDbContext>();
             var rawEventService = scope.ServiceProvider.GetRequiredService<RawEventLogService>();
 
-            var rawJson = await rawEventService.SerializeAndLogAsync(
+            rawJson = await rawEventService.SerializeAndLogAsync(
                 e, "AutoModActionExecuted", e.Rule.GuildId, e.Rule.ChannelId, e.Rule.UserId);
 
             // Note: e.Rule is actually DiscordAutoModerationActionExecution
@@ -153,6 +172,11 @@ public class AutoModEventHandler(IServiceScopeFactory scopeFactory, ILogger<Auto
         catch (Exception ex)
         {
             logger.LogError(ex, "Error handling automod action executed");
+            using var failureScope = scopeFactory.CreateScope();
+            var failedEventService = failureScope.ServiceProvider.GetRequiredService<FailedEventService>();
+            await failedEventService.RecordFailureAsync(
+                "AutoModActionExecuted", nameof(AutoModEventHandler), ex,
+                e.Rule?.GuildId, e.Rule?.ChannelId, e.Rule?.UserId, rawJson);
         }
     }
 }

--- a/src/DiscordEventService/Services/EventHandlers/BanEventHandler.cs
+++ b/src/DiscordEventService/Services/EventHandlers/BanEventHandler.cs
@@ -13,6 +13,7 @@ public class BanEventHandler(IServiceScopeFactory scopeFactory, ILogger<BanEvent
 {
     public async Task HandleEventAsync(DiscordClient sender, GuildBanAddedEventArgs e)
     {
+        string? rawJson = null;
         try
         {
             var now = DateTime.UtcNow;
@@ -21,7 +22,7 @@ public class BanEventHandler(IServiceScopeFactory scopeFactory, ILogger<BanEvent
             var userService = scope.ServiceProvider.GetRequiredService<UserService>();
             var rawEventService = scope.ServiceProvider.GetRequiredService<RawEventLogService>();
 
-            var rawJson = await rawEventService.SerializeAndLogAsync(
+            rawJson = await rawEventService.SerializeAndLogAsync(
                 e, "GuildBanAdded", e.Guild.Id, null, e.Member.Id);
 
             await userService.UpsertUserAsync(e.Member);
@@ -63,11 +64,17 @@ public class BanEventHandler(IServiceScopeFactory scopeFactory, ILogger<BanEvent
         catch (Exception ex)
         {
             logger.LogError(ex, "Error handling ban added for UserId={UserId}", e.Member.Id);
+            using var failureScope = scopeFactory.CreateScope();
+            var failedEventService = failureScope.ServiceProvider.GetRequiredService<FailedEventService>();
+            await failedEventService.RecordFailureAsync(
+                "GuildBanAdded", nameof(BanEventHandler), ex,
+                e.Guild?.Id, null, e.Member?.Id, rawJson);
         }
     }
 
     public async Task HandleEventAsync(DiscordClient sender, GuildBanRemovedEventArgs e)
     {
+        string? rawJson = null;
         try
         {
             var now = DateTime.UtcNow;
@@ -75,7 +82,7 @@ public class BanEventHandler(IServiceScopeFactory scopeFactory, ILogger<BanEvent
             var db = scope.ServiceProvider.GetRequiredService<DiscordDbContext>();
             var rawEventService = scope.ServiceProvider.GetRequiredService<RawEventLogService>();
 
-            var rawJson = await rawEventService.SerializeAndLogAsync(
+            rawJson = await rawEventService.SerializeAndLogAsync(
                 e, "GuildBanRemoved", e.Guild.Id, null, e.Member.Id);
 
             // Look up Guid FKs
@@ -107,6 +114,11 @@ public class BanEventHandler(IServiceScopeFactory scopeFactory, ILogger<BanEvent
         catch (Exception ex)
         {
             logger.LogError(ex, "Error handling ban removed for UserId={UserId}", e.Member.Id);
+            using var failureScope = scopeFactory.CreateScope();
+            var failedEventService = failureScope.ServiceProvider.GetRequiredService<FailedEventService>();
+            await failedEventService.RecordFailureAsync(
+                "GuildBanRemoved", nameof(BanEventHandler), ex,
+                e.Guild?.Id, null, e.Member?.Id, rawJson);
         }
     }
 }


### PR DESCRIPTION
## Summary
- Wire `FailedEventService.RecordFailureAsync` into all 7 catch blocks across `AuditLogEventHandler.cs` (1), `AutoModEventHandler.cs` (4: RuleCreated/Updated/Deleted/ActionExecuted), `BanEventHandler.cs` (2). Mirrors canonical at `MessageEventHandler.cs:83-91`. `rawJson` hoisted out of each `try` so it's reachable from `catch`.
- `AutoModRuleEventHandler.cs` (separate file) already uses the dead-letter pattern correctly and is intentionally not modified, per the issue.
- Closes #57. Part of §P1.1 in #53.

## Test plan
- [x] `dotnet build` — green (4 pre-existing unrelated warnings in `AutoModRuleEventHandler.cs`).
- [x] `grep -c RecordFailureAsync` per file: AuditLog=1, AutoMod=4, Ban=2.
- [ ] Post-deploy probe: trigger a ban with DB unreachable → row in `failed_events` with `handler_name='BanEventHandler'`, `event_type='GuildBanAdded'`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)