### PR TITLE
feat: wire downtime tracking + heartbeat (#65)

### DIFF
--- a/src/DiscordEventService/Data/DiscordDbContext.cs
+++ b/src/DiscordEventService/Data/DiscordDbContext.cs
@@ -77,6 +77,9 @@ public class DiscordDbContext(DbContextOptions<DiscordDbContext> options) : DbCo
     // Bot downtime intervals
     public DbSet<BotDowntimeIntervalEntity> BotDowntimeIntervals => Set<BotDowntimeIntervalEntity>();
 
+    // Bot heartbeats (single-row liveness signal for power-loss detection)
+    public DbSet<BotHeartbeatEntity> BotHeartbeats => Set<BotHeartbeatEntity>();
+
     protected override void OnModelCreating(ModelBuilder modelBuilder)
     {
         base.OnModelCreating(modelBuilder);

--- a/src/DiscordEventService/Data/Entities/Core/BotHeartbeatEntity.cs
+++ b/src/DiscordEventService/Data/Entities/Core/BotHeartbeatEntity.cs
@@ -1,0 +1,9 @@
+namespace DiscordEventService.Data.Entities.Core;
+
+public class BotHeartbeatEntity : ITimestamped
+{
+    public Guid Id { get; set; }
+    public DateTime LastHeartbeatUtc { get; set; }
+    public DateTime FirstSeenUtc { get; set; }
+    public DateTime LastUpdatedUtc { get; set; }
+}

--- a/src/DiscordEventService/Data/Migrations/20260512192201_AddBotHeartbeats.Designer.cs
+++ b/src/DiscordEventService/Data/Migrations/20260512192201_AddBotHeartbeats.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using DiscordEventService.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -11,9 +12,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace DiscordEventService.Data.Migrations
 {
     [DbContext(typeof(DiscordDbContext))]
-    partial class DiscordDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260512192201_AddBotHeartbeats")]
+    partial class AddBotHeartbeats
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/DiscordEventService/Data/Migrations/20260512192201_AddBotHeartbeats.cs
+++ b/src/DiscordEventService/Data/Migrations/20260512192201_AddBotHeartbeats.cs
@@ -1,0 +1,36 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace DiscordEventService.Data.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddBotHeartbeats : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "bot_heartbeats",
+                columns: table => new
+                {
+                    id = table.Column<Guid>(type: "uuid", nullable: false, defaultValueSql: "uuidv7()"),
+                    last_heartbeat_utc = table.Column<DateTime>(type: "timestamp with time zone", nullable: false),
+                    first_seen_utc = table.Column<DateTime>(type: "timestamp with time zone", nullable: false),
+                    last_updated_utc = table.Column<DateTime>(type: "timestamp with time zone", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("pk_bot_heartbeats", x => x.id);
+                });
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "bot_heartbeats");
+        }
+    }
+}

--- a/src/DiscordEventService/Endpoints/OpsEndpoints.cs
+++ b/src/DiscordEventService/Endpoints/OpsEndpoints.cs
@@ -25,12 +25,17 @@ public static class OpsEndpoints
             return Results.BadRequest(new { error = $"Unknown downtime type: {(int)type}" });
         }
 
-        var id = await tracker.OpenDowntimeAsync(
+        var result = await tracker.OpenDowntimeAsync(
             type,
             BotDowntimeDetectionMethod.Manual,
             reason);
 
-        return Results.Ok(new DowntimeStartResponse { Id = id, Type = type.ToString() });
+        return Results.Ok(new DowntimeStartResponse
+        {
+            Id = result.Id,
+            Type = result.ActualType.ToString(),
+            Created = result.Created
+        });
     }
 }
 
@@ -38,4 +43,5 @@ public record DowntimeStartResponse
 {
     public required Guid Id { get; init; }
     public required string Type { get; init; }
+    public required bool Created { get; init; }
 }

