### PR TITLE
feat: widen MemberEventHandler.Updated filter; +10 before/after columns (#63)

### DIFF
--- a/src/DiscordEventService/Data/Entities/Events/MemberEventEntity.cs
+++ b/src/DiscordEventService/Data/Entities/Events/MemberEventEntity.cs
@@ -24,6 +24,16 @@ public class MemberEventEntity
     public string? RolesAddedJson { get; set; }
     public string? RolesRemovedJson { get; set; }
     public DateTime? TimeoutUntilUtc { get; set; }
+    public DateTime? PremiumSinceBefore { get; set; }
+    public DateTime? PremiumSinceAfter { get; set; }
+    public string? GuildAvatarHashBefore { get; set; }
+    public string? GuildAvatarHashAfter { get; set; }
+    public bool? IsPendingBefore { get; set; }
+    public bool? IsPendingAfter { get; set; }
+    public bool? IsMutedBefore { get; set; }
+    public bool? IsMutedAfter { get; set; }
+    public bool? IsDeafenedBefore { get; set; }
+    public bool? IsDeafenedAfter { get; set; }
     public string? BanReason { get; set; }
     /// <summary>For Joined events, populated from Member.JoinedAt. For Left/Updated/Banned/Unbanned, DSharpPlus does not expose a per-event timestamp; equals ReceivedAtUtc by design.</summary>
     public DateTime EventTimestampUtc { get; set; }

--- a/src/DiscordEventService/Data/Migrations/20260427175800_WidenMemberUpdatedFilter.Designer.cs
+++ b/src/DiscordEventService/Data/Migrations/20260427175800_WidenMemberUpdatedFilter.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using DiscordEventService.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -11,9 +12,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace DiscordEventService.Data.Migrations
 {
     [DbContext(typeof(DiscordDbContext))]
-    partial class DiscordDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260427175800_WidenMemberUpdatedFilter")]
+    partial class WidenMemberUpdatedFilter
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/DiscordEventService/Data/Migrations/20260427175800_WidenMemberUpdatedFilter.cs
+++ b/src/DiscordEventService/Data/Migrations/20260427175800_WidenMemberUpdatedFilter.cs
@@ -1,0 +1,119 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace DiscordEventService.Data.Migrations
+{
+    /// <inheritdoc />
+    public partial class WidenMemberUpdatedFilter : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<string>(
+                name: "guild_avatar_hash_after",
+                table: "member_events",
+                type: "text",
+                nullable: true);
+
+            migrationBuilder.AddColumn<string>(
+                name: "guild_avatar_hash_before",
+                table: "member_events",
+                type: "text",
+                nullable: true);
+
+            migrationBuilder.AddColumn<bool>(
+                name: "is_deafened_after",
+                table: "member_events",
+                type: "boolean",
+                nullable: true);
+
+            migrationBuilder.AddColumn<bool>(
+                name: "is_deafened_before",
+                table: "member_events",
+                type: "boolean",
+                nullable: true);
+
+            migrationBuilder.AddColumn<bool>(
+                name: "is_muted_after",
+                table: "member_events",
+                type: "boolean",
+                nullable: true);
+
+            migrationBuilder.AddColumn<bool>(
+                name: "is_muted_before",
+                table: "member_events",
+                type: "boolean",
+                nullable: true);
+
+            migrationBuilder.AddColumn<bool>(
+                name: "is_pending_after",
+                table: "member_events",
+                type: "boolean",
+                nullable: true);
+
+            migrationBuilder.AddColumn<bool>(
+                name: "is_pending_before",
+                table: "member_events",
+                type: "boolean",
+                nullable: true);
+
+            migrationBuilder.AddColumn<DateTime>(
+                name: "premium_since_after",
+                table: "member_events",
+                type: "timestamp with time zone",
+                nullable: true);
+
+            migrationBuilder.AddColumn<DateTime>(
+                name: "premium_since_before",
+                table: "member_events",
+                type: "timestamp with time zone",
+                nullable: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "guild_avatar_hash_after",
+                table: "member_events");
+
+            migrationBuilder.DropColumn(
+                name: "guild_avatar_hash_before",
+                table: "member_events");
+
+            migrationBuilder.DropColumn(
+                name: "is_deafened_after",
+                table: "member_events");
+
+            migrationBuilder.DropColumn(
+                name: "is_deafened_before",
+                table: "member_events");
+
+            migrationBuilder.DropColumn(
+                name: "is_muted_after",
+                table: "member_events");
+
+            migrationBuilder.DropColumn(
+                name: "is_muted_before",
+                table: "member_events");
+
+            migrationBuilder.DropColumn(
+                name: "is_pending_after",
+                table: "member_events");
+
+            migrationBuilder.DropColumn(
+                name: "is_pending_before",
+                table: "member_events");
+
+            migrationBuilder.DropColumn(
+                name: "premium_since_after",
+                table: "member_events");
+
+            migrationBuilder.DropColumn(
+                name: "premium_since_before",
+                table: "member_events");
+        }
+    }
+}

