### PR TITLE
fix: switch RawEventLogService to Newtonsoft.Json (#99)

### DIFF
--- a/src/DiscordEventService/Services/RawEventLogService.cs
+++ b/src/DiscordEventService/Services/RawEventLogService.cs
@@ -1,21 +1,18 @@
 using DiscordEventService.Data;
 using DiscordEventService.Data.Entities.Events;
-using System.Text.Encodings.Web;
-using System.Text.Json;
-using System.Text.Json.Serialization;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Serialization;
 
 namespace DiscordEventService.Services;
 
 public class RawEventLogService(DiscordDbContext dbContext, ILogger<RawEventLogService> logger)
 {
-    private static readonly JsonSerializerOptions JsonOptions = new()
+    private static readonly JsonSerializerSettings JsonSettings = new()
     {
-        PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
-        WriteIndented = false,
-        ReferenceHandler = ReferenceHandler.IgnoreCycles,
-        DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull,
-        Encoder = JavaScriptEncoder.UnsafeRelaxedJsonEscaping,
-        MaxDepth = 32
+        ContractResolver = new CamelCasePropertyNamesContractResolver(),
+        ReferenceLoopHandling = ReferenceLoopHandling.Ignore,
+        NullValueHandling = NullValueHandling.Ignore,
+        MaxDepth = 32,
     };
 
     /// <summary>
@@ -25,17 +22,17 @@ public class RawEventLogService(DiscordDbContext dbContext, ILogger<RawEventLogS
     {
         try
         {
-            return JsonSerializer.Serialize(eventArgs, JsonOptions);
+            return JsonConvert.SerializeObject(eventArgs, JsonSettings);
         }
         catch (Exception ex)
         {
             logger.LogWarning(ex, "Failed to serialize {EventType}, falling back to type info only", typeof(T).Name);
-            return JsonSerializer.Serialize(new
+            return JsonConvert.SerializeObject(new
             {
                 Error = "Serialization failed",
                 EventType = typeof(T).Name,
                 Message = ex.Message
-            }, JsonOptions);
+            }, JsonSettings);
         }
     }
 


### PR DESCRIPTION
## Summary

Fixes #99.

`System.Text.Json` throws `KeyNotFoundException: The given key 'deprecated' was not present in the dictionary.` deep inside its metadata cache while serializing real DSharpPlus event-args graphs in prod (1–8 events/min). Stack trace bottoms out at `ConcurrentDictionary.ThrowKeyNotFoundException` inside `JsonPropertyInfo.GetMemberAndWriteJson` after many nested `ObjectDefaultConverter` frames. The exact STJ-attribute or property metadata that primes the cache lookup of `"deprecated"` wasn't pinpointed (a synthetic repro that serializes `DiscordVoiceRegion` directly succeeds in both serializers — the failure only manifests on a live event-args graph).

What's clear:
- The failure happens on every serialization attempt for the affected event types (`MessageCreated`, `MessageReactionAdded`, `VoiceStateUpdated`, `TypingStarted`, `GuildMemberUpdated`).
- The catch path then writes a `{"error":"Serialization failed",...}` stub to `raw_event_logs.event_json`, losing the real payload.
- `Newtonsoft.Json` uses different metadata machinery and is the serializer DSharpPlus types were authored against (their internal model uses `[JsonProperty]`).

The fix switches the primary serializer to Newtonsoft, which sidesteps STJ's metadata cache entirely. Newtonsoft is already transitively available via Hangfire (13.0.3) — no new `PackageReference` needed. The stub catch path is retained as defence-in-depth.

## Test plan

- [x] `dotnet build src/DiscordEventService` green
- [x] `VALIDATE_AND_EXIT=1` against local Docker Postgres on port 5434 passes (DI graph still valid; DSharpPlus child container resolves 9 services)
- [ ] Post-deploy: Loki query `{compose_service="discord-event-service"} |= "deprecated"` count drops to ~0 within 15 min
- [ ] Post-deploy: `SELECT count(*) FROM raw_event_logs WHERE event_json LIKE '{"error":"Serialization failed"%' AND received_at_utc > '<deploy-time>'` returns 0
- [ ] Post-deploy: non-stub bytes present for the affected event types in `raw_event_logs`

🤖 Generated with [Claude Code](https://claude.com/claude-code)