### PR TITLE
feat: record gateway connection status + latency in heartbeat (#66)

### DIFF
--- a/src/DiscordEventService/Data/DiscordDbContext.cs
+++ b/src/DiscordEventService/Data/DiscordDbContext.cs
@@ -864,6 +864,14 @@ public class DiscordDbContext(DbContextOptions<DiscordDbContext> options) : DbCo
             b.HasIndex(x => x.EndedAtUtc)
                 .HasFilter("ended_at_utc IS NULL");
         });
+
+        // =====================================================
+        // BotHeartbeat configuration
+        // =====================================================
+        // Index on LastHeartbeatUtc — append-only table, "most recent tick"
+        // lookups via OrderByDescending(LastHeartbeatUtc).First() use this.
+        modelBuilder.Entity<BotHeartbeatEntity>()
+            .HasIndex(h => h.LastHeartbeatUtc);
     }
 
     public override Task<int> SaveChangesAsync(CancellationToken cancellationToken = default)

--- a/src/DiscordEventService/Data/Entities/Core/BotHeartbeatEntity.cs
+++ b/src/DiscordEventService/Data/Entities/Core/BotHeartbeatEntity.cs
@@ -4,6 +4,8 @@ public class BotHeartbeatEntity : ITimestamped
 {
     public Guid Id { get; set; }
     public DateTime LastHeartbeatUtc { get; set; }
+    public bool? IsGatewayConnected { get; set; }
+    public int? GatewayLatencyMs { get; set; }
     public DateTime FirstSeenUtc { get; set; }
     public DateTime LastUpdatedUtc { get; set; }
 }

--- a/src/DiscordEventService/Data/Migrations/20260512211534_AddGatewayStatusToHeartbeat.Designer.cs
+++ b/src/DiscordEventService/Data/Migrations/20260512211534_AddGatewayStatusToHeartbeat.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using DiscordEventService.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -11,9 +12,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace DiscordEventService.Data.Migrations
 {
     [DbContext(typeof(DiscordDbContext))]
-    partial class DiscordDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260512211534_AddGatewayStatusToHeartbeat")]
+    partial class AddGatewayStatusToHeartbeat
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/DiscordEventService/Data/Migrations/20260512211534_AddGatewayStatusToHeartbeat.cs
+++ b/src/DiscordEventService/Data/Migrations/20260512211534_AddGatewayStatusToHeartbeat.cs
@@ -1,0 +1,38 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace DiscordEventService.Data.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddGatewayStatusToHeartbeat : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<int>(
+                name: "gateway_latency_ms",
+                table: "bot_heartbeats",
+                type: "integer",
+                nullable: true);
+
+            migrationBuilder.AddColumn<bool>(
+                name: "is_gateway_connected",
+                table: "bot_heartbeats",
+                type: "boolean",
+                nullable: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "gateway_latency_ms",
+                table: "bot_heartbeats");
+
+            migrationBuilder.DropColumn(
+                name: "is_gateway_connected",
+                table: "bot_heartbeats");
+        }
+    }
+}

--- a/src/DiscordEventService/Data/Migrations/20260512212306_AddHeartbeatLastHeartbeatUtcIndex.Designer.cs
+++ b/src/DiscordEventService/Data/Migrations/20260512212306_AddHeartbeatLastHeartbeatUtcIndex.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using DiscordEventService.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -11,9 +12,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace DiscordEventService.Data.Migrations
 {
     [DbContext(typeof(DiscordDbContext))]
-    partial class DiscordDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260512212306_AddHeartbeatLastHeartbeatUtcIndex")]
+    partial class AddHeartbeatLastHeartbeatUtcIndex
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/DiscordEventService/Data/Migrations/20260512212306_AddHeartbeatLastHeartbeatUtcIndex.cs
+++ b/src/DiscordEventService/Data/Migrations/20260512212306_AddHeartbeatLastHeartbeatUtcIndex.cs
@@ -1,0 +1,27 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace DiscordEventService.Data.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddHeartbeatLastHeartbeatUtcIndex : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateIndex(
+                name: "ix_bot_heartbeats_last_heartbeat_utc",
+                table: "bot_heartbeats",
+                column: "last_heartbeat_utc");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropIndex(
+                name: "ix_bot_heartbeats_last_heartbeat_utc",
+                table: "bot_heartbeats");
+        }
+    }
+}

