### PR TITLE
hotfix: register GuildBackfillOrchestrator in DSharpPlus child DI

### DIFF
--- a/src/DiscordEventService/Program.cs
+++ b/src/DiscordEventService/Program.cs
@@ -68,6 +68,13 @@ builder.Services.AddSingleton(sp =>
         services.AddScoped<RawEventLogService>();
         services.AddScoped<FailedEventService>();
         services.AddScoped<DowntimeTrackerService>();
+        // SocketLifecycleHandler.GuildDownloadCompleted enqueues backfills via
+        // GuildBackfillOrchestrator; it resolves from the DSharpPlus child container
+        // so the orchestrator + IBackgroundJobClient must be registered here too.
+        // JobStorage.Current is initialized by AddHangfire on the root container
+        // before the DiscordClient singleton factory runs.
+        services.AddScoped<GuildBackfillOrchestrator>();
+        services.AddSingleton<IBackgroundJobClient>(_ => new BackgroundJobClient());
         services.AddMemoryCache();
     });
 


### PR DESCRIPTION
## Summary

Post-merge of #102, the prod logs at 22:04:30 showed:

\`\`\`
System.InvalidOperationException: No service for type
'DiscordEventService.Jobs.GuildBackfillOrchestrator' has been registered.
  at SocketLifecycleHandler.HandleEventAsync(GuildDownloadCompletedEventArgs e)
    in /src/Services/EventHandlers/SocketLifecycleHandler.cs:line 63
\`\`\`

The new \`GuildDownloadCompleted\` handler resolves \`GuildBackfillOrchestrator\` from its DI scope, but the handler runs inside the **DSharpPlus child DI container** (\`clientBuilder.ConfigureServices(...)\`). The orchestrator was registered only on the root container (\`builder.Services.AddScoped<GuildBackfillOrchestrator>()\`).

Same class of trap as the \`IHostEnvironment\` registration in #92 and the \`DowntimeTrackerService\` registration in #101.

## Fix

Register both \`GuildBackfillOrchestrator\` and \`IBackgroundJobClient\` in the DSharpPlus child container. \`JobStorage.Current\` is initialized by \`AddHangfire\` on the root container before the DiscordClient singleton factory runs, so \`new BackgroundJobClient()\` resolves it correctly.

## Impact

The bug never made the bot unhealthy — the handler's outer try/catch logged the error and continued. But the reconnect backfill **never fired**, defeating PR #102's stated purpose. Post-hotfix, future cold reconnects will correctly enqueue per-guild backfill chains.

## Test plan

- [x] \`dotnet build\` green
- [ ] Post-deploy: container healthy, no \`Failed to enqueue reconnect backfill\` errors
- [ ] Post-deploy: a forced gateway disconnect (e.g. block traffic to \`gateway.discord.gg\` briefly) results in a \`GatewayDisconnect\` row in \`bot_downtime_intervals\` and, on reconnect, a Hangfire backfill chain visible at \`/hangfire\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)