### PR TITLE
feat: add BotDowntimeIntervalEntity + EF migration (#64)

### DIFF
--- a/src/DiscordEventService/Data/DiscordDbContext.cs
+++ b/src/DiscordEventService/Data/DiscordDbContext.cs
@@ -74,6 +74,9 @@ public class DiscordDbContext(DbContextOptions<DiscordDbContext> options) : DbCo
     // Backfill checkpoints
     public DbSet<BackfillCheckpointEntity> BackfillCheckpoints => Set<BackfillCheckpointEntity>();
 
+    // Bot downtime intervals
+    public DbSet<BotDowntimeIntervalEntity> BotDowntimeIntervals => Set<BotDowntimeIntervalEntity>();
+
     protected override void OnModelCreating(ModelBuilder modelBuilder)
     {
         base.OnModelCreating(modelBuilder);
@@ -848,6 +851,16 @@ public class DiscordDbContext(DbContextOptions<DiscordDbContext> options) : DbCo
 
         modelBuilder.Entity<BackfillCheckpointEntity>()
             .HasIndex(b => b.HangfireJobId);
+
+        // =====================================================
+        // BotDowntimeInterval configuration
+        // =====================================================
+        modelBuilder.Entity<BotDowntimeIntervalEntity>(b =>
+        {
+            b.HasIndex(x => new { x.StartedAtUtc, x.EndedAtUtc });
+            b.HasIndex(x => x.EndedAtUtc)
+                .HasFilter("ended_at_utc IS NULL");
+        });
     }
 
     public override Task<int> SaveChangesAsync(CancellationToken cancellationToken = default)

--- a/src/DiscordEventService/Data/Entities/Core/BotDowntimeIntervalEntity.cs
+++ b/src/DiscordEventService/Data/Entities/Core/BotDowntimeIntervalEntity.cs
@@ -1,0 +1,33 @@
+namespace DiscordEventService.Data.Entities.Core;
+
+public class BotDowntimeIntervalEntity : ITimestamped
+{
+    public Guid Id { get; set; }
+    public DateTime StartedAtUtc { get; set; }
+    public DateTime? EndedAtUtc { get; set; }
+    public BotDowntimeType Type { get; set; }
+    public BotDowntimeDetectionMethod DetectionMethod { get; set; }
+    public DateTime? LastEventBeforeUtc { get; set; }
+    public DateTime? FirstEventAfterUtc { get; set; }
+    public string? Notes { get; set; }
+    public DateTime FirstSeenUtc { get; set; }
+    public DateTime LastUpdatedUtc { get; set; }
+}
+
+public enum BotDowntimeType
+{
+    GracefulShutdown = 0,
+    Deploy = 1,
+    HostDown = 2,
+    GatewayDisconnect = 3,
+    DbUnreachable = 4,
+    Inferred = 5
+}
+
+public enum BotDowntimeDetectionMethod
+{
+    GracefulStop = 0,
+    StartupGapInference = 1,
+    GatewayEvent = 2,
+    Manual = 3
+}

--- a/src/DiscordEventService/Data/Migrations/20260427164707_AddBotDowntimeIntervals.Designer.cs
+++ b/src/DiscordEventService/Data/Migrations/20260427164707_AddBotDowntimeIntervals.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using DiscordEventService.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -11,9 +12,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace DiscordEventService.Data.Migrations
 {
     [DbContext(typeof(DiscordDbContext))]
-    partial class DiscordDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260427164707_AddBotDowntimeIntervals")]
+    partial class AddBotDowntimeIntervals
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/DiscordEventService/Data/Migrations/20260427164707_AddBotDowntimeIntervals.cs
+++ b/src/DiscordEventService/Data/Migrations/20260427164707_AddBotDowntimeIntervals.cs
@@ -1,0 +1,53 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace DiscordEventService.Data.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddBotDowntimeIntervals : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "bot_downtime_intervals",
+                columns: table => new
+                {
+                    id = table.Column<Guid>(type: "uuid", nullable: false, defaultValueSql: "uuidv7()"),
+                    started_at_utc = table.Column<DateTime>(type: "timestamp with time zone", nullable: false),
+                    ended_at_utc = table.Column<DateTime>(type: "timestamp with time zone", nullable: true),
+                    type = table.Column<int>(type: "integer", nullable: false),
+                    detection_method = table.Column<int>(type: "integer", nullable: false),
+                    last_event_before_utc = table.Column<DateTime>(type: "timestamp with time zone", nullable: true),
+                    first_event_after_utc = table.Column<DateTime>(type: "timestamp with time zone", nullable: true),
+                    notes = table.Column<string>(type: "text", nullable: true),
+                    first_seen_utc = table.Column<DateTime>(type: "timestamp with time zone", nullable: false),
+                    last_updated_utc = table.Column<DateTime>(type: "timestamp with time zone", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("pk_bot_downtime_intervals", x => x.id);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "ix_bot_downtime_intervals_ended_at_utc",
+                table: "bot_downtime_intervals",
+                column: "ended_at_utc",
+                filter: "ended_at_utc IS NULL");
+
+            migrationBuilder.CreateIndex(
+                name: "ix_bot_downtime_intervals_started_at_utc_ended_at_utc",
+                table: "bot_downtime_intervals",
+                columns: new[] { "started_at_utc", "ended_at_utc" });
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "bot_downtime_intervals");
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Adds `BotDowntimeIntervalEntity` + `BotDowntimeType` / `BotDowntimeDetectionMethod` enums (template: `BackfillCheckpointEntity`).
- Registers `DbSet<BotDowntimeIntervalEntity>` and two indexes on `OnModelCreating`:
  - composite `(started_at_utc, ended_at_utc)`
  - partial index on `ended_at_utc WHERE ended_at_utc IS NULL` for fast "currently down" lookup.
- Auto-generated migration `AddBotDowntimeIntervals` — single `CreateTable` + the two indexes, no unrelated drift.

This is §P1.8 step 1 of 3. Wiring (Start/Stop + socket events + `POST /api/ops/downtime/start`) lands in #65; historical zero-event-hour backfill lands in #66.

Migrations apply on startup (`Database.AutoMigrate=true`).

Closes #64.

## Test plan
- [x] `dotnet build` green (4 pre-existing AutoModRule warnings unchanged)
- [x] `dotnet ef migrations add` produces clean migration (no unrelated drift)
- [ ] Post-deploy: `\d bot_downtime_intervals` shows table + both indexes on homelab psql

🤖 Generated with [Claude Code](https://claude.com/claude-code)