### PR TITLE
chore: enable ValidateOnBuild + DSharpPlus child container DI validation

### DIFF
--- a/src/DiscordEventService/Program.cs
+++ b/src/DiscordEventService/Program.cs
@@ -21,6 +21,17 @@ if (File.Exists(envPath))
 
 var builder = WebApplication.CreateBuilder(args);
 
+// Fail fast on DI misconfigurations: ValidateOnBuild constructs every
+// registered service at host build time so missing/unresolvable dependencies
+// surface immediately, not when the dependent path first fires at runtime.
+// ValidateScopes catches captive-dependency mistakes (singleton consuming
+// scoped); kept dev-only because of per-resolution overhead.
+builder.Host.UseDefaultServiceProvider(opts =>
+{
+    opts.ValidateOnBuild = true;
+    opts.ValidateScopes = builder.Environment.IsDevelopment();
+});
+
 // Configuration with validation
 builder.Services.AddOptions<DatabaseOptions>()
     .Bind(builder.Configuration.GetSection(DatabaseOptions.SectionName));
@@ -168,6 +179,17 @@ builder.Services.AddScoped<ReactionsBackfillJob>();
 builder.Services.AddScoped<GuildBackfillOrchestrator>();
 
 var app = builder.Build();
+
+// Validate the DSharpPlus child DI container by resolving each service that
+// event handlers depend on. The root container's ValidateOnBuild can't reach
+// the child container's IServiceProvider, so we do it explicitly here. Throws
+// at startup (before app.Run()) if anything is missing or misregistered.
+{
+    var discordClient = app.Services.GetRequiredService<DiscordClient>();
+    StartupValidator.ValidateChildContainer(
+        discordClient.ServiceProvider,
+        app.Services.GetRequiredService<ILogger<Program>>());
+}
 
 // Apply migrations if configured
 var dbOptions = app.Services.GetRequiredService<IOptions<DatabaseOptions>>().Value;

