### PR TITLE
fix: idempotent Message/Channel/Role/Guild inserts via 23505 retry (#60)

### DIFF
--- a/src/DiscordEventService/Services/EventHandlers/ChannelEventHandler.cs
+++ b/src/DiscordEventService/Services/EventHandlers/ChannelEventHandler.cs
@@ -19,6 +19,7 @@ public class ChannelEventHandler(IServiceScopeFactory scopeFactory, ILogger<Chan
         string? rawJson = null;
         try
         {
+            var receivedAt = DateTime.UtcNow;
             using var scope = scopeFactory.CreateScope();
             var db = scope.ServiceProvider.GetRequiredService<DiscordDbContext>();
             var rawEventService = scope.ServiceProvider.GetRequiredService<RawEventLogService>();
@@ -38,8 +39,8 @@ public class ChannelEventHandler(IServiceScopeFactory scopeFactory, ILogger<Chan
                 NameAfter = e.Channel.Name,
                 TopicAfter = e.Channel.Topic,
                 PositionAfter = e.Channel.Position,
-                EventTimestampUtc = DateTime.UtcNow,
-                ReceivedAtUtc = DateTime.UtcNow,
+                EventTimestampUtc = receivedAt,
+                ReceivedAtUtc = receivedAt,
                 RawEventJson = rawJson
             };
 

--- a/src/DiscordEventService/Services/EventHandlers/ChannelEventHandler.cs
+++ b/src/DiscordEventService/Services/EventHandlers/ChannelEventHandler.cs
@@ -29,6 +29,20 @@ public class ChannelEventHandler(IServiceScopeFactory scopeFactory, ILogger<Chan
             // Look up Guild Guid
             var guild = await db.Guilds.FirstOrDefaultAsync(g => g.DiscordId == e.Guild.Id);
 
+            ChannelEventEntity NewChannelEvent() => new()
+            {
+                ChannelDiscordId = e.Channel.Id,
+                GuildDiscordId = e.Guild.Id,
+                ChannelType = (int)e.Channel.Type,
+                EventType = ChannelEventType.Created,
+                NameAfter = e.Channel.Name,
+                TopicAfter = e.Channel.Topic,
+                PositionAfter = e.Channel.Position,
+                EventTimestampUtc = DateTime.UtcNow,
+                ReceivedAtUtc = DateTime.UtcNow,
+                RawEventJson = rawJson
+            };
+
             var channelEntity = await db.Channels
                 .FirstOrDefaultAsync(c => c.DiscordId == e.Channel.Id);
 
@@ -43,23 +57,24 @@ public class ChannelEventHandler(IServiceScopeFactory scopeFactory, ILogger<Chan
             }
 
             UpdateChannelEntity(channelEntity, e.Channel);
+            db.ChannelEvents.Add(NewChannelEvent());
 
-            var channelEvent = new ChannelEventEntity
+            try
             {
-                ChannelDiscordId = e.Channel.Id,
-                GuildDiscordId = e.Guild.Id,
-                ChannelType = (int)e.Channel.Type,
-                EventType = ChannelEventType.Created,
-                NameAfter = e.Channel.Name,
-                TopicAfter = e.Channel.Topic,
-                PositionAfter = e.Channel.Position,
-                EventTimestampUtc = DateTime.UtcNow,
-                ReceivedAtUtc = DateTime.UtcNow,
-                RawEventJson = rawJson
-            };
-
-            db.ChannelEvents.Add(channelEvent);
-            await db.SaveChangesAsync();
+                await db.SaveChangesAsync();
+            }
+            catch (DbUpdateException dbEx) when (dbEx.InnerException is Npgsql.PostgresException { SqlState: "23505" })
+            {
+                // Concurrent insert won the race. Re-fetch the now-existing row, update it, re-add the event.
+                db.ChangeTracker.Clear();
+                var existing = await db.Channels.FirstOrDefaultAsync(c => c.DiscordId == e.Channel.Id);
+                if (existing != null)
+                {
+                    UpdateChannelEntity(existing, e.Channel);
+                }
+                db.ChannelEvents.Add(NewChannelEvent());
+                await db.SaveChangesAsync();
+            }
         }
         catch (Exception ex)
         {

--- a/src/DiscordEventService/Services/EventHandlers/GuildEventHandler.cs
+++ b/src/DiscordEventService/Services/EventHandlers/GuildEventHandler.cs
@@ -22,6 +22,14 @@ public class GuildEventHandler(IServiceScopeFactory scopeFactory, ILogger<GuildE
             using var scope = scopeFactory.CreateScope();
             var db = scope.ServiceProvider.GetRequiredService<DiscordDbContext>();
 
+            void ApplyGuildFields(GuildEntity g)
+            {
+                g.Name = e.Guild.Name;
+                g.IconHash = e.Guild.IconHash;
+                g.OwnerId = e.Guild.OwnerId;
+                g.LeftAtUtc = null;
+            }
+
             // Upsert guild
             var existingGuild = await db.Guilds
                 .Where(g => g.DiscordId == e.Guild.Id)
@@ -49,18 +57,12 @@ public class GuildEventHandler(IServiceScopeFactory scopeFactory, ILogger<GuildE
                         .Where(g => g.DiscordId == e.Guild.Id)
                         .FirstOrDefaultAsync()
                         ?? throw new InvalidOperationException($"Guild {e.Guild.Id} disappeared after 23505 conflict");
-                    existingGuild.Name = e.Guild.Name;
-                    existingGuild.IconHash = e.Guild.IconHash;
-                    existingGuild.OwnerId = e.Guild.OwnerId;
-                    existingGuild.LeftAtUtc = null;
+                    ApplyGuildFields(existingGuild);
                 }
             }
             else
             {
-                existingGuild.Name = e.Guild.Name;
-                existingGuild.IconHash = e.Guild.IconHash;
-                existingGuild.OwnerId = e.Guild.OwnerId;
-                existingGuild.LeftAtUtc = null;
+                ApplyGuildFields(existingGuild);
             }
 
             var guildGuid = existingGuild.Id;
@@ -74,8 +76,14 @@ public class GuildEventHandler(IServiceScopeFactory scopeFactory, ILogger<GuildE
             catch (DbUpdateException dbEx) when (dbEx.InnerException is Npgsql.PostgresException { SqlState: "23505" })
             {
                 // Concurrent GuildCreated inserted a channel/role that wasn't in our batch lookup.
-                // Clear, re-batch-load (now including the conflicting rows), and re-apply updates.
+                // Clear drops the Guild field updates set above, so re-fetch and re-apply them
+                // alongside the channel/role re-batch-load before saving.
                 db.ChangeTracker.Clear();
+                var refreshedGuild = await db.Guilds.FirstOrDefaultAsync(g => g.DiscordId == e.Guild.Id);
+                if (refreshedGuild != null)
+                {
+                    ApplyGuildFields(refreshedGuild);
+                }
                 await UpsertChannelsAndRolesAsync(db, e.Guild, guildGuid);
                 await db.SaveChangesAsync();
             }

--- a/src/DiscordEventService/Services/EventHandlers/GuildEventHandler.cs
+++ b/src/DiscordEventService/Services/EventHandlers/GuildEventHandler.cs
@@ -37,7 +37,23 @@ public class GuildEventHandler(IServiceScopeFactory scopeFactory, ILogger<GuildE
                     LeftAtUtc = null
                 };
                 db.Guilds.Add(existingGuild);
-                await db.SaveChangesAsync(); // Save to get the Guid Id
+                try
+                {
+                    await db.SaveChangesAsync(); // Save to get the Guid Id
+                }
+                catch (DbUpdateException dbEx) when (dbEx.InnerException is Npgsql.PostgresException { SqlState: "23505" })
+                {
+                    // Concurrent insert won the race. Re-fetch and update.
+                    db.ChangeTracker.Clear();
+                    existingGuild = await db.Guilds
+                        .Where(g => g.DiscordId == e.Guild.Id)
+                        .FirstOrDefaultAsync()
+                        ?? throw new InvalidOperationException($"Guild {e.Guild.Id} disappeared after 23505 conflict");
+                    existingGuild.Name = e.Guild.Name;
+                    existingGuild.IconHash = e.Guild.IconHash;
+                    existingGuild.OwnerId = e.Guild.OwnerId;
+                    existingGuild.LeftAtUtc = null;
+                }
             }
             else
             {
@@ -49,85 +65,20 @@ public class GuildEventHandler(IServiceScopeFactory scopeFactory, ILogger<GuildE
 
             var guildGuid = existingGuild.Id;
 
-            // Batch load existing channels
-            var channelIds = e.Guild.Channels.Keys.ToList();
-            var existingChannels = await db.Channels
-                .Where(c => channelIds.Contains(c.DiscordId))
-                .ToDictionaryAsync(c => c.DiscordId);
+            await UpsertChannelsAndRolesAsync(db, e.Guild, guildGuid);
 
-            foreach (var channel in e.Guild.Channels.Values)
+            try
             {
-                if (!existingChannels.TryGetValue(channel.Id, out var existingChannel))
-                {
-                    db.Channels.Add(new ChannelEntity
-                    {
-                        DiscordId = channel.Id,
-                        GuildId = guildGuid,
-                        ParentDiscordId = channel.Parent?.Id,
-                        Name = channel.Name,
-                        Type = MapChannelType(channel.Type),
-                        Topic = channel.Topic,
-                        Bitrate = channel.Bitrate,
-                        UserLimit = channel.UserLimit,
-                        RateLimitPerUser = channel.PerUserRateLimit,
-                        IsNsfw = false,
-                        Position = channel.Position,
-                        IsDeleted = false
-                    });
-                }
-                else
-                {
-                    existingChannel.Name = channel.Name;
-                    existingChannel.ParentDiscordId = channel.Parent?.Id;
-                    existingChannel.Type = MapChannelType(channel.Type);
-                    existingChannel.Topic = channel.Topic;
-                    existingChannel.Bitrate = channel.Bitrate;
-                    existingChannel.UserLimit = channel.UserLimit;
-                    existingChannel.RateLimitPerUser = channel.PerUserRateLimit;
-                    existingChannel.IsNsfw = false;
-                    existingChannel.Position = channel.Position;
-                    existingChannel.IsDeleted = false;
-                }
+                await db.SaveChangesAsync();
             }
-
-            // Batch load existing roles
-            var roleIds = e.Guild.Roles.Keys.ToList();
-            var existingRoles = await db.Roles
-                .Where(r => roleIds.Contains(r.DiscordId))
-                .ToDictionaryAsync(r => r.DiscordId);
-
-            foreach (var role in e.Guild.Roles.Values)
+            catch (DbUpdateException dbEx) when (dbEx.InnerException is Npgsql.PostgresException { SqlState: "23505" })
             {
-                if (!existingRoles.TryGetValue(role.Id, out var existingRole))
-                {
-                    db.Roles.Add(new RoleEntity
-                    {
-                        DiscordId = role.Id,
-                        GuildId = guildGuid,
-                        Name = role.Name,
-                        Color = role.Color.Value,
-                        IsHoisted = role.IsHoisted,
-                        Position = role.Position,
-                        Permissions = long.TryParse(role.Permissions.ToString(), out var p) ? p : 0,
-                        IsManaged = role.IsManaged,
-                        IsMentionable = role.IsMentionable,
-                        IsDeleted = false
-                    });
-                }
-                else
-                {
-                    existingRole.Name = role.Name;
-                    existingRole.Color = role.Color.Value;
-                    existingRole.IsHoisted = role.IsHoisted;
-                    existingRole.Position = role.Position;
-                    existingRole.Permissions = long.TryParse(role.Permissions.ToString(), out var perm) ? perm : 0;
-                    existingRole.IsManaged = role.IsManaged;
-                    existingRole.IsMentionable = role.IsMentionable;
-                    existingRole.IsDeleted = false;
-                }
+                // Concurrent GuildCreated inserted a channel/role that wasn't in our batch lookup.
+                // Clear, re-batch-load (now including the conflicting rows), and re-apply updates.
+                db.ChangeTracker.Clear();
+                await UpsertChannelsAndRolesAsync(db, e.Guild, guildGuid);
+                await db.SaveChangesAsync();
             }
-
-            await db.SaveChangesAsync();
         }
         catch (Exception ex)
         {
@@ -265,6 +216,87 @@ public class GuildEventHandler(IServiceScopeFactory scopeFactory, ILogger<GuildE
             await failedEventService.RecordFailureAsync(
                 "GuildEmojisUpdated", nameof(GuildEventHandler), ex,
                 e.Guild?.Id, null, null);
+        }
+    }
+
+    private static async Task UpsertChannelsAndRolesAsync(DiscordDbContext db, DiscordGuild guild, Guid guildGuid)
+    {
+        // Batch load existing channels
+        var channelIds = guild.Channels.Keys.ToList();
+        var existingChannels = await db.Channels
+            .Where(c => channelIds.Contains(c.DiscordId))
+            .ToDictionaryAsync(c => c.DiscordId);
+
+        foreach (var channel in guild.Channels.Values)
+        {
+            if (!existingChannels.TryGetValue(channel.Id, out var existingChannel))
+            {
+                db.Channels.Add(new ChannelEntity
+                {
+                    DiscordId = channel.Id,
+                    GuildId = guildGuid,
+                    ParentDiscordId = channel.Parent?.Id,
+                    Name = channel.Name,
+                    Type = MapChannelType(channel.Type),
+                    Topic = channel.Topic,
+                    Bitrate = channel.Bitrate,
+                    UserLimit = channel.UserLimit,
+                    RateLimitPerUser = channel.PerUserRateLimit,
+                    IsNsfw = false,
+                    Position = channel.Position,
+                    IsDeleted = false
+                });
+            }
+            else
+            {
+                existingChannel.Name = channel.Name;
+                existingChannel.ParentDiscordId = channel.Parent?.Id;
+                existingChannel.Type = MapChannelType(channel.Type);
+                existingChannel.Topic = channel.Topic;
+                existingChannel.Bitrate = channel.Bitrate;
+                existingChannel.UserLimit = channel.UserLimit;
+                existingChannel.RateLimitPerUser = channel.PerUserRateLimit;
+                existingChannel.IsNsfw = false;
+                existingChannel.Position = channel.Position;
+                existingChannel.IsDeleted = false;
+            }
+        }
+
+        // Batch load existing roles
+        var roleIds = guild.Roles.Keys.ToList();
+        var existingRoles = await db.Roles
+            .Where(r => roleIds.Contains(r.DiscordId))
+            .ToDictionaryAsync(r => r.DiscordId);
+
+        foreach (var role in guild.Roles.Values)
+        {
+            if (!existingRoles.TryGetValue(role.Id, out var existingRole))
+            {
+                db.Roles.Add(new RoleEntity
+                {
+                    DiscordId = role.Id,
+                    GuildId = guildGuid,
+                    Name = role.Name,
+                    Color = role.Color.Value,
+                    IsHoisted = role.IsHoisted,
+                    Position = role.Position,
+                    Permissions = long.TryParse(role.Permissions.ToString(), out var p) ? p : 0,
+                    IsManaged = role.IsManaged,
+                    IsMentionable = role.IsMentionable,
+                    IsDeleted = false
+                });
+            }
+            else
+            {
+                existingRole.Name = role.Name;
+                existingRole.Color = role.Color.Value;
+                existingRole.IsHoisted = role.IsHoisted;
+                existingRole.Position = role.Position;
+                existingRole.Permissions = long.TryParse(role.Permissions.ToString(), out var perm) ? perm : 0;
+                existingRole.IsManaged = role.IsManaged;
+                existingRole.IsMentionable = role.IsMentionable;
+                existingRole.IsDeleted = false;
+            }
         }
     }
 

--- a/src/DiscordEventService/Services/EventHandlers/MessageEventHandler.cs
+++ b/src/DiscordEventService/Services/EventHandlers/MessageEventHandler.cs
@@ -44,23 +44,7 @@ public class MessageEventHandler(IServiceScopeFactory scopeFactory, ILogger<Mess
             var channel = await db.Channels.FirstOrDefaultAsync(c => c.DiscordId == e.Channel.Id);
             var author = await db.Users.FirstOrDefaultAsync(u => u.DiscordId == e.Author.Id);
 
-            // Upsert message entity
-            db.Messages.Add(new MessageEntity
-            {
-                DiscordId = e.Message.Id,
-                ChannelId = channel?.Id,
-                GuildId = guild?.Id,
-                AuthorId = author?.Id,
-                Content = e.Message.Content,
-                ReplyToDiscordId = e.Message.ReferencedMessage?.Id,
-                HasAttachments = e.Message.Attachments.Count > 0,
-                HasEmbeds = e.Message.Embeds.Count > 0,
-                AttachmentsJson = attachmentsJson,
-                EmbedsJson = embedsJson,
-                CreatedAtUtc = e.Message.Timestamp.UtcDateTime
-            });
-
-            db.MessageEvents.Add(new MessageEventEntity
+            MessageEventEntity NewMessageEvent() => new()
             {
                 MessageDiscordId = e.Message.Id,
                 ChannelDiscordId = e.Channel.Id,
@@ -76,9 +60,44 @@ public class MessageEventHandler(IServiceScopeFactory scopeFactory, ILogger<Mess
                 EventTimestampUtc = e.Message.Timestamp.UtcDateTime,
                 ReceivedAtUtc = DateTime.UtcNow,
                 RawEventJson = rawJson
-            });
+            };
 
-            await db.SaveChangesAsync();
+            db.Messages.Add(new MessageEntity
+            {
+                DiscordId = e.Message.Id,
+                ChannelId = channel?.Id,
+                GuildId = guild?.Id,
+                AuthorId = author?.Id,
+                Content = e.Message.Content,
+                ReplyToDiscordId = e.Message.ReferencedMessage?.Id,
+                HasAttachments = e.Message.Attachments.Count > 0,
+                HasEmbeds = e.Message.Embeds.Count > 0,
+                AttachmentsJson = attachmentsJson,
+                EmbedsJson = embedsJson,
+                CreatedAtUtc = e.Message.Timestamp.UtcDateTime
+            });
+            db.MessageEvents.Add(NewMessageEvent());
+
+            try
+            {
+                await db.SaveChangesAsync();
+            }
+            catch (DbUpdateException dbEx) when (dbEx.InnerException is Npgsql.PostgresException { SqlState: "23505" })
+            {
+                // Gateway redelivery: message already stored. Refresh mutable fields and record the event row.
+                db.ChangeTracker.Clear();
+                await db.Messages
+                    .Where(m => m.DiscordId == e.Message.Id)
+                    .ExecuteUpdateAsync(s => s
+                        .SetProperty(m => m.Content, e.Message.Content)
+                        .SetProperty(m => m.HasAttachments, e.Message.Attachments.Count > 0)
+                        .SetProperty(m => m.HasEmbeds, e.Message.Embeds.Count > 0)
+                        .SetProperty(m => m.AttachmentsJson, attachmentsJson)
+                        .SetProperty(m => m.EmbedsJson, embedsJson)
+                        .SetProperty(m => m.ReplyToDiscordId, e.Message.ReferencedMessage?.Id));
+                db.MessageEvents.Add(NewMessageEvent());
+                await db.SaveChangesAsync();
+            }
         }
         catch (Exception ex)
         {

--- a/src/DiscordEventService/Services/EventHandlers/RoleEventHandler.cs
+++ b/src/DiscordEventService/Services/EventHandlers/RoleEventHandler.cs
@@ -29,6 +29,18 @@ public class RoleEventHandler(IServiceScopeFactory scopeFactory, ILogger<RoleEve
             // Look up Guild Guid
             var guild = await db.Guilds.FirstOrDefaultAsync(g => g.DiscordId == e.Guild.Id);
 
+            RoleEventEntity NewRoleEvent() => new()
+            {
+                RoleDiscordId = e.Role.Id,
+                GuildDiscordId = e.Guild.Id,
+                EventType = RoleEventType.Created,
+                NameAfter = e.Role.Name,
+                ColorAfter = e.Role.Color.Value,
+                EventTimestampUtc = receivedAt,
+                ReceivedAtUtc = receivedAt,
+                RawEventJson = rawJson
+            };
+
             var roleEntity = await db.Roles
                 .FirstOrDefaultAsync(r => r.DiscordId == e.Role.Id);
 
@@ -43,21 +55,24 @@ public class RoleEventHandler(IServiceScopeFactory scopeFactory, ILogger<RoleEve
             }
 
             UpdateRoleEntity(roleEntity, e.Role);
+            db.RoleEvents.Add(NewRoleEvent());
 
-            var roleEvent = new RoleEventEntity
+            try
             {
-                RoleDiscordId = e.Role.Id,
-                GuildDiscordId = e.Guild.Id,
-                EventType = RoleEventType.Created,
-                NameAfter = e.Role.Name,
-                ColorAfter = e.Role.Color.Value,
-                EventTimestampUtc = receivedAt,
-                ReceivedAtUtc = receivedAt,
-                RawEventJson = rawJson
-            };
-
-            db.RoleEvents.Add(roleEvent);
-            await db.SaveChangesAsync();
+                await db.SaveChangesAsync();
+            }
+            catch (DbUpdateException dbEx) when (dbEx.InnerException is Npgsql.PostgresException { SqlState: "23505" })
+            {
+                // Concurrent insert won the race. Re-fetch, update, re-add the event.
+                db.ChangeTracker.Clear();
+                var existing = await db.Roles.FirstOrDefaultAsync(r => r.DiscordId == e.Role.Id);
+                if (existing != null)
+                {
+                    UpdateRoleEntity(existing, e.Role);
+                }
+                db.RoleEvents.Add(NewRoleEvent());
+                await db.SaveChangesAsync();
+            }
         }
         catch (Exception ex)
         {


### PR DESCRIPTION
## Summary

Closes #60 (§P1.3).

Discord's gateway can redeliver events after a reconnect, and concurrent first-seen inserts on Channel/Role/Guild can race. Today these crash the handler — and now (post-§P1.1) get dead-lettered via `FailedEventService` instead of being swallowed. This change makes them idempotent no-ops.

## Changes

- **MessageEventHandler.MessageCreated** (CRITICAL): bare `db.Messages.Add` had no upsert and no retry. On 23505, `ChangeTracker.Clear` then `ExecuteUpdate` to refresh mutable content fields (`Content`, `HasAttachments`, `HasEmbeds`, `AttachmentsJson`, `EmbedsJson`, `ReplyToDiscordId`). `CreatedAtUtc` is immutable — not refreshed. The `MessageEvents` row is re-added (append-only).
- **ChannelEventHandler.ChannelCreated**, **RoleEventHandler.RoleCreated**: `FirstOrDefault + Add` race window. On 23505, clear, re-fetch, apply the existing `UpdateXxxEntity` helper, re-add event.
- **GuildEventHandler.GuildCreated**: two-save flow. First save (Guild) gets the same wrap; if Guild disappeared after re-fetch (impossible in practice), throws to surface a corrupt state. Second save (channels/roles) calls a new `UpsertChannelsAndRolesAsync` helper twice on conflict — once in happy path, again after Clear with re-fetched dictionaries.

Each handler uses a local `NewXxxEvent()` factory function so the event row can be re-added after `ChangeTracker.Clear` without duplicating field assignments.

## Out of scope

- Idempotency on `*_events` tables (per OD#2(a): events are append-only; redeliveries correctly produce two event rows).
- Member/User upsert paths (already idempotent in `UserService`).
- Transaction wrapping — that's #61 / §P1.4. Order matters: with #60 in place, retries during a future tx-wrapped flow won't lose work mid-tx.
- Extracting a shared `IsUniqueViolation()` predicate — across now ~8 sites, but matches the existing inline pattern. A future cross-cutting cleanup PR.

## Test plan

- [x] `dotnet build src/DiscordEventService/DiscordEventService.csproj` — green
- [ ] Acceptance probe (post-deploy, weekly): `SELECT count(*) FROM failed_events WHERE event_type IN ('MessageCreated','ChannelCreated','RoleCreated','GuildCreated','GuildAvailable') AND exception_type LIKE '%PostgresException%' AND failed_at_utc > now() - interval '7 days'` → expect 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)