### PR TITLE
fix: record FailedEventService dead-letter for misc handlers (#58)

### DIFF
--- a/src/DiscordEventService/Services/EventHandlers/EmojiEventHandler.cs
+++ b/src/DiscordEventService/Services/EventHandlers/EmojiEventHandler.cs
@@ -13,6 +13,7 @@ public class EmojiEventHandler(IServiceScopeFactory scopeFactory, ILogger<EmojiE
 {
     public async Task HandleEventAsync(DiscordClient sender, GuildEmojisUpdatedEventArgs e)
     {
+        string? rawJson = null;
         try
         {
             var now = DateTime.UtcNow;
@@ -20,7 +21,7 @@ public class EmojiEventHandler(IServiceScopeFactory scopeFactory, ILogger<EmojiE
             var db = scope.ServiceProvider.GetRequiredService<DiscordDbContext>();
             var rawEventService = scope.ServiceProvider.GetRequiredService<RawEventLogService>();
 
-            var rawJson = await rawEventService.SerializeAndLogAsync(
+            rawJson = await rawEventService.SerializeAndLogAsync(
                 e, "GuildEmojisUpdated", e.Guild.Id, null, null);
 
             // Look up Guild Guid
@@ -91,6 +92,11 @@ public class EmojiEventHandler(IServiceScopeFactory scopeFactory, ILogger<EmojiE
         catch (Exception ex)
         {
             logger.LogError(ex, "Error handling emojis updated for GuildId={GuildId}", e.Guild.Id);
+            using var failureScope = scopeFactory.CreateScope();
+            var failedEventService = failureScope.ServiceProvider.GetRequiredService<FailedEventService>();
+            await failedEventService.RecordFailureAsync(
+                "GuildEmojisUpdated", nameof(EmojiEventHandler), ex,
+                e.Guild?.Id, null, null, rawJson);
         }
     }
 }

--- a/src/DiscordEventService/Services/EventHandlers/IntegrationEventHandler.cs
+++ b/src/DiscordEventService/Services/EventHandlers/IntegrationEventHandler.cs
@@ -14,6 +14,7 @@ public class IntegrationEventHandler(IServiceScopeFactory scopeFactory, ILogger<
 {
     public async Task HandleEventAsync(DiscordClient sender, IntegrationCreatedEventArgs e)
     {
+        string? rawJson = null;
         try
         {
             var now = DateTime.UtcNow;
@@ -21,7 +22,7 @@ public class IntegrationEventHandler(IServiceScopeFactory scopeFactory, ILogger<
             var db = scope.ServiceProvider.GetRequiredService<DiscordDbContext>();
             var rawEventService = scope.ServiceProvider.GetRequiredService<RawEventLogService>();
 
-            var rawJson = await rawEventService.SerializeAndLogAsync(
+            rawJson = await rawEventService.SerializeAndLogAsync(
                 e, "IntegrationCreated", e.Guild.Id, null, null);
 
             // Look up Guid FK
@@ -54,11 +55,17 @@ public class IntegrationEventHandler(IServiceScopeFactory scopeFactory, ILogger<
         catch (Exception ex)
         {
             logger.LogError(ex, "Error handling integration created");
+            using var failureScope = scopeFactory.CreateScope();
+            var failedEventService = failureScope.ServiceProvider.GetRequiredService<FailedEventService>();
+            await failedEventService.RecordFailureAsync(
+                "IntegrationCreated", nameof(IntegrationEventHandler), ex,
+                e.Guild?.Id, null, null, rawJson);
         }
     }
 
     public async Task HandleEventAsync(DiscordClient sender, IntegrationUpdatedEventArgs e)
     {
+        string? rawJson = null;
         try
         {
             var now = DateTime.UtcNow;
@@ -66,7 +73,7 @@ public class IntegrationEventHandler(IServiceScopeFactory scopeFactory, ILogger<
             var db = scope.ServiceProvider.GetRequiredService<DiscordDbContext>();
             var rawEventService = scope.ServiceProvider.GetRequiredService<RawEventLogService>();
 
-            var rawJson = await rawEventService.SerializeAndLogAsync(
+            rawJson = await rawEventService.SerializeAndLogAsync(
                 e, "IntegrationUpdated", e.Guild.Id, null, null);
 
             await db.Integrations
@@ -93,11 +100,17 @@ public class IntegrationEventHandler(IServiceScopeFactory scopeFactory, ILogger<
         catch (Exception ex)
         {
             logger.LogError(ex, "Error handling integration updated");
+            using var failureScope = scopeFactory.CreateScope();
+            var failedEventService = failureScope.ServiceProvider.GetRequiredService<FailedEventService>();
+            await failedEventService.RecordFailureAsync(
+                "IntegrationUpdated", nameof(IntegrationEventHandler), ex,
+                e.Guild?.Id, null, null, rawJson);
         }
     }
 
     public async Task HandleEventAsync(DiscordClient sender, IntegrationDeletedEventArgs e)
     {
+        string? rawJson = null;
         try
         {
             var now = DateTime.UtcNow;
@@ -105,7 +118,7 @@ public class IntegrationEventHandler(IServiceScopeFactory scopeFactory, ILogger<
             var db = scope.ServiceProvider.GetRequiredService<DiscordDbContext>();
             var rawEventService = scope.ServiceProvider.GetRequiredService<RawEventLogService>();
 
-            var rawJson = await rawEventService.SerializeAndLogAsync(
+            rawJson = await rawEventService.SerializeAndLogAsync(
                 e, "IntegrationDeleted", e.Guild.Id, null, null);
 
             await db.Integrations
@@ -127,6 +140,11 @@ public class IntegrationEventHandler(IServiceScopeFactory scopeFactory, ILogger<
         catch (Exception ex)
         {
             logger.LogError(ex, "Error handling integration deleted");
+            using var failureScope = scopeFactory.CreateScope();
+            var failedEventService = failureScope.ServiceProvider.GetRequiredService<FailedEventService>();
+            await failedEventService.RecordFailureAsync(
+                "IntegrationDeleted", nameof(IntegrationEventHandler), ex,
+                e.Guild?.Id, null, null, rawJson);
         }
     }
 }

--- a/src/DiscordEventService/Services/EventHandlers/InviteEventHandler.cs
+++ b/src/DiscordEventService/Services/EventHandlers/InviteEventHandler.cs
@@ -13,6 +13,7 @@ public class InviteEventHandler(IServiceScopeFactory scopeFactory, ILogger<Invit
 {
     public async Task HandleEventAsync(DiscordClient sender, InviteCreatedEventArgs e)
     {
+        string? rawJson = null;
         try
         {
             var now = DateTime.UtcNow;
@@ -20,7 +21,7 @@ public class InviteEventHandler(IServiceScopeFactory scopeFactory, ILogger<Invit
             var db = scope.ServiceProvider.GetRequiredService<DiscordDbContext>();
             var rawEventService = scope.ServiceProvider.GetRequiredService<RawEventLogService>();
 
-            var rawJson = await rawEventService.SerializeAndLogAsync(
+            rawJson = await rawEventService.SerializeAndLogAsync(
                 e, "InviteCreated", e.Guild.Id, e.Channel.Id, e.Invite.Inviter?.Id);
 
             // Look up Guid FKs
@@ -72,11 +73,17 @@ public class InviteEventHandler(IServiceScopeFactory scopeFactory, ILogger<Invit
         catch (Exception ex)
         {
             logger.LogError(ex, "Error handling invite created");
+            using var failureScope = scopeFactory.CreateScope();
+            var failedEventService = failureScope.ServiceProvider.GetRequiredService<FailedEventService>();
+            await failedEventService.RecordFailureAsync(
+                "InviteCreated", nameof(InviteEventHandler), ex,
+                e.Guild?.Id, e.Channel?.Id, e.Invite?.Inviter?.Id, rawJson);
         }
     }
 
     public async Task HandleEventAsync(DiscordClient sender, InviteDeletedEventArgs e)
     {
+        string? rawJson = null;
         try
         {
             var now = DateTime.UtcNow;
@@ -84,7 +91,7 @@ public class InviteEventHandler(IServiceScopeFactory scopeFactory, ILogger<Invit
             var db = scope.ServiceProvider.GetRequiredService<DiscordDbContext>();
             var rawEventService = scope.ServiceProvider.GetRequiredService<RawEventLogService>();
 
-            var rawJson = await rawEventService.SerializeAndLogAsync(
+            rawJson = await rawEventService.SerializeAndLogAsync(
                 e, "InviteDeleted", e.Guild.Id, e.Channel.Id, null);
 
             // Mark invite as deleted
@@ -109,6 +116,11 @@ public class InviteEventHandler(IServiceScopeFactory scopeFactory, ILogger<Invit
         catch (Exception ex)
         {
             logger.LogError(ex, "Error handling invite deleted");
+            using var failureScope = scopeFactory.CreateScope();
+            var failedEventService = failureScope.ServiceProvider.GetRequiredService<FailedEventService>();
+            await failedEventService.RecordFailureAsync(
+                "InviteDeleted", nameof(InviteEventHandler), ex,
+                e.Guild?.Id, e.Channel?.Id, null, rawJson);
         }
     }
 }

--- a/src/DiscordEventService/Services/EventHandlers/PinEventHandler.cs
+++ b/src/DiscordEventService/Services/EventHandlers/PinEventHandler.cs
@@ -12,6 +12,7 @@ public class PinEventHandler(IServiceScopeFactory scopeFactory, ILogger<PinEvent
     {
         if (e.Guild is null) return;
 
+        string? rawJson = null;
         try
         {
             var now = DateTime.UtcNow;
@@ -19,7 +20,7 @@ public class PinEventHandler(IServiceScopeFactory scopeFactory, ILogger<PinEvent
             var db = scope.ServiceProvider.GetRequiredService<DiscordDbContext>();
             var rawEventService = scope.ServiceProvider.GetRequiredService<RawEventLogService>();
 
-            var rawJson = await rawEventService.SerializeAndLogAsync(
+            rawJson = await rawEventService.SerializeAndLogAsync(
                 e, "ChannelPinsUpdated", e.Guild.Id, e.Channel.Id, null);
 
             db.PinEvents.Add(new PinEventEntity
@@ -37,6 +38,11 @@ public class PinEventHandler(IServiceScopeFactory scopeFactory, ILogger<PinEvent
         catch (Exception ex)
         {
             logger.LogError(ex, "Error handling pins updated for ChannelId={ChannelId}", e.Channel.Id);
+            using var failureScope = scopeFactory.CreateScope();
+            var failedEventService = failureScope.ServiceProvider.GetRequiredService<FailedEventService>();
+            await failedEventService.RecordFailureAsync(
+                "ChannelPinsUpdated", nameof(PinEventHandler), ex,
+                e.Guild?.Id, e.Channel?.Id, null, rawJson);
         }
     }
 }

--- a/src/DiscordEventService/Services/EventHandlers/PollEventHandler.cs
+++ b/src/DiscordEventService/Services/EventHandlers/PollEventHandler.cs
@@ -13,6 +13,7 @@ public class PollEventHandler(IServiceScopeFactory scopeFactory, ILogger<PollEve
         var update = e.PollVoteUpdate;
         if (update.Guild is null) return;
 
+        string? rawJson = null;
         try
         {
             var now = DateTime.UtcNow;
@@ -20,7 +21,7 @@ public class PollEventHandler(IServiceScopeFactory scopeFactory, ILogger<PollEve
             var db = scope.ServiceProvider.GetRequiredService<DiscordDbContext>();
             var rawEventService = scope.ServiceProvider.GetRequiredService<RawEventLogService>();
 
-            var rawJson = await rawEventService.SerializeAndLogAsync(
+            rawJson = await rawEventService.SerializeAndLogAsync(
                 e, "MessagePollVoted", update.Guild.Id, update.Message?.ChannelId, update.User?.Id);
 
             db.PollEvents.Add(new PollEventEntity
@@ -41,6 +42,11 @@ public class PollEventHandler(IServiceScopeFactory scopeFactory, ILogger<PollEve
         catch (Exception ex)
         {
             logger.LogError(ex, "Error handling poll vote");
+            using var failureScope = scopeFactory.CreateScope();
+            var failedEventService = failureScope.ServiceProvider.GetRequiredService<FailedEventService>();
+            await failedEventService.RecordFailureAsync(
+                "MessagePollVoted", nameof(PollEventHandler), ex,
+                update.Guild?.Id, update.Message?.ChannelId, update.User?.Id, rawJson);
         }
     }
 }

--- a/src/DiscordEventService/Services/EventHandlers/ScheduledEventHandler.cs
+++ b/src/DiscordEventService/Services/EventHandlers/ScheduledEventHandler.cs
@@ -18,6 +18,7 @@ public class ScheduledEventHandler(IServiceScopeFactory scopeFactory, ILogger<Sc
 {
     public async Task HandleEventAsync(DiscordClient sender, ScheduledGuildEventCreatedEventArgs e)
     {
+        string? rawJson = null;
         try
         {
             var now = DateTime.UtcNow;
@@ -25,7 +26,7 @@ public class ScheduledEventHandler(IServiceScopeFactory scopeFactory, ILogger<Sc
             var db = scope.ServiceProvider.GetRequiredService<DiscordDbContext>();
             var rawEventService = scope.ServiceProvider.GetRequiredService<RawEventLogService>();
 
-            var rawJson = await rawEventService.SerializeAndLogAsync(
+            rawJson = await rawEventService.SerializeAndLogAsync(
                 e, "ScheduledGuildEventCreated", e.Guild.Id, e.Channel?.Id, e.Creator?.Id);
 
             await UpsertScheduledEventAsync(db, e.Event, e.Creator?.Id);
@@ -54,11 +55,17 @@ public class ScheduledEventHandler(IServiceScopeFactory scopeFactory, ILogger<Sc
         catch (Exception ex)
         {
             logger.LogError(ex, "Error handling scheduled event created");
+            using var failureScope = scopeFactory.CreateScope();
+            var failedEventService = failureScope.ServiceProvider.GetRequiredService<FailedEventService>();
+            await failedEventService.RecordFailureAsync(
+                "ScheduledGuildEventCreated", nameof(ScheduledEventHandler), ex,
+                e.Guild?.Id, e.Channel?.Id, e.Creator?.Id, rawJson);
         }
     }
 
     public async Task HandleEventAsync(DiscordClient sender, ScheduledGuildEventUpdatedEventArgs e)
     {
+        string? rawJson = null;
         try
         {
             var now = DateTime.UtcNow;
@@ -66,7 +73,7 @@ public class ScheduledEventHandler(IServiceScopeFactory scopeFactory, ILogger<Sc
             var db = scope.ServiceProvider.GetRequiredService<DiscordDbContext>();
             var rawEventService = scope.ServiceProvider.GetRequiredService<RawEventLogService>();
 
-            var rawJson = await rawEventService.SerializeAndLogAsync(
+            rawJson = await rawEventService.SerializeAndLogAsync(
                 e, "ScheduledGuildEventUpdated", e.EventAfter.GuildId, e.EventAfter.ChannelId, e.EventAfter.Creator?.Id);
 
             await UpsertScheduledEventAsync(db, e.EventAfter, e.EventAfter.Creator?.Id);
@@ -95,11 +102,17 @@ public class ScheduledEventHandler(IServiceScopeFactory scopeFactory, ILogger<Sc
         catch (Exception ex)
         {
             logger.LogError(ex, "Error handling scheduled event updated");
+            using var failureScope = scopeFactory.CreateScope();
+            var failedEventService = failureScope.ServiceProvider.GetRequiredService<FailedEventService>();
+            await failedEventService.RecordFailureAsync(
+                "ScheduledGuildEventUpdated", nameof(ScheduledEventHandler), ex,
+                e.EventAfter?.GuildId, e.EventAfter?.ChannelId, e.EventAfter?.Creator?.Id, rawJson);
         }
     }
 
     public async Task HandleEventAsync(DiscordClient sender, ScheduledGuildEventDeletedEventArgs e)
     {
+        string? rawJson = null;
         try
         {
             var now = DateTime.UtcNow;
@@ -107,7 +120,7 @@ public class ScheduledEventHandler(IServiceScopeFactory scopeFactory, ILogger<Sc
             var db = scope.ServiceProvider.GetRequiredService<DiscordDbContext>();
             var rawEventService = scope.ServiceProvider.GetRequiredService<RawEventLogService>();
 
-            var rawJson = await rawEventService.SerializeAndLogAsync(
+            rawJson = await rawEventService.SerializeAndLogAsync(
                 e, "ScheduledGuildEventDeleted", e.Event.GuildId, e.Event.ChannelId, null);
 
             // Mark as deleted
@@ -133,11 +146,17 @@ public class ScheduledEventHandler(IServiceScopeFactory scopeFactory, ILogger<Sc
         catch (Exception ex)
         {
             logger.LogError(ex, "Error handling scheduled event deleted");
+            using var failureScope = scopeFactory.CreateScope();
+            var failedEventService = failureScope.ServiceProvider.GetRequiredService<FailedEventService>();
+            await failedEventService.RecordFailureAsync(
+                "ScheduledGuildEventDeleted", nameof(ScheduledEventHandler), ex,
+                e.Event?.GuildId, e.Event?.ChannelId, null, rawJson);
         }
     }
 
     public async Task HandleEventAsync(DiscordClient sender, ScheduledGuildEventCompletedEventArgs e)
     {
+        string? rawJson = null;
         try
         {
             var now = DateTime.UtcNow;
@@ -145,7 +164,7 @@ public class ScheduledEventHandler(IServiceScopeFactory scopeFactory, ILogger<Sc
             var db = scope.ServiceProvider.GetRequiredService<DiscordDbContext>();
             var rawEventService = scope.ServiceProvider.GetRequiredService<RawEventLogService>();
 
-            var rawJson = await rawEventService.SerializeAndLogAsync(
+            rawJson = await rawEventService.SerializeAndLogAsync(
                 e, "ScheduledGuildEventCompleted", e.Event.GuildId, e.Event.ChannelId, null);
 
             await UpsertScheduledEventAsync(db, e.Event, e.Event.Creator?.Id);
@@ -169,11 +188,17 @@ public class ScheduledEventHandler(IServiceScopeFactory scopeFactory, ILogger<Sc
         catch (Exception ex)
         {
             logger.LogError(ex, "Error handling scheduled event completed");
+            using var failureScope = scopeFactory.CreateScope();
+            var failedEventService = failureScope.ServiceProvider.GetRequiredService<FailedEventService>();
+            await failedEventService.RecordFailureAsync(
+                "ScheduledGuildEventCompleted", nameof(ScheduledEventHandler), ex,
+                e.Event?.GuildId, e.Event?.ChannelId, null, rawJson);
         }
     }
 
     public async Task HandleEventAsync(DiscordClient sender, ScheduledGuildEventUserAddedEventArgs e)
     {
+        string? rawJson = null;
         try
         {
             var now = DateTime.UtcNow;
@@ -181,7 +206,7 @@ public class ScheduledEventHandler(IServiceScopeFactory scopeFactory, ILogger<Sc
             var db = scope.ServiceProvider.GetRequiredService<DiscordDbContext>();
             var rawEventService = scope.ServiceProvider.GetRequiredService<RawEventLogService>();
 
-            var rawJson = await rawEventService.SerializeAndLogAsync(
+            rawJson = await rawEventService.SerializeAndLogAsync(
                 e, "ScheduledGuildEventUserAdded", e.Guild.Id, null, e.User.Id);
 
             // Increment user count
@@ -206,11 +231,17 @@ public class ScheduledEventHandler(IServiceScopeFactory scopeFactory, ILogger<Sc
         catch (Exception ex)
         {
             logger.LogError(ex, "Error handling scheduled event user added");
+            using var failureScope = scopeFactory.CreateScope();
+            var failedEventService = failureScope.ServiceProvider.GetRequiredService<FailedEventService>();
+            await failedEventService.RecordFailureAsync(
+                "ScheduledGuildEventUserAdded", nameof(ScheduledEventHandler), ex,
+                e.Guild?.Id, null, e.User?.Id, rawJson);
         }
     }
 
     public async Task HandleEventAsync(DiscordClient sender, ScheduledGuildEventUserRemovedEventArgs e)
     {
+        string? rawJson = null;
         try
         {
             var now = DateTime.UtcNow;
@@ -218,7 +249,7 @@ public class ScheduledEventHandler(IServiceScopeFactory scopeFactory, ILogger<Sc
             var db = scope.ServiceProvider.GetRequiredService<DiscordDbContext>();
             var rawEventService = scope.ServiceProvider.GetRequiredService<RawEventLogService>();
 
-            var rawJson = await rawEventService.SerializeAndLogAsync(
+            rawJson = await rawEventService.SerializeAndLogAsync(
                 e, "ScheduledGuildEventUserRemoved", e.Guild.Id, null, e.User.Id);
 
             // Decrement user count
@@ -243,6 +274,11 @@ public class ScheduledEventHandler(IServiceScopeFactory scopeFactory, ILogger<Sc
         catch (Exception ex)
         {
             logger.LogError(ex, "Error handling scheduled event user removed");
+            using var failureScope = scopeFactory.CreateScope();
+            var failedEventService = failureScope.ServiceProvider.GetRequiredService<FailedEventService>();
+            await failedEventService.RecordFailureAsync(
+                "ScheduledGuildEventUserRemoved", nameof(ScheduledEventHandler), ex,
+                e.Guild?.Id, null, e.User?.Id, rawJson);
         }
     }
 

--- a/src/DiscordEventService/Services/EventHandlers/StageInstanceEventHandler.cs
+++ b/src/DiscordEventService/Services/EventHandlers/StageInstanceEventHandler.cs
@@ -14,6 +14,7 @@ public class StageInstanceEventHandler(IServiceScopeFactory scopeFactory, ILogge
 {
     public async Task HandleEventAsync(DiscordClient sender, StageInstanceCreatedEventArgs e)
     {
+        string? rawJson = null;
         try
         {
             var now = DateTime.UtcNow;
@@ -21,7 +22,7 @@ public class StageInstanceEventHandler(IServiceScopeFactory scopeFactory, ILogge
             var db = scope.ServiceProvider.GetRequiredService<DiscordDbContext>();
             var rawEventService = scope.ServiceProvider.GetRequiredService<RawEventLogService>();
 
-            var rawJson = await rawEventService.SerializeAndLogAsync(
+            rawJson = await rawEventService.SerializeAndLogAsync(
                 e, "StageInstanceCreated", e.StageInstance.GuildId, e.StageInstance.ChannelId, null);
 
             // Look up Guid FKs
@@ -55,11 +56,17 @@ public class StageInstanceEventHandler(IServiceScopeFactory scopeFactory, ILogge
         catch (Exception ex)
         {
             logger.LogError(ex, "Error handling stage instance created");
+            using var failureScope = scopeFactory.CreateScope();
+            var failedEventService = failureScope.ServiceProvider.GetRequiredService<FailedEventService>();
+            await failedEventService.RecordFailureAsync(
+                "StageInstanceCreated", nameof(StageInstanceEventHandler), ex,
+                e.StageInstance?.GuildId, e.StageInstance?.ChannelId, null, rawJson);
         }
     }
 
     public async Task HandleEventAsync(DiscordClient sender, StageInstanceUpdatedEventArgs e)
     {
+        string? rawJson = null;
         try
         {
             var now = DateTime.UtcNow;
@@ -67,7 +74,7 @@ public class StageInstanceEventHandler(IServiceScopeFactory scopeFactory, ILogge
             var db = scope.ServiceProvider.GetRequiredService<DiscordDbContext>();
             var rawEventService = scope.ServiceProvider.GetRequiredService<RawEventLogService>();
 
-            var rawJson = await rawEventService.SerializeAndLogAsync(
+            rawJson = await rawEventService.SerializeAndLogAsync(
                 e, "StageInstanceUpdated", e.StageInstanceAfter.GuildId, e.StageInstanceAfter.ChannelId, null);
 
             await db.StageInstances
@@ -96,11 +103,17 @@ public class StageInstanceEventHandler(IServiceScopeFactory scopeFactory, ILogge
         catch (Exception ex)
         {
             logger.LogError(ex, "Error handling stage instance updated");
+            using var failureScope = scopeFactory.CreateScope();
+            var failedEventService = failureScope.ServiceProvider.GetRequiredService<FailedEventService>();
+            await failedEventService.RecordFailureAsync(
+                "StageInstanceUpdated", nameof(StageInstanceEventHandler), ex,
+                e.StageInstanceAfter?.GuildId, e.StageInstanceAfter?.ChannelId, null, rawJson);
         }
     }
 
     public async Task HandleEventAsync(DiscordClient sender, StageInstanceDeletedEventArgs e)
     {
+        string? rawJson = null;
         try
         {
             var now = DateTime.UtcNow;
@@ -108,7 +121,7 @@ public class StageInstanceEventHandler(IServiceScopeFactory scopeFactory, ILogge
             var db = scope.ServiceProvider.GetRequiredService<DiscordDbContext>();
             var rawEventService = scope.ServiceProvider.GetRequiredService<RawEventLogService>();
 
-            var rawJson = await rawEventService.SerializeAndLogAsync(
+            rawJson = await rawEventService.SerializeAndLogAsync(
                 e, "StageInstanceDeleted", e.StageInstance.GuildId, e.StageInstance.ChannelId, null);
 
             await db.StageInstances
@@ -133,6 +146,11 @@ public class StageInstanceEventHandler(IServiceScopeFactory scopeFactory, ILogge
         catch (Exception ex)
         {
             logger.LogError(ex, "Error handling stage instance deleted");
+            using var failureScope = scopeFactory.CreateScope();
+            var failedEventService = failureScope.ServiceProvider.GetRequiredService<FailedEventService>();
+            await failedEventService.RecordFailureAsync(
+                "StageInstanceDeleted", nameof(StageInstanceEventHandler), ex,
+                e.StageInstance?.GuildId, e.StageInstance?.ChannelId, null, rawJson);
         }
     }
 }

--- a/src/DiscordEventService/Services/EventHandlers/StickerEventHandler.cs
+++ b/src/DiscordEventService/Services/EventHandlers/StickerEventHandler.cs
@@ -13,6 +13,7 @@ public class StickerEventHandler(IServiceScopeFactory scopeFactory, ILogger<Stic
 {
     public async Task HandleEventAsync(DiscordClient sender, GuildStickersUpdatedEventArgs e)
     {
+        string? rawJson = null;
         try
         {
             var now = DateTime.UtcNow;
@@ -20,7 +21,7 @@ public class StickerEventHandler(IServiceScopeFactory scopeFactory, ILogger<Stic
             var db = scope.ServiceProvider.GetRequiredService<DiscordDbContext>();
             var rawEventService = scope.ServiceProvider.GetRequiredService<RawEventLogService>();
 
-            var rawJson = await rawEventService.SerializeAndLogAsync(
+            rawJson = await rawEventService.SerializeAndLogAsync(
                 e, "GuildStickersUpdated", e.Guild.Id, null, null);
 
             // Look up Guild Guid
@@ -93,6 +94,11 @@ public class StickerEventHandler(IServiceScopeFactory scopeFactory, ILogger<Stic
         catch (Exception ex)
         {
             logger.LogError(ex, "Error handling stickers updated for GuildId={GuildId}", e.Guild.Id);
+            using var failureScope = scopeFactory.CreateScope();
+            var failedEventService = failureScope.ServiceProvider.GetRequiredService<FailedEventService>();
+            await failedEventService.RecordFailureAsync(
+                "GuildStickersUpdated", nameof(StickerEventHandler), ex,
+                e.Guild?.Id, null, null, rawJson);
         }
     }
 }

--- a/src/DiscordEventService/Services/EventHandlers/ThreadEventHandler.cs
+++ b/src/DiscordEventService/Services/EventHandlers/ThreadEventHandler.cs
@@ -14,13 +14,14 @@ public class ThreadEventHandler(IServiceScopeFactory scopeFactory, ILogger<Threa
 {
     public async Task HandleEventAsync(DiscordClient sender, ThreadCreatedEventArgs e)
     {
+        string? rawJson = null;
         try
         {
             using var scope = scopeFactory.CreateScope();
             var db = scope.ServiceProvider.GetRequiredService<DiscordDbContext>();
             var rawEventService = scope.ServiceProvider.GetRequiredService<RawEventLogService>();
 
-            var rawJson = await rawEventService.SerializeAndLogAsync(
+            rawJson = await rawEventService.SerializeAndLogAsync(
                 e, "ThreadCreated", e.Guild.Id, e.Thread.Id, e.Thread.CreatorId);
 
             var threadEvent = new ThreadEventEntity
@@ -44,18 +45,24 @@ public class ThreadEventHandler(IServiceScopeFactory scopeFactory, ILogger<Threa
         catch (Exception ex)
         {
             logger.LogError(ex, "Error handling thread created for ThreadId={ThreadId}", e.Thread.Id);
+            using var failureScope = scopeFactory.CreateScope();
+            var failedEventService = failureScope.ServiceProvider.GetRequiredService<FailedEventService>();
+            await failedEventService.RecordFailureAsync(
+                "ThreadCreated", nameof(ThreadEventHandler), ex,
+                e.Guild?.Id, e.Thread?.Id, e.Thread?.CreatorId, rawJson);
         }
     }
 
     public async Task HandleEventAsync(DiscordClient sender, ThreadUpdatedEventArgs e)
     {
+        string? rawJson = null;
         try
         {
             using var scope = scopeFactory.CreateScope();
             var db = scope.ServiceProvider.GetRequiredService<DiscordDbContext>();
             var rawEventService = scope.ServiceProvider.GetRequiredService<RawEventLogService>();
 
-            var rawJson = await rawEventService.SerializeAndLogAsync(
+            rawJson = await rawEventService.SerializeAndLogAsync(
                 e, "ThreadUpdated", e.Guild.Id, e.ThreadAfter.Id, e.ThreadAfter.CreatorId);
 
             var threadEvent = new ThreadEventEntity
@@ -79,18 +86,24 @@ public class ThreadEventHandler(IServiceScopeFactory scopeFactory, ILogger<Threa
         catch (Exception ex)
         {
             logger.LogError(ex, "Error handling thread updated for ThreadId={ThreadId}", e.ThreadAfter.Id);
+            using var failureScope = scopeFactory.CreateScope();
+            var failedEventService = failureScope.ServiceProvider.GetRequiredService<FailedEventService>();
+            await failedEventService.RecordFailureAsync(
+                "ThreadUpdated", nameof(ThreadEventHandler), ex,
+                e.Guild?.Id, e.ThreadAfter?.Id, e.ThreadAfter?.CreatorId, rawJson);
         }
     }
 
     public async Task HandleEventAsync(DiscordClient sender, ThreadDeletedEventArgs e)
     {
+        string? rawJson = null;
         try
         {
             using var scope = scopeFactory.CreateScope();
             var db = scope.ServiceProvider.GetRequiredService<DiscordDbContext>();
             var rawEventService = scope.ServiceProvider.GetRequiredService<RawEventLogService>();
 
-            var rawJson = await rawEventService.SerializeAndLogAsync(
+            rawJson = await rawEventService.SerializeAndLogAsync(
                 e, "ThreadDeleted", e.Guild.Id, e.Thread.Id, e.Thread.CreatorId);
 
             var threadEvent = new ThreadEventEntity
@@ -114,18 +127,24 @@ public class ThreadEventHandler(IServiceScopeFactory scopeFactory, ILogger<Threa
         catch (Exception ex)
         {
             logger.LogError(ex, "Error handling thread deleted for ThreadId={ThreadId}", e.Thread.Id);
+            using var failureScope = scopeFactory.CreateScope();
+            var failedEventService = failureScope.ServiceProvider.GetRequiredService<FailedEventService>();
+            await failedEventService.RecordFailureAsync(
+                "ThreadDeleted", nameof(ThreadEventHandler), ex,
+                e.Guild?.Id, e.Thread?.Id, e.Thread?.CreatorId, rawJson);
         }
     }
 
     public async Task HandleEventAsync(DiscordClient sender, ThreadMembersUpdatedEventArgs e)
     {
+        string? rawJson = null;
         try
         {
             using var scope = scopeFactory.CreateScope();
             var db = scope.ServiceProvider.GetRequiredService<DiscordDbContext>();
             var rawEventService = scope.ServiceProvider.GetRequiredService<RawEventLogService>();
 
-            var rawJson = await rawEventService.SerializeAndLogAsync(
+            rawJson = await rawEventService.SerializeAndLogAsync(
                 e, "ThreadMembersUpdated", e.Guild.Id, e.Thread.Id, null);
 
             string? membersAddedJson = null;
@@ -166,6 +185,11 @@ public class ThreadEventHandler(IServiceScopeFactory scopeFactory, ILogger<Threa
         catch (Exception ex)
         {
             logger.LogError(ex, "Error handling thread members updated for ThreadId={ThreadId}", e.Thread.Id);
+            using var failureScope = scopeFactory.CreateScope();
+            var failedEventService = failureScope.ServiceProvider.GetRequiredService<FailedEventService>();
+            await failedEventService.RecordFailureAsync(
+                "ThreadMembersUpdated", nameof(ThreadEventHandler), ex,
+                e.Guild?.Id, e.Thread?.Id, null, rawJson);
         }
     }
 }

--- a/src/DiscordEventService/Services/EventHandlers/ThreadSyncHandler.cs
+++ b/src/DiscordEventService/Services/EventHandlers/ThreadSyncHandler.cs
@@ -17,6 +17,7 @@ public class ThreadSyncHandler(IServiceScopeFactory scopeFactory, ILogger<Thread
 
     public async Task HandleEventAsync(DiscordClient sender, ThreadListSyncedEventArgs args)
     {
+        string? rawJson = null;
         try
         {
             var now = DateTime.UtcNow;
@@ -25,7 +26,7 @@ public class ThreadSyncHandler(IServiceScopeFactory scopeFactory, ILogger<Thread
             var db = scope.ServiceProvider.GetRequiredService<DiscordDbContext>();
             var rawEventService = scope.ServiceProvider.GetRequiredService<RawEventLogService>();
 
-            var rawJson = await rawEventService.SerializeAndLogAsync(
+            rawJson = await rawEventService.SerializeAndLogAsync(
                 args, "ThreadListSynced", args.Guild.Id, null, null);
 
             var syncEvent = new ThreadSyncEventEntity
@@ -50,6 +51,11 @@ public class ThreadSyncHandler(IServiceScopeFactory scopeFactory, ILogger<Thread
         catch (Exception ex)
         {
             logger.LogError(ex, "Error handling thread list sync for guild {GuildId}", args.Guild.Id);
+            using var failureScope = scopeFactory.CreateScope();
+            var failedEventService = failureScope.ServiceProvider.GetRequiredService<FailedEventService>();
+            await failedEventService.RecordFailureAsync(
+                "ThreadListSynced", nameof(ThreadSyncHandler), ex,
+                args.Guild?.Id, null, null, rawJson);
         }
     }
 }

--- a/src/DiscordEventService/Services/EventHandlers/TypingEventHandler.cs
+++ b/src/DiscordEventService/Services/EventHandlers/TypingEventHandler.cs
@@ -13,6 +13,7 @@ public class TypingEventHandler(IServiceScopeFactory scopeFactory, ILogger<Typin
 
     public async Task HandleEventAsync(DiscordClient sender, TypingStartedEventArgs e)
     {
+        string? rawJson = null;
         try
         {
             // Throttle: skip if we've seen this user+channel combo recently
@@ -27,7 +28,7 @@ public class TypingEventHandler(IServiceScopeFactory scopeFactory, ILogger<Typin
             var db = scope.ServiceProvider.GetRequiredService<DiscordDbContext>();
             var rawEventService = scope.ServiceProvider.GetRequiredService<RawEventLogService>();
 
-            var rawJson = await rawEventService.SerializeAndLogAsync(
+            rawJson = await rawEventService.SerializeAndLogAsync(
                 e, "TypingStarted", e.Guild?.Id ?? 0, e.Channel.Id, e.User.Id);
 
             var entity = new TypingEventEntity
@@ -46,6 +47,11 @@ public class TypingEventHandler(IServiceScopeFactory scopeFactory, ILogger<Typin
         catch (Exception ex)
         {
             logger.LogError(ex, "Error handling typing started");
+            using var failureScope = scopeFactory.CreateScope();
+            var failedEventService = failureScope.ServiceProvider.GetRequiredService<FailedEventService>();
+            await failedEventService.RecordFailureAsync(
+                "TypingStarted", nameof(TypingEventHandler), ex,
+                e.Guild?.Id, e.Channel?.Id, e.User?.Id, rawJson);
         }
     }
 }

--- a/src/DiscordEventService/Services/EventHandlers/WebhookEventHandler.cs
+++ b/src/DiscordEventService/Services/EventHandlers/WebhookEventHandler.cs
@@ -10,6 +10,7 @@ public class WebhookEventHandler(IServiceScopeFactory scopeFactory, ILogger<Webh
 {
     public async Task HandleEventAsync(DiscordClient sender, WebhooksUpdatedEventArgs e)
     {
+        string? rawJson = null;
         try
         {
             var now = DateTime.UtcNow;
@@ -17,7 +18,7 @@ public class WebhookEventHandler(IServiceScopeFactory scopeFactory, ILogger<Webh
             var db = scope.ServiceProvider.GetRequiredService<DiscordDbContext>();
             var rawEventService = scope.ServiceProvider.GetRequiredService<RawEventLogService>();
 
-            var rawJson = await rawEventService.SerializeAndLogAsync(
+            rawJson = await rawEventService.SerializeAndLogAsync(
                 e, "WebhooksUpdated", e.Guild.Id, e.Channel.Id, null);
 
             db.WebhookEvents.Add(new WebhookEventEntity
@@ -34,6 +35,11 @@ public class WebhookEventHandler(IServiceScopeFactory scopeFactory, ILogger<Webh
         catch (Exception ex)
         {
             logger.LogError(ex, "Error handling webhooks updated for ChannelId={ChannelId}", e.Channel.Id);
+            using var failureScope = scopeFactory.CreateScope();
+            var failedEventService = failureScope.ServiceProvider.GetRequiredService<FailedEventService>();
+            await failedEventService.RecordFailureAsync(
+                "WebhooksUpdated", nameof(WebhookEventHandler), ex,
+                e.Guild?.Id, e.Channel?.Id, null, rawJson);
         }
     }
 }


### PR DESCRIPTION
## Summary
- Wire `FailedEventService.RecordFailureAsync` into all 25 catch blocks across the remaining 12 handlers — Emoji (1), Integration (3), Invite (2), Pin (1), Poll (1), ScheduledEvent (6), StageInstance (3), Sticker (1), Thread (4), ThreadSync (1), Typing (1), Webhook (1). Mirrors canonical at `MessageEventHandler.cs:83-91`. `rawJson` hoisted out of each `try` for catch reachability.
- Closes #58. **Completes §P1.1** of #53.

## Impact
After this lands, `grep -L FailedEventService src/DiscordEventService/Services/EventHandlers/*.cs` returns nothing — every catch in every handler now records to `failed_events` instead of silently swallowing the exception. The 22-of-27-silent-handlers number from the epic body becomes 0-of-27.

## Test plan
- [x] `dotnet build` — green (4 pre-existing unrelated warnings in `AutoModRuleEventHandler.cs`).
- [x] Per-file `grep` counts — catches == records:  
   Emoji=1, Integration=3, Invite=2, Pin=1, Poll=1, ScheduledEvent=6, StageInstance=3, Sticker=1, Thread=4, ThreadSync=1, Typing=1, Webhook=1.
- [x] `grep -L FailedEventService src/DiscordEventService/Services/EventHandlers/*.cs` returns nothing (acceptance criterion).
- [ ] Post-deploy probe: weekly verification §5.1 in #53 epic — any orphan raw events without matching `failed_events` rows now indicates a real bug, not a missing handler.

🤖 Generated with [Claude Code](https://claude.com/claude-code)