--- a/src/DiscordEventService/Endpoints/OpsEndpoints.cs
+++ b/src/DiscordEventService/Endpoints/OpsEndpoints.cs
@@ -1,0 +1,41 @@
+using DiscordEventService.Data.Entities.Core;
+using DiscordEventService.Services;
+
+namespace DiscordEventService.Endpoints;
+
+public static class OpsEndpoints
+{
+    public static void MapOpsEndpoints(this WebApplication app)
+    {
+        var group = app.MapGroup("/api/ops");
+
+        group.MapPost("/downtime/start", StartDowntime)
+            .WithName("StartDowntime")
+            .Produces<DowntimeStartResponse>(StatusCodes.Status200OK)
+            .Produces(StatusCodes.Status400BadRequest);
+    }
+
+    private static async Task<IResult> StartDowntime(
+        BotDowntimeType type,
+        string? reason,
+        DowntimeTrackerService tracker)
+    {
+        if (!Enum.IsDefined(type))
+        {
+            return Results.BadRequest(new { error = $"Unknown downtime type: {(int)type}" });
+        }
+
+        var id = await tracker.OpenDowntimeAsync(
+            type,
+            BotDowntimeDetectionMethod.Manual,
+            reason);
+
+        return Results.Ok(new DowntimeStartResponse { Id = id, Type = type.ToString() });
+    }
+}
+
+public record DowntimeStartResponse
+{
+    public required Guid Id { get; init; }
+    public required string Type { get; init; }
+}

--- a/src/DiscordEventService/Program.cs
+++ b/src/DiscordEventService/Program.cs
@@ -67,6 +67,7 @@ builder.Services.AddSingleton(sp =>
         services.AddScoped<UserService>();
         services.AddScoped<RawEventLogService>();
         services.AddScoped<FailedEventService>();
+        services.AddScoped<DowntimeTrackerService>();
         services.AddMemoryCache();
     });
 
@@ -108,6 +109,8 @@ builder.Services.AddSingleton(sp =>
         .AddEventHandlers<IntegrationEventHandler>(ServiceLifetime.Scoped)
         // Audit Log
         .AddEventHandlers<AuditLogEventHandler>(ServiceLifetime.Scoped)
+        // Socket lifecycle (downtime tracking)
+        .AddEventHandlers<SocketLifecycleHandler>(ServiceLifetime.Scoped)
     );
 
     return clientBuilder.Build();
@@ -115,6 +118,7 @@ builder.Services.AddSingleton(sp =>
 
 // Hosted Service
 builder.Services.AddHostedService<DiscordHostedService>();
+builder.Services.AddHostedService<HeartbeatBackgroundService>();
 
 // Memory cache for throttling
 builder.Services.AddMemoryCache();
@@ -123,6 +127,7 @@ builder.Services.AddMemoryCache();
 builder.Services.AddScoped<UserService>();
 builder.Services.AddScoped<RawEventLogService>();
 builder.Services.AddScoped<FailedEventService>();
+builder.Services.AddScoped<DowntimeTrackerService>();
 
 // Health checks
 builder.Services.AddHealthChecks()
@@ -170,5 +175,8 @@ app.MapHangfireDashboard("/hangfire");
 
 // Backfill API
 app.MapBackfillEndpoints();
+
+// Operations API
+app.MapOpsEndpoints();
 
 app.Run();

--- a/src/DiscordEventService/Program.cs
+++ b/src/DiscordEventService/Program.cs
@@ -117,6 +117,9 @@ builder.Services.AddSingleton(sp =>
 });
 
 // Hosted Service
+// Order is load-bearing: DiscordHostedService.StartAsync runs InferStartupGapAsync
+// (against the stale last_heartbeat_utc) before HeartbeatBackgroundService can write
+// a fresh tick that would mask the gap. Do not reorder.
 builder.Services.AddHostedService<DiscordHostedService>();
 builder.Services.AddHostedService<HeartbeatBackgroundService>();
 

