### PR TITLE
feat: orphan replay endpoint (#68)

### DIFF
--- a/src/DiscordEventService/Endpoints/OpsEndpoints.cs
+++ b/src/DiscordEventService/Endpoints/OpsEndpoints.cs
@@ -13,6 +13,11 @@ public static class OpsEndpoints
             .WithName("StartDowntime")
             .Produces<DowntimeStartResponse>(StatusCodes.Status200OK)
             .Produces(StatusCodes.Status400BadRequest);
+
+        group.MapPost("/replay-orphans", ReplayOrphans)
+            .WithName("ReplayOrphans")
+            .Produces<OrphanReplayResult>(StatusCodes.Status200OK)
+            .Produces(StatusCodes.Status400BadRequest);
     }
 
     private static async Task<IResult> StartDowntime(
@@ -36,6 +41,20 @@ public static class OpsEndpoints
             Type = result.ActualType.ToString(),
             Created = result.Created
         });
+    }
+
+    private static async Task<IResult> ReplayOrphans(
+        string event_type,
+        OrphanReplayService svc,
+        CancellationToken ct)
+    {
+        if (!string.Equals(event_type, "GuildMemberUpdated", StringComparison.Ordinal))
+        {
+            return Results.BadRequest(new { error = $"event_type '{event_type}' not yet supported" });
+        }
+
+        var result = await svc.ReplayMemberUpdateOrphansAsync(ct);
+        return Results.Ok(result);
     }
 }
 

--- a/src/DiscordEventService/Program.cs
+++ b/src/DiscordEventService/Program.cs
@@ -157,6 +157,7 @@ builder.Services.AddScoped<UserService>();
 builder.Services.AddScoped<RawEventLogService>();
 builder.Services.AddScoped<FailedEventService>();
 builder.Services.AddScoped<DowntimeTrackerService>();
+builder.Services.AddScoped<OrphanReplayService>();
 
 // Health checks
 builder.Services.AddHealthChecks()

--- a/src/DiscordEventService/Services/OrphanReplayService.cs
+++ b/src/DiscordEventService/Services/OrphanReplayService.cs
@@ -1,0 +1,51 @@
+using DiscordEventService.Data;
+using Microsoft.EntityFrameworkCore;
+
+namespace DiscordEventService.Services;
+
+public record OrphanReplayResult(int Scanned, int Inserted, int Skipped);
+
+public class OrphanReplayService(DiscordDbContext db, ILogger<OrphanReplayService> logger)
+{
+    // Scan-only for now. Reconstruction (BuildMemberUpdateEntityFromJson) is
+    // deferred until a real (non-stub) GuildMemberUpdated orphan appears in
+    // prod and we can sample its JSON shape — the Newtonsoft-with-[JsonProperty]
+    // field names for GuildMemberUpdatedEventArgs aren't predictable without one.
+    // Any such row is logged at Warn below so it can be reverse-engineered.
+    public async Task<OrphanReplayResult> ReplayMemberUpdateOrphansAsync(CancellationToken ct)
+    {
+        var orphans = await db.RawEventLogs
+            .Where(r => r.EventType == "GuildMemberUpdated"
+                && !db.MemberEvents.Any(m =>
+                    m.UserDiscordId == r.UserDiscordId
+                    && m.ReceivedAtUtc >= r.ReceivedAtUtc.AddSeconds(-5)
+                    && m.ReceivedAtUtc <= r.ReceivedAtUtc.AddSeconds(5)))
+            .Select(r => new { r.Id, r.UserDiscordId, r.ReceivedAtUtc, r.EventJson })
+            .ToListAsync(ct);
+
+        var skipped = 0;
+        foreach (var o in orphans)
+        {
+            if (IsStubFallback(o.EventJson))
+            {
+                skipped++;
+                continue;
+            }
+
+            // Reconstruction not yet implemented — log so we can find the sample.
+            logger.LogWarning(
+                "Non-stub GuildMemberUpdated orphan found: raw_event_log_id={Id} user={User} received={ReceivedAt}. JSON reconstruction not yet implemented.",
+                o.Id, o.UserDiscordId, o.ReceivedAtUtc);
+            skipped++;
+        }
+
+        return new OrphanReplayResult(orphans.Count, 0, skipped);
+    }
+
+    // Matches the stub written by RawEventLogService.SerializeEvent's catch path.
+    // Postgres jsonb normalizes whitespace to `"key": value` (with space), so
+    // we look for the spaced form. Substring match is order-independent because
+    // jsonb may reorder keys on storage.
+    private static bool IsStubFallback(string json)
+        => json.Contains("\"error\": \"Serialization failed\"", StringComparison.Ordinal);
+}

--- a/src/DiscordEventService/Services/OrphanReplayService.cs
+++ b/src/DiscordEventService/Services/OrphanReplayService.cs
@@ -1,4 +1,5 @@
 using DiscordEventService.Data;
