### PR TITLE
chore: DI validation v2 (fixes Hangfire JobStorage timing, locally verified)

### DIFF
--- a/src/DiscordEventService/Program.cs
+++ b/src/DiscordEventService/Program.cs
@@ -21,6 +21,17 @@ if (File.Exists(envPath))
 
 var builder = WebApplication.CreateBuilder(args);
 
+// Fail fast on DI misconfigurations: ValidateOnBuild constructs every
+// registered service at host build time so missing/unresolvable dependencies
+// surface immediately, not when the dependent path first fires at runtime.
+// ValidateScopes catches captive-dependency mistakes (singleton consuming
+// scoped); kept dev-only because of per-resolution overhead.
+builder.Host.UseDefaultServiceProvider(opts =>
+{
+    opts.ValidateOnBuild = true;
+    opts.ValidateScopes = builder.Environment.IsDevelopment();
+});
+
 // Configuration with validation
 builder.Services.AddOptions<DatabaseOptions>()
     .Bind(builder.Configuration.GetSection(DatabaseOptions.SectionName));
@@ -47,11 +58,14 @@ builder.Services.AddDbContext<DiscordDbContext>(options =>
 var discordToken = builder.Configuration.GetSection(DiscordOptions.SectionName).Get<DiscordOptions>()?.Token
     ?? throw new InvalidOperationException("Discord:Token is required");
 
-builder.Services.AddSingleton(sp =>
+builder.Services.AddSingleton(rootSp =>
 {
     var clientBuilder = DiscordClientBuilder.CreateDefault(discordToken, DiscordIntents.All);
 
-    // Register ASP.NET Core services in DSharpPlus's DI container
+    // Register ASP.NET Core services in DSharpPlus's DI container.
+    // NOTE: when adding a new registration here that event handlers depend on,
+    // also add the type to StartupValidator.RequiredChildContainerServices so
+    // missing registrations fail at startup instead of at runtime.
     clientBuilder.ConfigureServices(services =>
     {
         services.AddDbContext<DiscordDbContext>(options =>
@@ -69,12 +83,17 @@ builder.Services.AddSingleton(sp =>
         services.AddScoped<FailedEventService>();
         services.AddScoped<DowntimeTrackerService>();
         // SocketLifecycleHandler.GuildDownloadCompleted enqueues backfills via
-        // GuildBackfillOrchestrator; it resolves from the DSharpPlus child container
-        // so the orchestrator + IBackgroundJobClient must be registered here too.
-        // JobStorage.Current is initialized by AddHangfire on the root container
-        // before the DiscordClient singleton factory runs.
+        // GuildBackfillOrchestrator; it resolves from the DSharpPlus child
+        // container, so the orchestrator must be registered here too.
         services.AddScoped<GuildBackfillOrchestrator>();
-        services.AddSingleton<IBackgroundJobClient>(_ => new BackgroundJobClient());
+        // IBackgroundJobClient forwards to the root container's registration.
+        // Hangfire registers IBackgroundJobClient as Transient with DI-based
+        // JobStorage resolution; using `new BackgroundJobClient()` directly
+        // would read JobStorage.Current (a static set by AddHangfireServer's
+        // HostedService at app.Run() time), which is null at validator time
+        // post-Build but pre-Run. Forwarding resolves through Hangfire's
+        // DI-aware factory which works at any time after Build.
+        services.AddSingleton<IBackgroundJobClient>(_ => rootSp.GetRequiredService<IBackgroundJobClient>());
         services.AddMemoryCache();
     });
 
@@ -168,6 +187,27 @@ builder.Services.AddScoped<ReactionsBackfillJob>();
 builder.Services.AddScoped<GuildBackfillOrchestrator>();
 
 var app = builder.Build();
+
+// Validate the DSharpPlus child DI container by resolving each service that
+// event handlers depend on. The root container's ValidateOnBuild can't reach
+// the child container's IServiceProvider, so we do it explicitly here. Throws
+// at startup (before app.Run()) if anything is missing or misregistered.
+{
+    var discordClient = app.Services.GetRequiredService<DiscordClient>();
+    StartupValidator.ValidateChildContainer(
+        discordClient.ServiceProvider,
+        app.Services.GetRequiredService<ILogger<Program>>());
+}
+
+// VALIDATE_AND_EXIT=1 short-circuits startup right after DI validation.
+// Useful as a CI/local smoke test to confirm registrations are correct
+// without booting the bot.
+if (Environment.GetEnvironmentVariable("VALIDATE_AND_EXIT") == "1")
+{
+    app.Services.GetRequiredService<ILogger<Program>>()
+        .LogInformation("VALIDATE_AND_EXIT=1 set, exiting after DI validation.");
+    return;
+}
 
 // Apply migrations if configured
 var dbOptions = app.Services.GetRequiredService<IOptions<DatabaseOptions>>().Value;

--- a/src/DiscordEventService/Services/StartupValidator.cs
+++ b/src/DiscordEventService/Services/StartupValidator.cs
@@ -1,0 +1,63 @@
+using DiscordEventService.Data;
+using DiscordEventService.Jobs;
+using Hangfire;
+using Microsoft.Extensions.Caching.Memory;
+
+namespace DiscordEventService.Services;
+
+/// <summary>
+/// Validates that every service event handlers depend on is registered in the
+/// DSharpPlus child DI container. Without this, missing registrations only
+/// surface at runtime when the handler actually fires — sometimes hours after
+/// deploy, often only logged at Error level inside a handler's catch block.
+/// </summary>
+public static class StartupValidator
+{
+    // Services event handlers resolve via scopeFactory.CreateScope().
+    // Constructor-injected transitive dependencies are also validated by trying
+    // to construct each entry below.
+    private static readonly Type[] RequiredChildContainerServices =
+    [
+        typeof(DiscordDbContext),
+        typeof(UserService),
+        typeof(RawEventLogService),
+        typeof(FailedEventService),
+        typeof(DowntimeTrackerService),
+        typeof(GuildBackfillOrchestrator),
+        typeof(IBackgroundJobClient),
+        typeof(IHostEnvironment),
+        typeof(IMemoryCache),
+    ];
+
+    public static void ValidateChildContainer(IServiceProvider childProvider, ILogger logger)
+    {
+        using var scope = childProvider.CreateScope();
+        var failures = new List<string>();
+
+        foreach (var type in RequiredChildContainerServices)
+        {
+            try
+            {
+                var service = scope.ServiceProvider.GetService(type);
+                if (service is null)
+                {
+                    failures.Add($"{type.FullName} is not registered");
+                }
+            }
+            catch (Exception ex)
+            {
+                failures.Add($"{type.FullName} resolved with error: {ex.GetType().Name}: {ex.Message}");
+            }
+        }
+
+        if (failures.Count > 0)
+        {
+            var message = "DSharpPlus child container DI validation failed:\n  - " + string.Join("\n  - ", failures);
+            throw new InvalidOperationException(message);
+        }
+
+        logger.LogInformation(
+            "DSharpPlus child container DI validation passed ({Count} services resolved)",
+            RequiredChildContainerServices.Length);
+    }
+}


### PR DESCRIPTION
## Summary

Second attempt at #105's DI validation. The v1 was reverted in \`4ed03cf\` because it surfaced its own latent bug: the child container's \`IBackgroundJobClient\` registration used the parameterless \`new BackgroundJobClient()\` constructor, which reads the static \`JobStorage.Current\`. That static is only set by Hangfire when \`AddHangfireServer\`'s HostedService starts — during \`app.Run()\`, **after** the validator runs.

In production without the validator, the child's factory was invoked lazily (at first \`GuildDownloadCompleted\`), by which point \`JobStorage.Current\` was set. With the validator, the factory fired during validation and crash-looped the container.

## Fix

Change the child container's \`IBackgroundJobClient\` registration to forward to the root container's:

\`\`\`csharp
services.AddSingleton<IBackgroundJobClient>(_ => rootSp.GetRequiredService<IBackgroundJobClient>());
\`\`\`

Hangfire registers that as Transient with DI-based \`JobStorage\` resolution (not the static), so it works at any time after host build.

Validation infrastructure is identical to v1:

1. **Root container**: \`ValidateOnBuild=true\` (always), \`ValidateScopes=true\` (dev only).
2. **DSharpPlus child container**: \`StartupValidator.ValidateChildContainer\` walks a hard-coded list of services event handlers depend on and throws with a precise failure list if anything's missing or unresolvable.

## New: VALIDATE_AND_EXIT smoke-test env var

Adds support for \`VALIDATE_AND_EXIT=1\` — short-circuits startup after DI validation passes. Useful as a CI/local smoke test for DI registrations without booting the bot.

## Locally verified

Spun up a throwaway local Docker Postgres on port 5434 and ran with \`VALIDATE_AND_EXIT=1\` to verify both happy and sad paths:

**Positive** (all registrations in place):
\`\`\`
info: Program[0]
      DSharpPlus child container DI validation passed (9 services resolved)
info: Program[0]
      VALIDATE_AND_EXIT=1 set, exiting after DI validation.
\`\`\`

**Negative** (temporarily removed \`services.AddScoped<GuildBackfillOrchestrator>()\`):
\`\`\`
Unhandled exception. System.InvalidOperationException: DSharpPlus child container DI validation failed:
  - DiscordEventService.Jobs.GuildBackfillOrchestrator is not registered
   at DiscordEventService.Services.StartupValidator.ValidateChildContainer(...)
\`\`\`

Confirms the validator both passes when correct AND surfaces the exact missing-service case that bit us in #104.

## Files

\`\`\`
NEW     src/DiscordEventService/Services/StartupValidator.cs
MODIFY  src/DiscordEventService/Program.cs
\`\`\`

## Test plan

- [x] Local build green
- [x] \`VALIDATE_AND_EXIT=1\` positive run against local Docker Postgres: passes
- [x] \`VALIDATE_AND_EXIT=1\` negative run with a removed registration: fails with clear message
- [ ] Post-deploy: container starts cleanly, log line \"DSharpPlus child container DI validation passed (9 services resolved)\" appears at startup
- [ ] Post-deploy: no crash loop (the failure mode of #105)

🤖 Generated with [Claude Code](https://claude.com/claude-code)