### PR TITLE
fix: wrap multi-row handler inserts in explicit transactions (#61)

### DIFF
--- a/src/DiscordEventService/Services/EventHandlers/GuildEventHandler.cs
+++ b/src/DiscordEventService/Services/EventHandlers/GuildEventHandler.cs
@@ -30,63 +30,76 @@ public class GuildEventHandler(IServiceScopeFactory scopeFactory, ILogger<GuildE
                 g.LeftAtUtc = null;
             }
 
-            // Upsert guild
-            var existingGuild = await db.Guilds
-                .Where(g => g.DiscordId == e.Guild.Id)
-                .FirstOrDefaultAsync();
-            if (existingGuild == null)
+            // Wrap the two-stage upsert (Guild flush for Guid, then channels/roles) in
+            // one transaction so a partial failure (e.g. FK error on roles after Guild
+            // already flushed) rolls back atomically. ExecutionStrategy is required
+            // because EnableRetryOnFailure is configured on the DbContext.
+            var strategy = db.Database.CreateExecutionStrategy();
+            await strategy.ExecuteAsync(async () =>
             {
-                existingGuild = new GuildEntity
+                db.ChangeTracker.Clear();
+                await using var tx = await db.Database.BeginTransactionAsync();
+
+                // Upsert guild
+                var existingGuild = await db.Guilds
+                    .Where(g => g.DiscordId == e.Guild.Id)
+                    .FirstOrDefaultAsync();
+                if (existingGuild == null)
                 {
-                    DiscordId = e.Guild.Id,
-                    Name = e.Guild.Name,
-                    IconHash = e.Guild.IconHash,
-                    OwnerId = e.Guild.OwnerId,
-                    LeftAtUtc = null
-                };
-                db.Guilds.Add(existingGuild);
+                    existingGuild = new GuildEntity
+                    {
+                        DiscordId = e.Guild.Id,
+                        Name = e.Guild.Name,
+                        IconHash = e.Guild.IconHash,
+                        OwnerId = e.Guild.OwnerId,
+                        LeftAtUtc = null
+                    };
+                    db.Guilds.Add(existingGuild);
+                    try
+                    {
+                        await db.SaveChangesAsync(); // Flush to get the Guid Id (committed atomically with the rest at tx.CommitAsync).
+                    }
+                    catch (DbUpdateException dbEx) when (dbEx.InnerException is Npgsql.PostgresException { SqlState: "23505" })
+                    {
+                        // Concurrent insert won the race. Re-fetch and update.
+                        db.ChangeTracker.Clear();
+                        existingGuild = await db.Guilds
+                            .Where(g => g.DiscordId == e.Guild.Id)
+                            .FirstOrDefaultAsync()
+                            ?? throw new InvalidOperationException($"Guild {e.Guild.Id} disappeared after 23505 conflict");
+                        ApplyGuildFields(existingGuild);
+                    }
+                }
+                else
+                {
+                    ApplyGuildFields(existingGuild);
+                }
+
+                var guildGuid = existingGuild.Id;
+
+                await UpsertChannelsAndRolesAsync(db, e.Guild, guildGuid);
+
                 try
                 {
-                    await db.SaveChangesAsync(); // Save to get the Guid Id
+                    await db.SaveChangesAsync();
                 }
                 catch (DbUpdateException dbEx) when (dbEx.InnerException is Npgsql.PostgresException { SqlState: "23505" })
                 {
-                    // Concurrent insert won the race. Re-fetch and update.
+                    // Concurrent GuildCreated inserted a channel/role that wasn't in our batch lookup.
+                    // Clear drops the Guild field updates set above, so re-fetch and re-apply them
+                    // alongside the channel/role re-batch-load before saving.
                     db.ChangeTracker.Clear();
-                    existingGuild = await db.Guilds
-                        .Where(g => g.DiscordId == e.Guild.Id)
-                        .FirstOrDefaultAsync()
-                        ?? throw new InvalidOperationException($"Guild {e.Guild.Id} disappeared after 23505 conflict");
-                    ApplyGuildFields(existingGuild);
+                    var refreshedGuild = await db.Guilds.FirstOrDefaultAsync(g => g.DiscordId == e.Guild.Id);
+                    if (refreshedGuild != null)
+                    {
+                        ApplyGuildFields(refreshedGuild);
+                    }
+                    await UpsertChannelsAndRolesAsync(db, e.Guild, guildGuid);
+                    await db.SaveChangesAsync();
                 }
-            }
-            else
-            {
-                ApplyGuildFields(existingGuild);
-            }
 
-            var guildGuid = existingGuild.Id;
-
-            await UpsertChannelsAndRolesAsync(db, e.Guild, guildGuid);
-
-            try
-            {
-                await db.SaveChangesAsync();
-            }
-            catch (DbUpdateException dbEx) when (dbEx.InnerException is Npgsql.PostgresException { SqlState: "23505" })
-            {
-                // Concurrent GuildCreated inserted a channel/role that wasn't in our batch lookup.
-                // Clear drops the Guild field updates set above, so re-fetch and re-apply them
-                // alongside the channel/role re-batch-load before saving.
-                db.ChangeTracker.Clear();
-                var refreshedGuild = await db.Guilds.FirstOrDefaultAsync(g => g.DiscordId == e.Guild.Id);
-                if (refreshedGuild != null)
-                {
-                    ApplyGuildFields(refreshedGuild);
-                }
-                await UpsertChannelsAndRolesAsync(db, e.Guild, guildGuid);
-                await db.SaveChangesAsync();
-            }
+                await tx.CommitAsync();
+            });
         }
         catch (Exception ex)
         {

--- a/src/DiscordEventService/Services/EventHandlers/MessageEventHandler.cs
+++ b/src/DiscordEventService/Services/EventHandlers/MessageEventHandler.cs
@@ -62,6 +62,11 @@ public class MessageEventHandler(IServiceScopeFactory scopeFactory, ILogger<Mess
                 RawEventJson = rawJson
             };
 
+            // SerializeAndLogAsync staged a RawEventLog row but did NOT save it; flush it
+            // (and any other pending work like UpsertUserAsync's tracked update) before
+            // the strategy lambda's ChangeTracker.Clear() detaches it.
+            await db.SaveChangesAsync();
+
             // Wrap multi-row writes in a transaction so the 23505 retry path
             // (ExecuteUpdate + insert) is atomic. ExecutionStrategy is required
             // because EnableRetryOnFailure is configured on the DbContext.
@@ -147,6 +152,10 @@ public class MessageEventHandler(IServiceScopeFactory scopeFactory, ILogger<Mess
             // Get the message entity for FK reference (read-only snapshot, used inside the tx)
             var message = await db.Messages.FirstOrDefaultAsync(m => m.DiscordId == e.Message.Id);
             var messageGuid = message?.Id;
+
+            // SerializeAndLogAsync staged a RawEventLog row but did NOT save it; flush it
+            // before the strategy lambda's ChangeTracker.Clear() detaches it.
+            await db.SaveChangesAsync();
 
             // Wrap the ExecuteUpdate (auto-commits without a tx) and the event-log inserts
             // in one transaction so a failure between them rolls back atomically.

--- a/src/DiscordEventService/Services/EventHandlers/MessageEventHandler.cs
+++ b/src/DiscordEventService/Services/EventHandlers/MessageEventHandler.cs
@@ -62,42 +62,54 @@ public class MessageEventHandler(IServiceScopeFactory scopeFactory, ILogger<Mess
                 RawEventJson = rawJson
             };
 
-            db.Messages.Add(new MessageEntity
+            // Wrap multi-row writes in a transaction so the 23505 retry path
+            // (ExecuteUpdate + insert) is atomic. ExecutionStrategy is required
+            // because EnableRetryOnFailure is configured on the DbContext.
+            var strategy = db.Database.CreateExecutionStrategy();
+            await strategy.ExecuteAsync(async () =>
             {
-                DiscordId = e.Message.Id,
-                ChannelId = channel?.Id,
-                GuildId = guild?.Id,
-                AuthorId = author?.Id,
-                Content = e.Message.Content,
-                ReplyToDiscordId = e.Message.ReferencedMessage?.Id,
-                HasAttachments = e.Message.Attachments.Count > 0,
-                HasEmbeds = e.Message.Embeds.Count > 0,
-                AttachmentsJson = attachmentsJson,
-                EmbedsJson = embedsJson,
-                CreatedAtUtc = e.Message.Timestamp.UtcDateTime
-            });
-            db.MessageEvents.Add(NewMessageEvent());
-
-            try
-            {
-                await db.SaveChangesAsync();
-            }
-            catch (DbUpdateException dbEx) when (dbEx.InnerException is Npgsql.PostgresException { SqlState: "23505" })
-            {
-                // Gateway redelivery: message already stored. Refresh mutable fields and record the event row.
                 db.ChangeTracker.Clear();
-                await db.Messages
-                    .Where(m => m.DiscordId == e.Message.Id)
-                    .ExecuteUpdateAsync(s => s
-                        .SetProperty(m => m.Content, e.Message.Content)
-                        .SetProperty(m => m.HasAttachments, e.Message.Attachments.Count > 0)
-                        .SetProperty(m => m.HasEmbeds, e.Message.Embeds.Count > 0)
-                        .SetProperty(m => m.AttachmentsJson, attachmentsJson)
-                        .SetProperty(m => m.EmbedsJson, embedsJson)
-                        .SetProperty(m => m.ReplyToDiscordId, e.Message.ReferencedMessage?.Id));
+                await using var tx = await db.Database.BeginTransactionAsync();
+
+                db.Messages.Add(new MessageEntity
+                {
+                    DiscordId = e.Message.Id,
+                    ChannelId = channel?.Id,
+                    GuildId = guild?.Id,
+                    AuthorId = author?.Id,
+                    Content = e.Message.Content,
+                    ReplyToDiscordId = e.Message.ReferencedMessage?.Id,
+                    HasAttachments = e.Message.Attachments.Count > 0,
+                    HasEmbeds = e.Message.Embeds.Count > 0,
+                    AttachmentsJson = attachmentsJson,
+                    EmbedsJson = embedsJson,
+                    CreatedAtUtc = e.Message.Timestamp.UtcDateTime
+                });
                 db.MessageEvents.Add(NewMessageEvent());
-                await db.SaveChangesAsync();
-            }
+
+                try
+                {
+                    await db.SaveChangesAsync();
+                }
+                catch (DbUpdateException dbEx) when (dbEx.InnerException is Npgsql.PostgresException { SqlState: "23505" })
+                {
+                    // Gateway redelivery: message already stored. Refresh mutable fields and record the event row.
+                    db.ChangeTracker.Clear();
+                    await db.Messages
+                        .Where(m => m.DiscordId == e.Message.Id)
+                        .ExecuteUpdateAsync(s => s
+                            .SetProperty(m => m.Content, e.Message.Content)
+                            .SetProperty(m => m.HasAttachments, e.Message.Attachments.Count > 0)
+                            .SetProperty(m => m.HasEmbeds, e.Message.Embeds.Count > 0)
+                            .SetProperty(m => m.AttachmentsJson, attachmentsJson)
+                            .SetProperty(m => m.EmbedsJson, embedsJson)
+                            .SetProperty(m => m.ReplyToDiscordId, e.Message.ReferencedMessage?.Id));
+                    db.MessageEvents.Add(NewMessageEvent());
+                    await db.SaveChangesAsync();
+                }
+
+                await tx.CommitAsync();
+            });
         }
         catch (Exception ex)
         {
@@ -132,55 +144,63 @@ public class MessageEventHandler(IServiceScopeFactory scopeFactory, ILogger<Mess
                 : null;
             var editedAt = e.Message.EditedTimestamp?.UtcDateTime ?? receivedAt;
 
-            // Get the message entity for FK reference
+            // Get the message entity for FK reference (read-only snapshot, used inside the tx)
             var message = await db.Messages.FirstOrDefaultAsync(m => m.DiscordId == e.Message.Id);
+            var messageGuid = message?.Id;
 
-            // Update message entity
-            await db.Messages
-                .Where(m => m.DiscordId == e.Message.Id)
-                .ExecuteUpdateAsync(s => s
-                    .SetProperty(m => m.Content, e.Message.Content)
-                    .SetProperty(m => m.HasAttachments, e.Message.Attachments.Count > 0)
-                    .SetProperty(m => m.HasEmbeds, e.Message.Embeds.Count > 0)
-                    .SetProperty(m => m.AttachmentsJson, attachmentsJson)
-                    .SetProperty(m => m.EmbedsJson, embedsJson)
-                    .SetProperty(m => m.EditedAtUtc, editedAt));
-
-            // Record edit in event log
-            db.MessageEvents.Add(new MessageEventEntity
+            // Wrap the ExecuteUpdate (auto-commits without a tx) and the event-log inserts
+            // in one transaction so a failure between them rolls back atomically.
+            var strategy = db.Database.CreateExecutionStrategy();
+            await strategy.ExecuteAsync(async () =>
             {
-                MessageDiscordId = e.Message.Id,
-                ChannelDiscordId = e.Channel.Id,
-                AuthorDiscordId = e.Author?.Id,
-                GuildDiscordId = e.Guild.Id,
-                EventType = MessageEventType.Updated,
-                Content = e.Message.Content,
-                ContentBefore = e.MessageBefore?.Content,
-                HasAttachments = e.Message.Attachments.Count > 0,
-                HasEmbeds = e.Message.Embeds.Count > 0,
-                ReplyToMessageDiscordId = e.Message.ReferencedMessage?.Id,
-                AttachmentsJson = attachmentsJson,
-                EmbedsJson = embedsJson,
-                EventTimestampUtc = editedAt,
-                ReceivedAtUtc = receivedAt,
-                RawEventJson = rawJson
-            });
+                db.ChangeTracker.Clear();
+                await using var tx = await db.Database.BeginTransactionAsync();
 
-            // Record in edit history table (tracks all edits with before/after)
-            if (e.MessageBefore?.Content != e.Message.Content)
-            {
-                db.MessageEditHistory.Add(new MessageEditHistoryEntity
+                await db.Messages
+                    .Where(m => m.DiscordId == e.Message.Id)
+                    .ExecuteUpdateAsync(s => s
+                        .SetProperty(m => m.Content, e.Message.Content)
+                        .SetProperty(m => m.HasAttachments, e.Message.Attachments.Count > 0)
+                        .SetProperty(m => m.HasEmbeds, e.Message.Embeds.Count > 0)
+                        .SetProperty(m => m.AttachmentsJson, attachmentsJson)
+                        .SetProperty(m => m.EmbedsJson, embedsJson)
+                        .SetProperty(m => m.EditedAtUtc, editedAt));
+
+                db.MessageEvents.Add(new MessageEventEntity
                 {
-                    MessageId = message?.Id,
                     MessageDiscordId = e.Message.Id,
+                    ChannelDiscordId = e.Channel.Id,
+                    AuthorDiscordId = e.Author?.Id,
+                    GuildDiscordId = e.Guild.Id,
+                    EventType = MessageEventType.Updated,
+                    Content = e.Message.Content,
                     ContentBefore = e.MessageBefore?.Content,
-                    ContentAfter = e.Message.Content,
-                    EditedAtUtc = editedAt,
-                    RecordedAtUtc = receivedAt
+                    HasAttachments = e.Message.Attachments.Count > 0,
+                    HasEmbeds = e.Message.Embeds.Count > 0,
+                    ReplyToMessageDiscordId = e.Message.ReferencedMessage?.Id,
+                    AttachmentsJson = attachmentsJson,
+                    EmbedsJson = embedsJson,
+                    EventTimestampUtc = editedAt,
+                    ReceivedAtUtc = receivedAt,
+                    RawEventJson = rawJson
                 });
-            }
 
-            await db.SaveChangesAsync();
+                if (e.MessageBefore?.Content != e.Message.Content)
+                {
+                    db.MessageEditHistory.Add(new MessageEditHistoryEntity
+                    {
+                        MessageId = messageGuid,
+                        MessageDiscordId = e.Message.Id,
+                        ContentBefore = e.MessageBefore?.Content,
+                        ContentAfter = e.Message.Content,
+                        EditedAtUtc = editedAt,
+                        RecordedAtUtc = receivedAt
+                    });
+                }
+
+                await db.SaveChangesAsync();
+                await tx.CommitAsync();
+            });
         }
         catch (Exception ex)
         {

--- a/src/DiscordEventService/Services/EventHandlers/MessageEventHandler.cs
+++ b/src/DiscordEventService/Services/EventHandlers/MessageEventHandler.cs
@@ -63,8 +63,7 @@ public class MessageEventHandler(IServiceScopeFactory scopeFactory, ILogger<Mess
             };
 
             // SerializeAndLogAsync staged a RawEventLog row but did NOT save it; flush it
-            // (and any other pending work like UpsertUserAsync's tracked update) before
-            // the strategy lambda's ChangeTracker.Clear() detaches it.
+            // before the strategy lambda's ChangeTracker.Clear() detaches it.
             await db.SaveChangesAsync();
 
             // Wrap multi-row writes in a transaction so the 23505 retry path


### PR DESCRIPTION
## Summary

Closes #61 (§P1.4).

Three handler methods write to multiple tables in a single try block today, with no `BeginTransactionAsync` boundary. If a partial failure happens between writes (FK violation, network hiccup mid-`SaveChangesAsync`), the DB ends up in an inconsistent state. **Live evidence**: 4 messages have `channel_id IS NULL` from a 2026-02-15 incident.

This change wraps the three sites in explicit transactions via `db.Database.CreateExecutionStrategy().ExecuteAsync(...)` (required because `Program.cs:40-43` configures `EnableRetryOnFailure(3, ...)` — direct `BeginTransactionAsync` would throw at runtime).

Each lambda starts with `db.ChangeTracker.Clear()` for retry-safety: on a transient failure the strategy reruns the lambda with a clean tracker, so re-staged `Add` calls don't double-insert.

## Sites

- **MessageEventHandler.MessageCreated**: `Messages` + `MessageEvents` inserts plus the 23505 retry path (`ExecuteUpdate` then re-add event) all in one tx, so `ExecuteUpdate` doesn't auto-commit ahead of the event insert.
- **MessageEventHandler.MessageUpdated**: `ExecuteUpdate` + `MessageEvents.Add` + `MessageEditHistory.Add` all in one tx. **The riskiest spot pre-fix**: `ExecuteUpdate` auto-committed before the next `SaveChanges`, so a failure between them silently dropped the edit-history row while still updating the message.
- **GuildEventHandler.GuildCreated**: Guild flush (for Guid) + `UpsertChannelsAndRolesAsync` in one tx. The first `SaveChangesAsync` flushes the Guild insert and EF Core populates the Guid via `INSERT...RETURNING`; everything commits atomically at `tx.CommitAsync`.

Pre-tx work (`UpsertUserAsync`, FK lookups) stays outside since it is read-only or idempotent and benefits from independent commit.

## One-shot orphan repair (deliver separately, not in this PR)

```sql
-- Repair the 4 messages with channel_id IS NULL from 2026-02-15
-- First verify whether messages has channel_discord_id column (\d messages).
UPDATE messages m
SET channel_id = c.id
FROM channels c
WHERE m.channel_id IS NULL
  AND m.channel_discord_id = c.discord_id;
```

If the column doesn't exist, defer to a follow-up endpoint that replays from `raw_event_logs`.

## Out of scope

- Wrapping single-row handlers (already atomic via single `SaveChanges`).
- Wrapping handlers from §P1.1 that write to one events table.
- Backfilling the 4 orphan messages via API endpoint (one-shot SQL is enough).
- Extracting a shared `ExecuteInTransactionAsync` helper — first introduction of the pattern; defer until a 4th site or a divergence bug.

## Test plan

- [x] `dotnet build src/DiscordEventService/DiscordEventService.csproj` — green
- [x] `grep -rn "BeginTransactionAsync" src/DiscordEventService/` — exactly 3 occurrences
- [ ] Acceptance probe: `SELECT count(*) FROM messages WHERE channel_id IS NULL` stays at 4 (or drops to 0 after one-shot repair) and never grows
- [ ] Manual fault-injection test (local): throw between Guild flush and channels/roles save → verify Guild insert is rolled back

🤖 Generated with [Claude Code](https://claude.com/claude-code)