--- a/src/DiscordEventService/Services/DowntimeTrackerService.cs
+++ b/src/DiscordEventService/Services/DowntimeTrackerService.cs
@@ -79,24 +79,16 @@ public class DowntimeTrackerService(DiscordDbContext db, ILogger<DowntimeTracker
         bool? isGatewayConnected = null,
         int? gatewayLatencyMs = null)
     {
-        // ExecuteUpdateAsync bypasses the SaveChangesAsync ITimestamped hook.
-        var updated = await db.BotHeartbeats
-            .ExecuteUpdateAsync(s => s
-                .SetProperty(h => h.LastHeartbeatUtc, nowUtc)
-                .SetProperty(h => h.IsGatewayConnected, isGatewayConnected)
-                .SetProperty(h => h.GatewayLatencyMs, gatewayLatencyMs)
-                .SetProperty(h => h.LastUpdatedUtc, nowUtc));
-
-        if (updated == 0)
+        // Append-only: every tick is a row. "Most recent" lookups use the
+        // index on LastHeartbeatUtc. Retaining all ticks keeps a permanent
+        // uptime + gateway-state history (~6M rows/year at 5s ticks).
+        db.BotHeartbeats.Add(new BotHeartbeatEntity
         {
-            db.BotHeartbeats.Add(new BotHeartbeatEntity
-            {
-                LastHeartbeatUtc = nowUtc,
-                IsGatewayConnected = isGatewayConnected,
-                GatewayLatencyMs = gatewayLatencyMs
-            });
-            await db.SaveChangesAsync();
-        }
+            LastHeartbeatUtc = nowUtc,
+            IsGatewayConnected = isGatewayConnected,
+            GatewayLatencyMs = gatewayLatencyMs
+        });
+        await db.SaveChangesAsync();
     }
 
     public async Task<Guid?> InferStartupGapAsync()

--- a/src/DiscordEventService/Services/DowntimeTrackerService.cs
+++ b/src/DiscordEventService/Services/DowntimeTrackerService.cs
@@ -74,17 +74,27 @@ public class DowntimeTrackerService(DiscordDbContext db, ILogger<DowntimeTracker
         return affected;
     }
 
-    public async Task RecordHeartbeatAsync(DateTime nowUtc)
+    public async Task RecordHeartbeatAsync(
+        DateTime nowUtc,
+        bool? isGatewayConnected = null,
+        int? gatewayLatencyMs = null)
     {
         // ExecuteUpdateAsync bypasses the SaveChangesAsync ITimestamped hook.
         var updated = await db.BotHeartbeats
             .ExecuteUpdateAsync(s => s
                 .SetProperty(h => h.LastHeartbeatUtc, nowUtc)
+                .SetProperty(h => h.IsGatewayConnected, isGatewayConnected)
+                .SetProperty(h => h.GatewayLatencyMs, gatewayLatencyMs)
                 .SetProperty(h => h.LastUpdatedUtc, nowUtc));
 
         if (updated == 0)
         {
-            db.BotHeartbeats.Add(new BotHeartbeatEntity { LastHeartbeatUtc = nowUtc });
+            db.BotHeartbeats.Add(new BotHeartbeatEntity
+            {
+                LastHeartbeatUtc = nowUtc,
+                IsGatewayConnected = isGatewayConnected,
+                GatewayLatencyMs = gatewayLatencyMs
+            });
             await db.SaveChangesAsync();
         }
     }