--- a/src/DiscordEventService/Services/DiscordHostedService.cs
+++ b/src/DiscordEventService/Services/DiscordHostedService.cs
@@ -1,3 +1,4 @@
+using DiscordEventService.Data.Entities.Core;
 using DSharpPlus;
 using DSharpPlus.Exceptions;
 
@@ -5,6 +6,7 @@ namespace DiscordEventService.Services;
 
 public class DiscordHostedService(
     DiscordClient client,
+    IServiceScopeFactory scopeFactory,
     ILogger<DiscordHostedService> logger) : IHostedService
 {
     public async Task StartAsync(CancellationToken cancellationToken)
@@ -23,10 +25,41 @@ public class DiscordHostedService(
         {
             logger.LogCritical(ex, "Failed to connect to Discord. Service will continue without Discord connection.");
         }
+
+        try
+        {
+            using var scope = scopeFactory.CreateScope();
+            var tracker = scope.ServiceProvider.GetRequiredService<DowntimeTrackerService>();
+            var closed = await tracker.CloseOpenDowntimeAsync(DateTime.UtcNow);
+            if (closed == 0)
+            {
+                await tracker.InferStartupGapAsync();
+            }
+        }
+        catch (Exception ex)
+        {
+            logger.LogError(ex, "Downtime tracker failed during StartAsync");
+        }
     }
 
     public async Task StopAsync(CancellationToken cancellationToken)
     {
+        try
+        {
+            using var scope = scopeFactory.CreateScope();
+            var tracker = scope.ServiceProvider.GetRequiredService<DowntimeTrackerService>();
+            var isDeploy = Environment.GetEnvironmentVariable("DEPLOY_IN_PROGRESS") == "1";
+            var deployVersion = Environment.GetEnvironmentVariable("DEPLOY_VERSION");
+            await tracker.OpenDowntimeAsync(
+                isDeploy ? BotDowntimeType.Deploy : BotDowntimeType.GracefulShutdown,
+                BotDowntimeDetectionMethod.GracefulStop,
+                isDeploy && !string.IsNullOrEmpty(deployVersion) ? $"deploy: {deployVersion}" : null);
+        }
+        catch (Exception ex)
+        {
+            logger.LogError(ex, "Downtime tracker failed during StopAsync");
+        }
+
         logger.LogInformation("Disconnecting from Discord...");
         try
         {

--- a/src/DiscordEventService/Services/DiscordHostedService.cs
+++ b/src/DiscordEventService/Services/DiscordHostedService.cs
@@ -11,21 +11,11 @@ public class DiscordHostedService(
 {
     public async Task StartAsync(CancellationToken cancellationToken)
     {
-        logger.LogInformation("Connecting to Discord...");
-        try
-        {
-            await client.ConnectAsync();
-            logger.LogInformation("Connected to Discord as {Username}", client.CurrentUser?.Username ?? "Unknown");
-        }
-        catch (UnauthorizedException ex)
-        {
-            logger.LogCritical(ex, "Invalid Discord bot token - check Discord:Token configuration. Service will continue without Discord connection.");
-        }
-        catch (Exception ex)
-        {
-            logger.LogCritical(ex, "Failed to connect to Discord. Service will continue without Discord connection.");
-        }
-
+        // Resolve prior-session downtime BEFORE connecting. Once ConnectAsync
+        // returns, DSharpPlus begins dispatching events that accumulated during
+        // the gap; their handlers write raw_event_logs rows with
+        // ReceivedAtUtc = now, which would pollute InferStartupGapAsync's
+        // maxReceivedAt query and silently mask the real gap.
         try
         {
             using var scope = scopeFactory.CreateScope();
@@ -39,6 +29,21 @@ public class DiscordHostedService(
         catch (Exception ex)
         {
             logger.LogError(ex, "Downtime tracker failed during StartAsync");
+        }
+
+        logger.LogInformation("Connecting to Discord...");
+        try
+        {
+            await client.ConnectAsync();
+            logger.LogInformation("Connected to Discord as {Username}", client.CurrentUser?.Username ?? "Unknown");
+        }
+        catch (UnauthorizedException ex)
+        {
+            logger.LogCritical(ex, "Invalid Discord bot token - check Discord:Token configuration. Service will continue without Discord connection.");
+        }
+        catch (Exception ex)
+        {
+            logger.LogCritical(ex, "Failed to connect to Discord. Service will continue without Discord connection.");
         }
     }
 

--- a/src/DiscordEventService/Services/DowntimeTrackerService.cs
+++ b/src/DiscordEventService/Services/DowntimeTrackerService.cs
@@ -90,6 +90,7 @@ public class DowntimeTrackerService(DiscordDbContext db, ILogger<DowntimeTracker
         // Heartbeat is the primary signal: it ticks regardless of Discord activity,
         // so it survives quiet periods that would leave raw_event_logs stale.
         var lastHeartbeat = await db.BotHeartbeats
+            .OrderByDescending(h => h.LastHeartbeatUtc)
             .Select(h => (DateTime?)h.LastHeartbeatUtc)
             .FirstOrDefaultAsync();
 

--- a/src/DiscordEventService/Services/DowntimeTrackerService.cs
+++ b/src/DiscordEventService/Services/DowntimeTrackerService.cs
@@ -1,0 +1,137 @@
+using DiscordEventService.Data;
+using DiscordEventService.Data.Entities.Core;
+using Microsoft.EntityFrameworkCore;
+
+namespace DiscordEventService.Services;
+
+public class DowntimeTrackerService(DiscordDbContext db, ILogger<DowntimeTrackerService> logger)
+{
+    private static readonly TimeSpan StartupGapThreshold = TimeSpan.FromSeconds(30);
+
+    public async Task<Guid> OpenDowntimeAsync(
+        BotDowntimeType type,
+        BotDowntimeDetectionMethod method,
+        string? notes,
+        DateTime? lastEventBeforeUtc = null)
+    {
+        var existingOpen = await db.BotDowntimeIntervals
+            .Where(x => x.EndedAtUtc == null)
+            .OrderByDescending(x => x.StartedAtUtc)
+            .FirstOrDefaultAsync();
+
+        if (existingOpen is not null)
+        {
+            logger.LogWarning(
+                "OpenDowntimeAsync({Type}/{Method}) skipped: open row Id={Id} Type={ExistingType} already exists",
+                type, method, existingOpen.Id, existingOpen.Type);
+            return existingOpen.Id;
+        }
+
+        var row = new BotDowntimeIntervalEntity
+        {
+            StartedAtUtc = DateTime.UtcNow,
+            EndedAtUtc = null,
+            Type = type,
+            DetectionMethod = method,
+            LastEventBeforeUtc = lastEventBeforeUtc,
+            Notes = notes
+        };
+        db.BotDowntimeIntervals.Add(row);
+        await db.SaveChangesAsync();
+        logger.LogInformation(
+            "Opened downtime row Id={Id} Type={Type} Method={Method}",
+            row.Id, type, method);
+        return row.Id;
+    }
+
+    public async Task<int> CloseOpenDowntimeAsync(DateTime endedAtUtc)
+    {
+        // FirstEventAfterUtc intentionally left null here; it represents the timestamp
+        // of the first real Discord event seen after recovery, not the moment we
+        // observed startup. Populate it later if/when we wire that signal.
+        // ExecuteUpdateAsync bypasses the SaveChangesAsync ITimestamped hook, so
+        // LastUpdatedUtc must be set explicitly.
+        var affected = await db.BotDowntimeIntervals
+            .Where(x => x.EndedAtUtc == null)
+            .ExecuteUpdateAsync(s => s
+                .SetProperty(x => x.EndedAtUtc, endedAtUtc)
+                .SetProperty(x => x.LastUpdatedUtc, endedAtUtc));
+
+        if (affected > 1)
+        {
+            logger.LogWarning("Closed {Count} open downtime rows (expected at most 1)", affected);
+        }
+        else if (affected == 1)
+        {
+            logger.LogInformation("Closed open downtime row at {EndedAt:O}", endedAtUtc);
+        }
+        return affected;
+    }
+
+    public async Task RecordHeartbeatAsync(DateTime nowUtc)
+    {
+        // ExecuteUpdateAsync bypasses the SaveChangesAsync ITimestamped hook.
+        var updated = await db.BotHeartbeats
+            .ExecuteUpdateAsync(s => s
+                .SetProperty(h => h.LastHeartbeatUtc, nowUtc)
+                .SetProperty(h => h.LastUpdatedUtc, nowUtc));
+
+        if (updated == 0)
+        {
+            db.BotHeartbeats.Add(new BotHeartbeatEntity { LastHeartbeatUtc = nowUtc });
+            await db.SaveChangesAsync();
+        }
+    }
+
+    public async Task<Guid?> InferStartupGapAsync()
+    {
+        var now = DateTime.UtcNow;
+
+        // Heartbeat is the primary signal: it ticks regardless of Discord activity,
+        // so it survives quiet periods that would leave raw_event_logs stale.
+        var lastHeartbeat = await db.BotHeartbeats
+            .Select(h => (DateTime?)h.LastHeartbeatUtc)
+            .FirstOrDefaultAsync();
+
+        var maxReceivedAt = await db.RawEventLogs
+            .OrderByDescending(r => r.ReceivedAtUtc)
+            .Select(r => (DateTime?)r.ReceivedAtUtc)
+            .FirstOrDefaultAsync();
+
+        var lastAlive = MaxNullable(lastHeartbeat, maxReceivedAt);
+        if (lastAlive is null)
+        {
+            return null;
+        }
+
+        var gap = now - lastAlive.Value;
+        if (gap < StartupGapThreshold)
+        {
+            return null;
+        }
+
+        var row = new BotDowntimeIntervalEntity
+        {
+            StartedAtUtc = lastAlive.Value,
+            EndedAtUtc = now,
+            Type = BotDowntimeType.Inferred,
+            DetectionMethod = BotDowntimeDetectionMethod.StartupGapInference,
+            LastEventBeforeUtc = lastAlive.Value,
+            FirstEventAfterUtc = now,
+            Notes = $"Startup gap inference: {gap.TotalSeconds:F0}s (heartbeat={lastHeartbeat:O}, event={maxReceivedAt:O})"
+        };
+        db.BotDowntimeIntervals.Add(row);
+        await db.SaveChangesAsync();
+        logger.LogInformation(
+            "Inferred startup gap of {Gap:F0}s, row Id={Id}",
+            gap.TotalSeconds, row.Id);
+        return row.Id;
+    }
+
+    private static DateTime? MaxNullable(DateTime? a, DateTime? b)
+    {
+        if (a is null) return b;
+        if (b is null) return a;
+        return a.Value > b.Value ? a : b;
+    }
+}

--- a/src/DiscordEventService/Services/DowntimeTrackerService.cs
+++ b/src/DiscordEventService/Services/DowntimeTrackerService.cs
@@ -8,7 +8,7 @@ public class DowntimeTrackerService(DiscordDbContext db, ILogger<DowntimeTracker
 {
     private static readonly TimeSpan StartupGapThreshold = TimeSpan.FromSeconds(30);
 
-    public async Task<Guid> OpenDowntimeAsync(
+    public async Task<OpenDowntimeResult> OpenDowntimeAsync(
         BotDowntimeType type,
         BotDowntimeDetectionMethod method,
         string? notes,
@@ -24,7 +24,7 @@ public class DowntimeTrackerService(DiscordDbContext db, ILogger<DowntimeTracker
             logger.LogWarning(
                 "OpenDowntimeAsync({Type}/{Method}) skipped: open row Id={Id} Type={ExistingType} already exists",
                 type, method, existingOpen.Id, existingOpen.Type);
-            return existingOpen.Id;
+            return new OpenDowntimeResult(existingOpen.Id, existingOpen.Type, Created: false);
         }
 
         var row = new BotDowntimeIntervalEntity
@@ -41,21 +41,27 @@ public class DowntimeTrackerService(DiscordDbContext db, ILogger<DowntimeTracker
         logger.LogInformation(
             "Opened downtime row Id={Id} Type={Type} Method={Method}",
             row.Id, type, method);
-        return row.Id;
+        return new OpenDowntimeResult(row.Id, type, Created: true);
     }
 
-    public async Task<int> CloseOpenDowntimeAsync(DateTime endedAtUtc)
+    public async Task<int> CloseOpenDowntimeAsync(DateTime endedAtUtc, BotDowntimeType? onlyType = null)
     {
         // FirstEventAfterUtc intentionally left null here; it represents the timestamp
         // of the first real Discord event seen after recovery, not the moment we
         // observed startup. Populate it later if/when we wire that signal.
         // ExecuteUpdateAsync bypasses the SaveChangesAsync ITimestamped hook, so
         // LastUpdatedUtc must be set explicitly.
-        var affected = await db.BotDowntimeIntervals
-            .Where(x => x.EndedAtUtc == null)
-            .ExecuteUpdateAsync(s => s
-                .SetProperty(x => x.EndedAtUtc, endedAtUtc)
-                .SetProperty(x => x.LastUpdatedUtc, endedAtUtc));
+        // onlyType scopes the close so a routine SessionResumed doesn't clobber a
+        // manually-opened Deploy/HostDown row from the ops endpoint.
+        var query = db.BotDowntimeIntervals.Where(x => x.EndedAtUtc == null);
+        if (onlyType.HasValue)
+        {
+            query = query.Where(x => x.Type == onlyType.Value);
+        }
+
+        var affected = await query.ExecuteUpdateAsync(s => s
+            .SetProperty(x => x.EndedAtUtc, endedAtUtc)
+            .SetProperty(x => x.LastUpdatedUtc, endedAtUtc));
 
         if (affected > 1)
         {
@@ -63,7 +69,7 @@ public class DowntimeTrackerService(DiscordDbContext db, ILogger<DowntimeTracker
         }
         else if (affected == 1)
         {
-            logger.LogInformation("Closed open downtime row at {EndedAt:O}", endedAtUtc);
+            logger.LogInformation("Closed open downtime row at {EndedAt:O} (filter={Filter})", endedAtUtc, onlyType?.ToString() ?? "any");
         }
         return affected;
     }
@@ -136,3 +142,6 @@ public class DowntimeTrackerService(DiscordDbContext db, ILogger<DowntimeTracker
         return a.Value > b.Value ? a : b;
     }
 }
+
+public record OpenDowntimeResult(Guid Id, BotDowntimeType ActualType, bool Created);
+

--- a/src/DiscordEventService/Services/EventHandlers/SocketLifecycleHandler.cs
+++ b/src/DiscordEventService/Services/EventHandlers/SocketLifecycleHandler.cs
@@ -33,7 +33,9 @@ public class SocketLifecycleHandler(
         {
             using var scope = scopeFactory.CreateScope();
             var tracker = scope.ServiceProvider.GetRequiredService<DowntimeTrackerService>();
-            await tracker.CloseOpenDowntimeAsync(DateTime.UtcNow);
+            // Scope to GatewayDisconnect so a routine resume doesn't clobber a
+            // manually-opened Deploy/HostDown row from the ops endpoint.
+            await tracker.CloseOpenDowntimeAsync(DateTime.UtcNow, onlyType: BotDowntimeType.GatewayDisconnect);
         }
         catch (Exception ex)
         {

--- a/src/DiscordEventService/Services/EventHandlers/SocketLifecycleHandler.cs
+++ b/src/DiscordEventService/Services/EventHandlers/SocketLifecycleHandler.cs
@@ -1,0 +1,43 @@
+using DiscordEventService.Data.Entities.Core;
+using DSharpPlus;
+using DSharpPlus.EventArgs;
+
+namespace DiscordEventService.Services.EventHandlers;
+
+public class SocketLifecycleHandler(
+    IServiceScopeFactory scopeFactory,
+    ILogger<SocketLifecycleHandler> logger) :
+    IEventHandler<SocketClosedEventArgs>,
+    IEventHandler<SessionResumedEventArgs>
+{
+    public async Task HandleEventAsync(DiscordClient sender, SocketClosedEventArgs e)
+    {
+        try
+        {
+            using var scope = scopeFactory.CreateScope();
+            var tracker = scope.ServiceProvider.GetRequiredService<DowntimeTrackerService>();
+            await tracker.OpenDowntimeAsync(
+                BotDowntimeType.GatewayDisconnect,
+                BotDowntimeDetectionMethod.GatewayEvent,
+                $"socket closed: code={e.CloseCode} message={e.CloseMessage}");
+        }
+        catch (Exception ex)
+        {
+            logger.LogError(ex, "Failed to open downtime row on SocketClosed (code={CloseCode})", e.CloseCode);
+        }
+    }
+
+    public async Task HandleEventAsync(DiscordClient sender, SessionResumedEventArgs e)
+    {
+        try
+        {
+            using var scope = scopeFactory.CreateScope();
+            var tracker = scope.ServiceProvider.GetRequiredService<DowntimeTrackerService>();
+            await tracker.CloseOpenDowntimeAsync(DateTime.UtcNow);
+        }
+        catch (Exception ex)
+        {
+            logger.LogError(ex, "Failed to close downtime row on SessionResumed");
+        }
+    }
+}

--- a/src/DiscordEventService/Services/HeartbeatBackgroundService.cs
+++ b/src/DiscordEventService/Services/HeartbeatBackgroundService.cs
@@ -1,0 +1,38 @@
+namespace DiscordEventService.Services;
+
+public class HeartbeatBackgroundService(
+    IServiceScopeFactory scopeFactory,
+    ILogger<HeartbeatBackgroundService> logger) : BackgroundService
+{
+    private static readonly TimeSpan Interval = TimeSpan.FromSeconds(5);
+
+    protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+    {
+        using var timer = new PeriodicTimer(Interval);
+        while (!stoppingToken.IsCancellationRequested)
+        {
+            try
+            {
+                using var scope = scopeFactory.CreateScope();
+                var tracker = scope.ServiceProvider.GetRequiredService<DowntimeTrackerService>();
+                await tracker.RecordHeartbeatAsync(DateTime.UtcNow);
+            }
+            catch (Exception ex)
+            {
+                logger.LogWarning(ex, "Heartbeat write failed; will retry next tick");
+            }
+
+            try
+            {
+                if (!await timer.WaitForNextTickAsync(stoppingToken))
+                {
+                    break;
+                }
+            }
+            catch (OperationCanceledException)
+            {
+                break;
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Connects `BotDowntimeIntervalEntity` (from #64) to four write paths plus a heartbeat for power-loss detection.

### Write paths

1. **`DiscordHostedService.StartAsync`** — closes any open row (graceful prior shutdown). If none was closed, infers a startup gap from the last alive signal.
2. **`DiscordHostedService.StopAsync`** — opens a `GracefulShutdown` row (or `Deploy` if `DEPLOY_IN_PROGRESS=1` env var is set).
3. **`SocketLifecycleHandler`** — opens a `GatewayDisconnect` row on `SocketClosed`; closes it on `SessionResumed`. `Ready`/cold-reconnect handler is deferred to #67.
4. **`OpsEndpoints`** — `POST /api/ops/downtime/start?type=Deploy&reason=v1.2.3` for manual/deploy-script-driven opens. Rejects out-of-range enum values (e.g. `?type=99`).

### Power-loss detection (extension to original plan)

The plan's `InferStartupGapAsync` relied on `max(received_at_utc) FROM raw_event_logs`. Problem: during quiet periods (e.g. 3 AM with no Discord activity) that timestamp is already stale, so a 30-min power loss in a quiet period wouldn't be cleanly detected.

Fix: a separate single-row `bot_heartbeats` table updated every **5 seconds** by a new `HeartbeatBackgroundService`. On startup, `InferStartupGapAsync` uses `max(last_heartbeat_utc, max(received_at_utc))` as the \"last alive\" signal. Threshold: 30 s.

### Efficiency

Both hot paths (5-s heartbeat write + the close-open-row update) use \`ExecuteUpdateAsync\` to skip EF change-tracking. \`LastUpdatedUtc\` is set explicitly because that bypasses the \`SaveChangesAsync\` \`ITimestamped\` hook.

### Files

\`\`\`
NEW      src/DiscordEventService/Data/Entities/Core/BotHeartbeatEntity.cs
NEW      src/DiscordEventService/Data/Migrations/20260512192201_AddBotHeartbeats.cs
NEW      src/DiscordEventService/Services/DowntimeTrackerService.cs
NEW      src/DiscordEventService/Services/HeartbeatBackgroundService.cs
NEW      src/DiscordEventService/Services/EventHandlers/SocketLifecycleHandler.cs
NEW      src/DiscordEventService/Endpoints/OpsEndpoints.cs
MODIFY   src/DiscordEventService/Services/DiscordHostedService.cs
MODIFY   src/DiscordEventService/Program.cs                     (DI + endpoint mapping)
MODIFY   src/DiscordEventService/Data/DiscordDbContext.cs       (DbSet)
\`\`\`

### Deploy-kill caveat

The homelab deploy workflow doesn't currently set \`DEPLOY_IN_PROGRESS=1\` before stopping the container. Deploys will therefore appear as either \`GracefulShutdown\` (if SIGTERM completes \`StopAsync\` in time — likely, since the new \`StopAsync\` does only one UPDATE before \`DisconnectAsync\`) or \`Inferred\` (if killed). Accepted for now; can be patched later in \`wiktorkowalski/github-workflows\` to either set the env var or \`curl POST /api/ops/downtime/start?type=Deploy\` immediately before container stop.

Closes #65.

## Test plan

- [x] \`dotnet build\` green (only the 4 pre-existing AutoModRule warnings)
- [x] \`dotnet ef migrations add\` produces a clean migration (single \`CreateTable bot_heartbeats\`, no unrelated drift)
- [ ] Post-deploy: \`\\d bot_heartbeats\` shows the table; \`SELECT * FROM bot_heartbeats\` returns one row with a recent \`last_heartbeat_utc\`
- [ ] Post-deploy: shortly after deploy, \`SELECT * FROM bot_downtime_intervals ORDER BY started_at_utc DESC LIMIT 5\` shows one row covering the deploy window (\`GracefulShutdown\` if SIGTERM clean, else \`Inferred\` with detection_method=\`StartupGapInference\`)
- [ ] Post-deploy: \`SELECT count(*) FROM bot_downtime_intervals WHERE ended_at_utc IS NULL\` returns 0 while the bot is running and connected to gateway
- [ ] \`curl -X POST 'http://homelab:8080/api/ops/downtime/start?type=Deploy&reason=test'\` returns 200 + row id; passing \`?type=99\` returns 400

🤖 Generated with [Claude Code](https://claude.com/claude-code)