--- a/src/DiscordEventService/Program.cs
+++ b/src/DiscordEventService/Program.cs
@@ -62,7 +62,10 @@ builder.Services.AddSingleton(sp =>
 {
     var clientBuilder = DiscordClientBuilder.CreateDefault(discordToken, DiscordIntents.All);
 
-    // Register ASP.NET Core services in DSharpPlus's DI container
+    // Register ASP.NET Core services in DSharpPlus's DI container.
+    // NOTE: when adding a new registration here that event handlers depend on,
+    // also add the type to StartupValidator.RequiredChildContainerServices so
+    // missing registrations fail at startup instead of at runtime.
     clientBuilder.ConfigureServices(services =>
     {
         services.AddDbContext<DiscordDbContext>(options =>

--- a/src/DiscordEventService/Services/StartupValidator.cs
+++ b/src/DiscordEventService/Services/StartupValidator.cs
@@ -1,0 +1,63 @@
+using DiscordEventService.Data;
+using DiscordEventService.Jobs;
+using Hangfire;
+using Microsoft.Extensions.Caching.Memory;
+
+namespace DiscordEventService.Services;
+
+/// <summary>
+/// Validates that every service event handlers depend on is registered in the
+/// DSharpPlus child DI container. Without this, missing registrations only
+/// surface at runtime when the handler actually fires — sometimes hours after
+/// deploy, often only logged at Error level inside a handler's catch block.
+/// </summary>
+public static class StartupValidator
+{
+    // Services event handlers resolve via scopeFactory.CreateScope().
+    // Constructor-injected transitive dependencies are also validated by trying
+    // to construct each entry below.
+    private static readonly Type[] RequiredChildContainerServices =
+    [
+        typeof(DiscordDbContext),
+        typeof(UserService),
+        typeof(RawEventLogService),
+        typeof(FailedEventService),
+        typeof(DowntimeTrackerService),
+        typeof(GuildBackfillOrchestrator),
+        typeof(IBackgroundJobClient),
+        typeof(IHostEnvironment),
+        typeof(IMemoryCache),
+    ];
+
+    public static void ValidateChildContainer(IServiceProvider childProvider, ILogger logger)
+    {
+        using var scope = childProvider.CreateScope();
+        var failures = new List<string>();
+
+        foreach (var type in RequiredChildContainerServices)
+        {
+            try
+            {
+                var service = scope.ServiceProvider.GetService(type);
+                if (service is null)
+                {
+                    failures.Add($"{type.FullName} is not registered");
+                }
+            }
+            catch (Exception ex)
+            {
+                failures.Add($"{type.FullName} resolved with error: {ex.GetType().Name}: {ex.Message}");
+            }
+        }
+
+        if (failures.Count > 0)
+        {
+            var message = "DSharpPlus child container DI validation failed:\n  - " + string.Join("\n  - ", failures);
+            throw new InvalidOperationException(message);
+        }
+
+        logger.LogInformation(
+            "DSharpPlus child container DI validation passed ({Count} services resolved)",
+            RequiredChildContainerServices.Length);
+    }
+}


### PR DESCRIPTION
## Summary

Follow-up to the hotfix #104 (missing \`GuildBackfillOrchestrator\` registration in the DSharpPlus child container). That class of bug has hit twice now (#92 \`IHostEnvironment\`, #104 \`GuildBackfillOrchestrator\`) and in both cases the runtime failure surfaced only when the dependent path fired, often hours after deploy, and only logged at \`Error\` inside the handler's catch block.

This PR catches them at startup instead.

## Two layers

### 1. Root container — \`ValidateOnBuild\`

\`\`\`csharp
builder.Host.UseDefaultServiceProvider(opts =>
{
    opts.ValidateOnBuild = true;
    opts.ValidateScopes = builder.Environment.IsDevelopment();
});
\`\`\`

- \`ValidateOnBuild = true\` eagerly constructs every registered service at host build time. Missing/unresolvable dependencies become a hard startup failure instead of a silent first-resolution failure later.
- \`ValidateScopes = dev only\` because of per-resolution overhead. Catches captive-dependency mistakes (singleton consuming scoped).

This catches root-container issues but does NOT reach the DSharpPlus child container — which is built separately inside the DiscordClient singleton factory.

### 2. DSharpPlus child container — explicit validator

New \`StartupValidator.ValidateChildContainer\` runs after \`app.Build()\` against \`discordClient.ServiceProvider\`. Walks a hard-coded list of services event handlers depend on and throws \`InvalidOperationException\` with a precise list of failures if anything can't be resolved.

Validated services (matches the registrations in \`clientBuilder.ConfigureServices\`):
- \`DiscordDbContext\`
- \`UserService\`
- \`RawEventLogService\`
- \`FailedEventService\`
- \`DowntimeTrackerService\`
- \`GuildBackfillOrchestrator\` (the one #104 was missing)
- \`IBackgroundJobClient\` (transitive via orchestrator)
- \`IHostEnvironment\` (the one #92 was missing)
- \`IMemoryCache\`

If a future PR adds a new event handler with a new service dependency, the developer needs to also add the service to \`RequiredChildContainerServices\`. That's the right tradeoff for a small project where the handler-dependency list is fairly stable.

## Files

\`\`\`
NEW     src/DiscordEventService/Services/StartupValidator.cs
MODIFY  src/DiscordEventService/Program.cs   (ValidateOnBuild + call to validator)
\`\`\`

## Test plan

- [x] \`dotnet build\` green
- [ ] Post-deploy: container starts cleanly, log line \"DSharpPlus child container DI validation passed (9 services resolved)\" appears at startup.
- [ ] Manual sanity: temporarily comment out the \`services.AddScoped<GuildBackfillOrchestrator>()\` line in the child container — verify container fails to start with a clear error message naming the missing service. (Will revert before merge.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)