--- a/src/DiscordEventService/Services/HeartbeatBackgroundService.cs
+++ b/src/DiscordEventService/Services/HeartbeatBackgroundService.cs
@@ -9,6 +9,12 @@ public class HeartbeatBackgroundService(
 {
     private static readonly TimeSpan Interval = TimeSpan.FromSeconds(5);
 
+    // Only emit a Debug log on the first occurrence of each consecutive
+    // failure streak — avoids per-tick log spam when DSharpPlus has been
+    // disconnected for an extended period.
+    private bool _connectedLookupFailed;
+    private bool _latencyLookupFailed;
+
     protected override async Task ExecuteAsync(CancellationToken stoppingToken)
     {
         using var timer = new PeriodicTimer(Interval);
@@ -51,10 +57,15 @@ public class HeartbeatBackgroundService(
         try
         {
             isConnected = discordClient.AllShardsConnected;
+            _connectedLookupFailed = false;
         }
         catch (Exception ex)
         {
-            logger.LogDebug(ex, "AllShardsConnected lookup failed");
+            if (!_connectedLookupFailed)
+            {
+                logger.LogDebug(ex, "AllShardsConnected lookup failed (further failures suppressed until recovery)");
+                _connectedLookupFailed = true;
+            }
         }
 
         try
@@ -63,11 +74,16 @@ public class HeartbeatBackgroundService(
             if (firstGuildId != 0)
             {
                 latencyMs = (int)discordClient.GetConnectionLatency(firstGuildId).TotalMilliseconds;
+                _latencyLookupFailed = false;
             }
         }
         catch (Exception ex)
         {
-            logger.LogDebug(ex, "GetConnectionLatency lookup failed");
+            if (!_latencyLookupFailed)
+            {
+                logger.LogDebug(ex, "GetConnectionLatency lookup failed (further failures suppressed until recovery)");
+                _latencyLookupFailed = true;
+            }
         }
 
         return (isConnected, latencyMs);

--- a/src/DiscordEventService/Services/HeartbeatBackgroundService.cs
+++ b/src/DiscordEventService/Services/HeartbeatBackgroundService.cs
@@ -1,7 +1,10 @@
+using DSharpPlus;
+
 namespace DiscordEventService.Services;
 
 public class HeartbeatBackgroundService(
     IServiceScopeFactory scopeFactory,
+    DiscordClient discordClient,
     ILogger<HeartbeatBackgroundService> logger) : BackgroundService
 {
     private static readonly TimeSpan Interval = TimeSpan.FromSeconds(5);
@@ -13,9 +16,10 @@ public class HeartbeatBackgroundService(
         {
             try
             {
+                var (isConnected, latencyMs) = ReadGatewayState();
                 using var scope = scopeFactory.CreateScope();
                 var tracker = scope.ServiceProvider.GetRequiredService<DowntimeTrackerService>();
-                await tracker.RecordHeartbeatAsync(DateTime.UtcNow);
+                await tracker.RecordHeartbeatAsync(DateTime.UtcNow, isConnected, latencyMs);
             }
             catch (Exception ex)
             {
@@ -34,5 +38,38 @@ public class HeartbeatBackgroundService(
                 break;
             }
         }
+    }
+
+    private (bool? IsConnected, int? LatencyMs) ReadGatewayState()
+    {
+        // DiscordClient.AllShardsConnected is the direct gateway-up signal; the
+        // per-guild latency is informational. Both are wrapped in try/catch
+        // because DSharpPlus can briefly throw during reconnect handshakes.
+        bool? isConnected = null;
+        int? latencyMs = null;
+
+        try
+        {
+            isConnected = discordClient.AllShardsConnected;
+        }
+        catch (Exception ex)
+        {
+            logger.LogDebug(ex, "AllShardsConnected lookup failed");
+        }
+
+        try
+        {
+            var firstGuildId = discordClient.Guilds.Keys.FirstOrDefault();
+            if (firstGuildId != 0)
+            {
+                latencyMs = (int)discordClient.GetConnectionLatency(firstGuildId).TotalMilliseconds;
+            }
+        }
+        catch (Exception ex)
+        {
+            logger.LogDebug(ex, "GetConnectionLatency lookup failed");
+        }
+
+        return (isConnected, latencyMs);
     }
 }


### PR DESCRIPTION
## Summary

Append-only heartbeat log with Discord gateway state. Each 5 s tick is its own row, retaining full uptime + connection history.

Rescoped from the original \"infer historical downtime from \`raw_event_logs\` gaps\" plan: quiet hours on a small server (overnight, no chat) are indistinguishable from real downtime when only counting events. Direct gateway-state signal is trustworthy; inference isn't.

### Schema

Two new nullable columns on \`bot_heartbeats\`:

| Column | Type | Source |
|---|---|---|
| \`is_gateway_connected\` | \`bool?\` | \`DiscordClient.AllShardsConnected\` |
| \`gateway_latency_ms\` | \`int?\` | \`DiscordClient.GetConnectionLatency(firstGuildId).TotalMilliseconds\` |

Plus a btree index on \`last_heartbeat_utc\` for fast \"most recent tick\" lookups via \`OrderByDescending(LastHeartbeatUtc).First()\`.

### Behavior change: append-only

\`bot_heartbeats\` was single-row in #65 (UPSERT every 5s). This PR pivots to **append-only** — every tick is its own row. Volume:

- 5 s ticks → 17,280 rows/day → ~6.3M rows/year → ~300 MB/year
- Comfortable for Postgres; the index keeps current-state lookups O(log n)
- Pruning policy can be a future concern; not adding one upfront

The single row already deployed from #65 stays in place as the first row. Subsequent ticks just start appending. All readers (\`GetLastAliveAtUtcAsync\`, \`InferStartupGapAsync\`) already order by \`LastHeartbeatUtc DESC\` so they pick the freshest tick automatically.

### Code

- \`HeartbeatBackgroundService\` injects \`DiscordClient\` (singleton in the root DI container) and reads \`AllShardsConnected\` + \`GetConnectionLatency\` every 5 s tick. Each lookup is wrapped in try/catch (DSharpPlus can briefly throw during reconnect handshakes); the Debug log is debounced per failure streak so a permanently-disconnected gateway doesn't spam logs.
- \`DowntimeTrackerService.RecordHeartbeatAsync\` simplified: drop the UPSERT, always \`Add\` a new row, single \`SaveChangesAsync\`.

### Why not the original #66 plan?

The original plan was to detect zero-event hour buckets in \`raw_event_logs\` and write \`bot_downtime_intervals\` rows of \`type=Inferred\` for each. For a small server, every quiet overnight stretch would be misclassified as downtime. The 115 h historical baseline gap can't be retroactively classified from event volume alone — we'd be guessing.

The new approach gives a trustworthy direct signal going forward. Combined with the existing \`GatewayDisconnect\` rows from \`SocketLifecycleHandler\` (transitions, from #65), and now per-tick connection state, full gateway-connectivity observability is in place without inference. The historical 115 h gap is intentionally left unmarked — a one-off manual SQL insert based on known incident timing is the correct way to fill it.

### Files

\`\`\`
MODIFY  src/DiscordEventService/Data/Entities/Core/BotHeartbeatEntity.cs               (+2 nullable cols)
NEW     src/DiscordEventService/Data/Migrations/20260512211534_AddGatewayStatusToHeartbeat.cs
NEW     src/DiscordEventService/Data/Migrations/20260512212306_AddHeartbeatLastHeartbeatUtcIndex.cs
MODIFY  src/DiscordEventService/Data/DiscordDbContext.cs                                (new index config)
MODIFY  src/DiscordEventService/Services/DowntimeTrackerService.cs                      (append-only RecordHeartbeatAsync)
MODIFY  src/DiscordEventService/Services/HeartbeatBackgroundService.cs                  (inject DiscordClient + read state + debounce)
\`\`\`

Closes #66.

## Test plan

- [x] \`dotnet build\` green (only the 4 pre-existing AutoModRule warnings)
- [x] Both EF migrations are clean (2 AddColumn + 1 CreateIndex, no drift)
- [ ] Post-deploy: \`SELECT count(*) FROM bot_heartbeats\` grows by ~12/min. The newest row (\`ORDER BY last_heartbeat_utc DESC LIMIT 1\`) has \`is_gateway_connected = true\` and a populated \`gateway_latency_ms\`.
- [ ] Post-deploy: temporarily block outbound traffic to \`gateway.discord.gg\` → newest \`bot_heartbeats\` row flips \`is_gateway_connected\` to \`false\` within ~5 s; flips back on reconnect. \`bot_downtime_intervals\` shows the corresponding \`GatewayDisconnect\` row from \`SocketLifecycleHandler\`.
- [ ] Post-deploy: \`SELECT date_trunc('minute', last_heartbeat_utc) AS m, count(*) FROM bot_heartbeats GROUP BY m ORDER BY m DESC LIMIT 5\` shows ~12 rows/min consistently.

🤖 Generated with [Claude Code](https://claude.com/claude-code)