+using DiscordEventService.Data.Entities.Events;
 using Microsoft.EntityFrameworkCore;
 
 namespace DiscordEventService.Services;
@@ -17,7 +18,8 @@ public class OrphanReplayService(DiscordDbContext db, ILogger<OrphanReplayServic
         var orphans = await db.RawEventLogs
             .Where(r => r.EventType == "GuildMemberUpdated"
                 && !db.MemberEvents.Any(m =>
-                    m.UserDiscordId == r.UserDiscordId
+                    m.EventType == MemberEventType.Updated
+                    && m.UserDiscordId == r.UserDiscordId
                     && m.ReceivedAtUtc >= r.ReceivedAtUtc.AddSeconds(-5)
                     && m.ReceivedAtUtc <= r.ReceivedAtUtc.AddSeconds(5)))
             .Select(r => new { r.Id, r.UserDiscordId, r.ReceivedAtUtc, r.EventJson })

--- a/src/DiscordEventService/Services/OrphanReplayService.cs
+++ b/src/DiscordEventService/Services/OrphanReplayService.cs
@@ -13,6 +13,15 @@ public class OrphanReplayService(DiscordDbContext db, ILogger<OrphanReplayServic
     // prod and we can sample its JSON shape — the Newtonsoft-with-[JsonProperty]
     // field names for GuildMemberUpdatedEventArgs aren't predictable without one.
     // Any such row is logged at Warn below so it can be reverse-engineered.
+    //
+    // Note for future reconstruction work: most non-stub orphans will NOT be
+    // handler crashes. MemberEventHandler.HandleEventAsync(GuildMemberUpdatedEventArgs)
+    // only inserts a MemberEventEntity when a watched field changed (nickname,
+    // roles, timeout, avatar, pending, premium, mute, deafen — see lines 146-180).
+    // GuildMemberUpdated for any other field (Member.Flags, UnusualDmActivityUntil,
+    // etc.) writes the raw log but intentionally skips the structured insert.
+    // Reconstruction must re-apply that same change-detection or it will
+    // resurrect rows the handler purposefully filtered out.
     public async Task<OrphanReplayResult> ReplayMemberUpdateOrphansAsync(CancellationToken ct)
     {
         var orphans = await db.RawEventLogs


### PR DESCRIPTION
## Summary

Closes #68.

Adds `POST /api/ops/replay-orphans?event_type=GuildMemberUpdated`. Scans `raw_event_logs` for `GuildMemberUpdated` rows with no matching `member_events` row (NOT EXISTS, ±5s window on `user_discord_id` + `received_at_utc`), classifies each as stub-fallback or non-stub, and returns `{ scanned, inserted, skipped }`.

### Scope decision: scan-only for now

The original plan called for `BuildMemberUpdateEntityFromJson` to reconstruct rows from JSON. Deferred because:

- All 9 historical orphans have **stub-fallback** JSON (`{"error": "Serialization failed", ...}`) from the pre-#99 catch path — unreconstructable by definition, so `inserted=0` regardless.
- No real-JSON sample of `GuildMemberUpdatedEventArgs` exists yet (Newtonsoft-with-`[JsonProperty]` produces field names that aren't reliably predictable without one).
- When a non-stub orphan finally materialises (handler crashed mid-process, DB save failed, etc.), `OrphanReplayService` logs it at `Warn` with `raw_event_log_id` so the JSON shape can be reverse-engineered. At that point a follow-up PR can add the reconstruction.

### Initial production call expectation

```
POST /api/ops/replay-orphans?event_type=GuildMemberUpdated
→ { "scanned": 9, "inserted": 0, "skipped": 9 }
```

### Other notes

- Idempotent — the `NOT EXISTS` filter naturally excludes already-replayed rows.
- Service registered scoped on the root container only; no DSharpPlus child-container registration since the endpoint is the only caller and no event handler depends on it.
- Stub-detection uses substring match on `"error": "Serialization failed"` (jsonb stores with space after colon, key order may be normalised — substring is order-independent).

## Test plan

- [x] `dotnet build src/DiscordEventService` green
- [x] `VALIDATE_AND_EXIT=1` against local Docker Postgres on port 5434 passes
- [ ] Post-deploy: `curl -X POST 'http://homelab:8080/api/ops/replay-orphans?event_type=GuildMemberUpdated'` returns `{"scanned":9,"inserted":0,"skipped":9}`
- [ ] Post-deploy: `curl -X POST 'http://homelab:8080/api/ops/replay-orphans?event_type=ChannelCreated'` returns 400 "not yet supported"
- [ ] Re-run is idempotent: second call returns identical counts

🤖 Generated with [Claude Code](https://claude.com/claude-code)