--- a/src/DiscordEventService/Services/EventHandlers/MemberEventHandler.cs
+++ b/src/DiscordEventService/Services/EventHandlers/MemberEventHandler.cs
@@ -124,17 +124,24 @@ public class MemberEventHandler(IServiceScopeFactory scopeFactory, ILogger<Membe
             var pendingChanged = e.PendingBefore != e.PendingAfter;
             var timeoutChanged = e.CommunicationDisabledUntilBefore != e.CommunicationDisabledUntilAfter;
 
-            var premiumBefore = e.MemberBefore?.PremiumSince;
+            // Member-object deltas are only meaningful when MemberBefore is cached.
+            // Without it we can't distinguish "field changed" from "field newly known",
+            // so treat unknown-before as unchanged to avoid spurious filter triggers.
+            // (DSharpPlus annotates MemberBefore as non-nullable, but defensively check.)
+            var memberBefore = e.MemberBefore;
+            var hasBefore = memberBefore is not null;
+
+            var premiumBefore = memberBefore?.PremiumSince;
             var premiumAfter = e.Member.PremiumSince;
-            var premiumChanged = premiumBefore != premiumAfter;
+            var premiumChanged = hasBefore && premiumBefore != premiumAfter;
 
-            bool? mutedBefore = e.MemberBefore?.IsMuted;
+            bool? mutedBefore = memberBefore?.IsMuted;
             bool mutedAfter = e.Member.IsMuted;
-            var mutedChanged = mutedBefore != mutedAfter;
+            var mutedChanged = mutedBefore.HasValue && mutedBefore.Value != mutedAfter;
 
-            bool? deafenedBefore = e.MemberBefore?.IsDeafened;
+            bool? deafenedBefore = memberBefore?.IsDeafened;
             bool deafenedAfter = e.Member.IsDeafened;
-            var deafenedChanged = deafenedBefore != deafenedAfter;
+            var deafenedChanged = deafenedBefore.HasValue && deafenedBefore.Value != deafenedAfter;
 
             if (nicknameChanged || rolesAdded.Any() || rolesRemoved.Any() || timeoutChanged
                 || avatarHashChanged || pendingChanged || premiumChanged || mutedChanged || deafenedChanged)

--- a/src/DiscordEventService/Services/EventHandlers/MemberEventHandler.cs
+++ b/src/DiscordEventService/Services/EventHandlers/MemberEventHandler.cs
@@ -119,28 +119,50 @@ public class MemberEventHandler(IServiceScopeFactory scopeFactory, ILogger<Membe
             var rolesAdded = newRoleIds.Except(oldRoleIds).ToList();
             var rolesRemoved = oldRoleIds.Except(newRoleIds).ToList();
 
-            var nicknameBefore = e.NicknameBefore;
-            var nicknameAfter = e.NicknameAfter;
-            var nicknameChanged = nicknameBefore != nicknameAfter;
+            var nicknameChanged = e.NicknameBefore != e.NicknameAfter;
+            var avatarHashChanged = e.GuildAvatarHashBefore != e.GuildAvatarHashAfter;
+            var pendingChanged = e.PendingBefore != e.PendingAfter;
+            var timeoutChanged = e.CommunicationDisabledUntilBefore != e.CommunicationDisabledUntilAfter;
 
-            var timeoutChanged = e.PendingBefore != e.PendingAfter || e.Member.CommunicationDisabledUntil != null;
+            var premiumBefore = e.MemberBefore?.PremiumSince;
+            var premiumAfter = e.Member.PremiumSince;
+            var premiumChanged = premiumBefore != premiumAfter;
 
-            if (nicknameChanged || rolesAdded.Any() || rolesRemoved.Any() || timeoutChanged)
+            bool? mutedBefore = e.MemberBefore?.IsMuted;
+            bool mutedAfter = e.Member.IsMuted;
+            var mutedChanged = mutedBefore != mutedAfter;
+
+            bool? deafenedBefore = e.MemberBefore?.IsDeafened;
+            bool deafenedAfter = e.Member.IsDeafened;
+            var deafenedChanged = deafenedBefore != deafenedAfter;
+
+            if (nicknameChanged || rolesAdded.Any() || rolesRemoved.Any() || timeoutChanged
+                || avatarHashChanged || pendingChanged || premiumChanged || mutedChanged || deafenedChanged)
             {
                 var memberEvent = new MemberEventEntity
                 {
                     UserDiscordId = e.Member.Id,
                     GuildDiscordId = e.Guild.Id,
                     EventType = MemberEventType.Updated,
-                    NicknameBefore = nicknameBefore,
-                    NicknameAfter = nicknameAfter,
+                    NicknameBefore = e.NicknameBefore,
+                    NicknameAfter = e.NicknameAfter,
                     RolesAddedJson = rolesAdded.Any()
                         ? JsonSerializer.Serialize(rolesAdded)
                         : null,
                     RolesRemovedJson = rolesRemoved.Any()
                         ? JsonSerializer.Serialize(rolesRemoved)
                         : null,
-                    TimeoutUntilUtc = e.Member.CommunicationDisabledUntil?.UtcDateTime,
+                    TimeoutUntilUtc = e.CommunicationDisabledUntilAfter?.UtcDateTime,
+                    PremiumSinceBefore = premiumBefore?.UtcDateTime,
+                    PremiumSinceAfter = premiumAfter?.UtcDateTime,
+                    GuildAvatarHashBefore = e.GuildAvatarHashBefore,
+                    GuildAvatarHashAfter = e.GuildAvatarHashAfter,
+                    IsPendingBefore = e.PendingBefore,
+                    IsPendingAfter = e.PendingAfter,
+                    IsMutedBefore = mutedBefore,
+                    IsMutedAfter = mutedAfter,
+                    IsDeafenedBefore = deafenedBefore,
+                    IsDeafenedAfter = deafenedAfter,
                     EventTimestampUtc = receivedAt,
                     ReceivedAtUtc = receivedAt,
                     RawEventJson = rawJson


### PR DESCRIPTION
## Summary

Widens \`MemberEventHandler\` \`GuildMemberUpdated\` capture per OD#3(a) of the Phase 1 batch 2 plan.

**Schema changes (member_events):** 10 new nullable columns
- \`premium_since_{before,after}\` (timestamptz) — server-boost start
- \`guild_avatar_hash_{before,after}\` (text)
- \`is_pending_{before,after}\` (bool) — membership-screening completion
- \`is_muted_{before,after}\` (bool) — server-side voice mute
- \`is_deafened_{before,after}\` (bool) — server-side voice deafen

**Handler changes (\`MemberEventHandler.cs\`):** widened filter to also fire on premium/avatar/pending/mute/deafen deltas. Captures all 10 new fields on the resulting \`MemberEventEntity\`.

**Bug fix:** pre-existing line 126 conflated \`pendingChanged || currently-timed-out\` under a misleading \`timeoutChanged\` name. The \`!= null\` half was always true for any active timeout (not just the transition). Split into:
- \`pendingChanged = e.PendingBefore != e.PendingAfter\`
- \`timeoutChanged = e.CommunicationDisabledUntilBefore != e.CommunicationDisabledUntilAfter\` (proper delta)

**DSharpPlus 5 surface verified** against \`5.0.0-nightly-02485\`:
- Event-args fields used directly: \`GuildAvatarHashBefore/After\`, \`PendingBefore/After\`, \`CommunicationDisabledUntilBefore/After\`.
- Member-object fields read via \`MemberBefore?.X\` vs \`Member.X\`: \`PremiumSince\`, \`IsMuted\`, \`IsDeafened\`. \`MemberBefore\` may be null when DSharpPlus has no prior cached state, so before-values are nullable.

Closes #63.

## Test plan

- [x] \`dotnet build\` green (only the 4 pre-existing AutoModRule warnings)
- [x] \`dotnet ef migrations add\` produces clean migration: 10 \`AddColumn\` statements only, no unrelated drift
- [ ] Post-deploy: \`\\d member_events\` shows the 10 new columns
- [ ] Post-deploy weekly probe (per the plan):
  \`\`\`sql
  SELECT count(*) FROM raw_event_logs r
  WHERE r.event_type='GuildMemberUpdated'
    AND r.received_at_utc > now() - interval '7 days'
    AND NOT EXISTS (
      SELECT 1 FROM member_events m
      WHERE m.user_discord_id = r.user_discord_id
        AND m.received_at_utc BETWEEN r.received_at_utc - interval '5 sec'
                                   AND r.received_at_utc + interval '5 sec'
    );
  \`\`\`
  Expected: 0 (after #68 replays the 9 existing orphans).

🤖 Generated with [Claude Code](https://claude.com/claude-code)