### PR TITLE
feat: threads upsert into channels + 69-orphan backfill (§P1.9)

### DIFF
--- a/src/DiscordEventService/Endpoints/OpsEndpoints.cs
+++ b/src/DiscordEventService/Endpoints/OpsEndpoints.cs
@@ -18,6 +18,10 @@ public static class OpsEndpoints
             .WithName("ReplayOrphans")
             .Produces<OrphanReplayResult>(StatusCodes.Status200OK)
             .Produces(StatusCodes.Status400BadRequest);
+
+        group.MapPost("/backfill-thread-channels", BackfillThreadChannels)
+            .WithName("BackfillThreadChannels")
+            .Produces<ThreadChannelBackfillService.Result>(StatusCodes.Status200OK);
     }
 
     private static async Task<IResult> StartDowntime(
@@ -54,6 +58,14 @@ public static class OpsEndpoints
         }
 
         var result = await svc.ReplayMemberUpdateOrphansAsync(ct);
+        return Results.Ok(result);
+    }
+
+    private static async Task<IResult> BackfillThreadChannels(
+        ThreadChannelBackfillService svc,
+        CancellationToken ct)
+    {
+        var result = await svc.BackfillAsync(ct);
         return Results.Ok(result);
     }
 }

--- a/src/DiscordEventService/Program.cs
+++ b/src/DiscordEventService/Program.cs
@@ -79,6 +79,8 @@ builder.Services.AddSingleton(rootSp =>
 
         services.AddSingleton<IHostEnvironment>(builder.Environment);
         services.AddScoped<UserService>();
+        services.AddScoped<GuildUpsertService>();
+        services.AddScoped<ChannelUpsertService>();
         services.AddScoped<RawEventLogService>();
         services.AddScoped<FailedEventService>();
         services.AddScoped<DowntimeTrackerService>();
@@ -154,10 +156,13 @@ builder.Services.AddMemoryCache();
 
 // Shared services
 builder.Services.AddScoped<UserService>();
+builder.Services.AddScoped<GuildUpsertService>();
+builder.Services.AddScoped<ChannelUpsertService>();
 builder.Services.AddScoped<RawEventLogService>();
 builder.Services.AddScoped<FailedEventService>();
 builder.Services.AddScoped<DowntimeTrackerService>();
 builder.Services.AddScoped<OrphanReplayService>();
+builder.Services.AddScoped<ThreadChannelBackfillService>();
 
 // Health checks
 builder.Services.AddHealthChecks()

--- a/src/DiscordEventService/Services/ChannelUpsertService.cs
+++ b/src/DiscordEventService/Services/ChannelUpsertService.cs
@@ -1,0 +1,114 @@
+using DiscordEventService.Data;
+using DiscordEventService.Data.Entities.Core;
+using DSharpPlus.Entities;
+using Microsoft.EntityFrameworkCore;
+
+namespace DiscordEventService.Services;
+
+public class ChannelUpsertService(DiscordDbContext db, ILogger<ChannelUpsertService> logger)
+{
+    public async Task<Guid> UpsertChannelAsync(DiscordChannel channel, Guid guildId)
+    {
+        var rowsAffected = await db.Channels
+            .Where(c => c.DiscordId == channel.Id)
+            .ExecuteUpdateAsync(s => s
+                .SetProperty(c => c.Name, channel.Name)
+                .SetProperty(c => c.Type, (ChannelType)channel.Type)
+                .SetProperty(c => c.Topic, channel.Topic)
+                .SetProperty(c => c.Position, channel.Position)
+                .SetProperty(c => c.ParentDiscordId, channel.ParentId)
+                .SetProperty(c => c.Bitrate, channel.Bitrate)
+                .SetProperty(c => c.UserLimit, channel.UserLimit)
+                .SetProperty(c => c.RateLimitPerUser, channel.PerUserRateLimit)
+                .SetProperty(c => c.IsNsfw, channel.IsNSFW));
+
+        if (rowsAffected == 0)
+        {
+            try
+            {
+                db.Channels.Add(new ChannelEntity
+                {
+                    DiscordId = channel.Id,
+                    GuildId = guildId,
+                    Name = channel.Name,
+                    Type = (ChannelType)channel.Type,
+                    Topic = channel.Topic,
+                    Position = channel.Position,
+                    ParentDiscordId = channel.ParentId,
+                    Bitrate = channel.Bitrate,
+                    UserLimit = channel.UserLimit,
+                    RateLimitPerUser = channel.PerUserRateLimit,
+                    IsNsfw = channel.IsNSFW,
+                    IsDeleted = false
+                });
+                await db.SaveChangesAsync();
+            }
+            catch (DbUpdateException ex) when (ex.InnerException is Npgsql.PostgresException { SqlState: "23505" })
+            {
+                db.ChangeTracker.Clear();
+                await db.Channels
+                    .Where(c => c.DiscordId == channel.Id)
+                    .ExecuteUpdateAsync(s => s
+                        .SetProperty(c => c.Name, channel.Name)
+                        .SetProperty(c => c.Type, (ChannelType)channel.Type)
+                        .SetProperty(c => c.Topic, channel.Topic)
+                        .SetProperty(c => c.Position, channel.Position)
+                        .SetProperty(c => c.ParentDiscordId, channel.ParentId)
+                        .SetProperty(c => c.Bitrate, channel.Bitrate)
+                        .SetProperty(c => c.UserLimit, channel.UserLimit)
+                        .SetProperty(c => c.RateLimitPerUser, channel.PerUserRateLimit)
+                        .SetProperty(c => c.IsNsfw, channel.IsNSFW));
+            }
+        }
+
+        var id = await db.Channels
+            .Where(c => c.DiscordId == channel.Id)
+            .Select(c => c.Id)
+            .FirstOrDefaultAsync();
+
+        if (id == Guid.Empty)
+        {
+            logger.LogError("ChannelUpsert lost the row for DiscordId={DiscordId} after upsert", channel.Id);
+        }
+
+        return id;
+    }
+
+    public async Task<Guid> InsertPlaceholderAsync(ulong channelDiscordId, Guid guildId, DateTime firstOrphanSeenUtc)
+    {
+        logger.LogWarning(
+            "Inserting placeholder channel row for unresolvable thread DiscordId={DiscordId}; first orphan message seen at {FirstSeen}",
+            channelDiscordId, firstOrphanSeenUtc);
+
+        try
+        {
+            var placeholder = new ChannelEntity
+            {
+                DiscordId = channelDiscordId,
+                GuildId = guildId,
+                Name = $"[unknown thread {channelDiscordId}]",
+                Type = ChannelType.PublicThread,
+                Position = 0,
+                IsDeleted = false
+            };
+            db.Channels.Add(placeholder);
+            await db.SaveChangesAsync();
+            return placeholder.Id;
+        }
+        catch (DbUpdateException ex) when (ex.InnerException is Npgsql.PostgresException { SqlState: "23505" })
+        {
+            db.ChangeTracker.Clear();
+            return await db.Channels
+                .Where(c => c.DiscordId == channelDiscordId)
+                .Select(c => c.Id)
+                .FirstAsync();
+        }
+    }
+
+    public async Task MarkDeletedAsync(ulong channelDiscordId)
+    {
+        await db.Channels
+            .Where(c => c.DiscordId == channelDiscordId)
+            .ExecuteUpdateAsync(s => s.SetProperty(c => c.IsDeleted, true));
+    }
+}

--- a/src/DiscordEventService/Services/EventHandlers/MessageEventHandler.cs
+++ b/src/DiscordEventService/Services/EventHandlers/MessageEventHandler.cs
@@ -25,6 +25,8 @@ public class MessageEventHandler(IServiceScopeFactory scopeFactory, ILogger<Mess
             using var scope = scopeFactory.CreateScope();
             var db = scope.ServiceProvider.GetRequiredService<DiscordDbContext>();
             var userService = scope.ServiceProvider.GetRequiredService<UserService>();
+            var guildUpsert = scope.ServiceProvider.GetRequiredService<GuildUpsertService>();
+            var channelUpsert = scope.ServiceProvider.GetRequiredService<ChannelUpsertService>();
             var rawEventService = scope.ServiceProvider.GetRequiredService<RawEventLogService>();
 
             rawJson = await rawEventService.SerializeAndLogAsync(
@@ -39,10 +41,15 @@ public class MessageEventHandler(IServiceScopeFactory scopeFactory, ILogger<Mess
                 ? JsonSerializer.Serialize(e.Message.Embeds)
                 : null;
 
-            // Look up related entities by DiscordId
-            var guild = await db.Guilds.FirstOrDefaultAsync(g => g.DiscordId == e.Guild.Id);
-            var channel = await db.Channels.FirstOrDefaultAsync(c => c.DiscordId == e.Channel.Id);
-            var author = await db.Users.FirstOrDefaultAsync(u => u.DiscordId == e.Author.Id);
+            // Resolve FKs via upsert-if-missing. The 2026-05-03 incident left 69 messages with
+            // channel_id IS NULL because the prior FirstOrDefault path silently wrote null when
+            // the channel (a thread) wasn't yet in our DB. §P1.9 closes that hole.
+            var guildId = await guildUpsert.UpsertGuildAsync(e.Guild);
+            var channelId = await channelUpsert.UpsertChannelAsync(e.Channel, guildId);
+            var authorId = await db.Users
+                .Where(u => u.DiscordId == e.Author.Id)
+                .Select(u => u.Id)
+                .FirstOrDefaultAsync();
 
             MessageEventEntity NewMessageEvent() => new()
             {
@@ -78,9 +85,9 @@ public class MessageEventHandler(IServiceScopeFactory scopeFactory, ILogger<Mess
                 db.Messages.Add(new MessageEntity
                 {
                     DiscordId = e.Message.Id,
-                    ChannelId = channel?.Id,
-                    GuildId = guild?.Id,
-                    AuthorId = author?.Id,
+                    ChannelId = channelId != Guid.Empty ? channelId : null,
+                    GuildId = guildId != Guid.Empty ? guildId : null,
+                    AuthorId = authorId != Guid.Empty ? authorId : null,
                     Content = e.Message.Content,
                     ReplyToDiscordId = e.Message.ReferencedMessage?.Id,
                     HasAttachments = e.Message.Attachments.Count > 0,

--- a/src/DiscordEventService/Services/EventHandlers/MessageEventHandler.cs
+++ b/src/DiscordEventService/Services/EventHandlers/MessageEventHandler.cs
@@ -74,10 +74,6 @@ public class MessageEventHandler(IServiceScopeFactory scopeFactory, ILogger<Mess
                 RawEventJson = rawJson
             };
 
-            // SerializeAndLogAsync staged a RawEventLog row but did NOT save it; flush it
-            // before the strategy lambda's ChangeTracker.Clear() detaches it.
-            await db.SaveChangesAsync();
-
             // Wrap multi-row writes in a transaction so the 23505 retry path
             // (ExecuteUpdate + insert) is atomic. ExecutionStrategy is required
             // because EnableRetryOnFailure is configured on the DbContext.

--- a/src/DiscordEventService/Services/EventHandlers/MessageEventHandler.cs
+++ b/src/DiscordEventService/Services/EventHandlers/MessageEventHandler.cs
@@ -32,6 +32,11 @@ public class MessageEventHandler(IServiceScopeFactory scopeFactory, ILogger<Mess
             rawJson = await rawEventService.SerializeAndLogAsync(
                 e, "MessageCreated", e.Guild.Id, e.Channel.Id, e.Author.Id);
 
+            // Persist the raw event row immediately. Otherwise any 23505 race inside one of the
+            // upsert services below clears the change tracker on its catch path and the staged
+            // raw_event_logs row is silently dropped along with the rolled-back insert.
+            await db.SaveChangesAsync();
+
             await userService.UpsertUserAsync(e.Author);
 
             var attachmentsJson = e.Message.Attachments.Count > 0

--- a/src/DiscordEventService/Services/EventHandlers/ThreadEventHandler.cs
+++ b/src/DiscordEventService/Services/EventHandlers/ThreadEventHandler.cs
@@ -20,9 +20,16 @@ public class ThreadEventHandler(IServiceScopeFactory scopeFactory, ILogger<Threa
             using var scope = scopeFactory.CreateScope();
             var db = scope.ServiceProvider.GetRequiredService<DiscordDbContext>();
             var rawEventService = scope.ServiceProvider.GetRequiredService<RawEventLogService>();
+            var guildUpsert = scope.ServiceProvider.GetRequiredService<GuildUpsertService>();
+            var channelUpsert = scope.ServiceProvider.GetRequiredService<ChannelUpsertService>();
 
             rawJson = await rawEventService.SerializeAndLogAsync(
                 e, "ThreadCreated", e.Guild.Id, e.Thread.Id, e.Thread.CreatorId);
+
+            // Threads are channels (ADR-0003): upsert the thread into `channels` so messages
+            // sent into it have a non-null channel_id from the first event onward.
+            var guildId = await guildUpsert.UpsertGuildAsync(e.Guild);
+            await channelUpsert.UpsertChannelAsync(e.Thread, guildId);
 
             var threadEvent = new ThreadEventEntity
             {
@@ -61,9 +68,14 @@ public class ThreadEventHandler(IServiceScopeFactory scopeFactory, ILogger<Threa
             using var scope = scopeFactory.CreateScope();
             var db = scope.ServiceProvider.GetRequiredService<DiscordDbContext>();
             var rawEventService = scope.ServiceProvider.GetRequiredService<RawEventLogService>();
+            var guildUpsert = scope.ServiceProvider.GetRequiredService<GuildUpsertService>();
+            var channelUpsert = scope.ServiceProvider.GetRequiredService<ChannelUpsertService>();
 
             rawJson = await rawEventService.SerializeAndLogAsync(
                 e, "ThreadUpdated", e.Guild.Id, e.ThreadAfter.Id, e.ThreadAfter.CreatorId);
+
+            var guildId = await guildUpsert.UpsertGuildAsync(e.Guild);
+            await channelUpsert.UpsertChannelAsync(e.ThreadAfter, guildId);
 
             var threadEvent = new ThreadEventEntity
             {
@@ -102,9 +114,14 @@ public class ThreadEventHandler(IServiceScopeFactory scopeFactory, ILogger<Threa
             using var scope = scopeFactory.CreateScope();
             var db = scope.ServiceProvider.GetRequiredService<DiscordDbContext>();
             var rawEventService = scope.ServiceProvider.GetRequiredService<RawEventLogService>();
+            var channelUpsert = scope.ServiceProvider.GetRequiredService<ChannelUpsertService>();
 
             rawJson = await rawEventService.SerializeAndLogAsync(
                 e, "ThreadDeleted", e.Guild.Id, e.Thread.Id, e.Thread.CreatorId);
+
+            // Mark the channel row deleted. DeletedAtUtc isn't on the schema yet (§P2.1 adds it);
+            // §P2.1 will retroactively populate this and other handlers.
+            await channelUpsert.MarkDeletedAsync(e.Thread.Id);
 
             var threadEvent = new ThreadEventEntity
             {

--- a/src/DiscordEventService/Services/EventHandlers/ThreadEventHandler.cs
+++ b/src/DiscordEventService/Services/EventHandlers/ThreadEventHandler.cs
@@ -26,6 +26,10 @@ public class ThreadEventHandler(IServiceScopeFactory scopeFactory, ILogger<Threa
             rawJson = await rawEventService.SerializeAndLogAsync(
                 e, "ThreadCreated", e.Guild.Id, e.Thread.Id, e.Thread.CreatorId);
 
+            // Flush the raw event row before any upsert; the upsert services' 23505 catch path
+            // calls ChangeTracker.Clear() which would otherwise drop the staged raw_event_logs row.
+            await db.SaveChangesAsync();
+
             // Threads are channels (ADR-0003): upsert the thread into `channels` so messages
             // sent into it have a non-null channel_id from the first event onward.
             var guildId = await guildUpsert.UpsertGuildAsync(e.Guild);
@@ -74,6 +78,8 @@ public class ThreadEventHandler(IServiceScopeFactory scopeFactory, ILogger<Threa
             rawJson = await rawEventService.SerializeAndLogAsync(
                 e, "ThreadUpdated", e.Guild.Id, e.ThreadAfter.Id, e.ThreadAfter.CreatorId);
 
+            await db.SaveChangesAsync();
+
             var guildId = await guildUpsert.UpsertGuildAsync(e.Guild);
             await channelUpsert.UpsertChannelAsync(e.ThreadAfter, guildId);
 
@@ -118,6 +124,8 @@ public class ThreadEventHandler(IServiceScopeFactory scopeFactory, ILogger<Threa
 
             rawJson = await rawEventService.SerializeAndLogAsync(
                 e, "ThreadDeleted", e.Guild.Id, e.Thread.Id, e.Thread.CreatorId);
+
+            await db.SaveChangesAsync();
 
             // Mark the channel row deleted. DeletedAtUtc isn't on the schema yet (§P2.1 adds it);
             // §P2.1 will retroactively populate this and other handlers.

--- a/src/DiscordEventService/Services/GuildUpsertService.cs
+++ b/src/DiscordEventService/Services/GuildUpsertService.cs
@@ -1,0 +1,57 @@
+using DiscordEventService.Data;
+using DiscordEventService.Data.Entities.Core;
+using DSharpPlus.Entities;
+using Microsoft.EntityFrameworkCore;
+
+namespace DiscordEventService.Services;
+
+public class GuildUpsertService(DiscordDbContext db, ILogger<GuildUpsertService> logger)
+{
+    public async Task<Guid> UpsertGuildAsync(DiscordGuild guild)
+    {
+        var rowsAffected = await db.Guilds
+            .Where(g => g.DiscordId == guild.Id)
+            .ExecuteUpdateAsync(s => s
+                .SetProperty(g => g.Name, guild.Name)
+                .SetProperty(g => g.IconHash, guild.IconHash)
+                .SetProperty(g => g.OwnerId, guild.OwnerId));
+
+        if (rowsAffected == 0)
+        {
+            try
+            {
+                db.Guilds.Add(new GuildEntity
+                {
+                    DiscordId = guild.Id,
+                    Name = guild.Name,
+                    IconHash = guild.IconHash,
+                    OwnerId = guild.OwnerId,
+                    LeftAtUtc = null
+                });
+                await db.SaveChangesAsync();
+            }
+            catch (DbUpdateException ex) when (ex.InnerException is Npgsql.PostgresException { SqlState: "23505" })
+            {
+                db.ChangeTracker.Clear();
+                await db.Guilds
+                    .Where(g => g.DiscordId == guild.Id)
+                    .ExecuteUpdateAsync(s => s
+                        .SetProperty(g => g.Name, guild.Name)
+                        .SetProperty(g => g.IconHash, guild.IconHash)
+                        .SetProperty(g => g.OwnerId, guild.OwnerId));
+            }
+        }
+
+        var id = await db.Guilds
+            .Where(g => g.DiscordId == guild.Id)
+            .Select(g => g.Id)
+            .FirstOrDefaultAsync();
+
+        if (id == Guid.Empty)
+        {
+            logger.LogError("GuildUpsert lost the row for DiscordId={DiscordId} after upsert", guild.Id);
+        }
+
+        return id;
+    }
+}

--- a/src/DiscordEventService/Services/StartupValidator.cs
+++ b/src/DiscordEventService/Services/StartupValidator.cs
@@ -20,6 +20,8 @@ public static class StartupValidator
     [
         typeof(DiscordDbContext),
         typeof(UserService),
+        typeof(GuildUpsertService),
+        typeof(ChannelUpsertService),
         typeof(RawEventLogService),
         typeof(FailedEventService),
         typeof(DowntimeTrackerService),

--- a/src/DiscordEventService/Services/ThreadChannelBackfillService.cs
+++ b/src/DiscordEventService/Services/ThreadChannelBackfillService.cs
@@ -1,0 +1,124 @@
+using DiscordEventService.Data;
+using DSharpPlus;
+using Microsoft.EntityFrameworkCore;
+
+namespace DiscordEventService.Services;
+
+public class ThreadChannelBackfillService(
+    DiscordDbContext db,
+    DiscordClient client,
+    ChannelUpsertService channelUpsert,
+    ILogger<ThreadChannelBackfillService> logger)
+{
+    public record Result(int OrphansScanned, int ChannelsFetched, int Placeholders, int MessagesLinked, int Unresolved);
+
+    public async Task<Result> BackfillAsync(CancellationToken ct)
+    {
+        var orphans = await db.Messages
+            .Where(m => m.ChannelId == null)
+            .Select(m => new { m.Id, m.DiscordId, m.FirstSeenUtc })
+            .ToListAsync(ct);
+
+        if (orphans.Count == 0)
+        {
+            return new Result(0, 0, 0, 0, 0);
+        }
+
+        // Resolve each orphan's channel_discord_id deterministically: pick the MessageCreated
+        // raw event within ±2s whose received_at_utc is closest to the orphan's first_seen_utc.
+        var orphanToChannel = new Dictionary<Guid, ulong>();
+        foreach (var orphan in orphans)
+        {
+            var windowStart = orphan.FirstSeenUtc.AddSeconds(-2);
+            var windowEnd = orphan.FirstSeenUtc.AddSeconds(2);
+
+            var candidates = await db.RawEventLogs
+                .Where(r => r.EventType == "MessageCreated"
+                    && r.ReceivedAtUtc >= windowStart
+                    && r.ReceivedAtUtc <= windowEnd
+                    && r.ChannelDiscordId != null)
+                .Select(r => new { r.ChannelDiscordId, r.ReceivedAtUtc })
+                .ToListAsync(ct);
+
+            var best = candidates
+                .OrderBy(c => Math.Abs((c.ReceivedAtUtc - orphan.FirstSeenUtc).TotalMilliseconds))
+                .FirstOrDefault();
+
+            if (best is { ChannelDiscordId: { } cid })
+            {
+                orphanToChannel[orphan.Id] = cid;
+            }
+            else
+            {
+                logger.LogWarning(
+                    "Could not resolve channel_discord_id for orphan message {MessageId} (DiscordId={DiscordId})",
+                    orphan.Id, orphan.DiscordId);
+            }
+        }
+
+        var uniqueChannels = orphanToChannel.Values.Distinct().ToList();
+        var guildId = await db.Guilds.Select(g => g.Id).FirstAsync(ct);
+
+        // Ensure each unique channel exists in `channels`. Try Discord API; fall back to placeholder.
+        int fetched = 0;
+        int placeholders = 0;
+        var resolvedChannelGuids = new Dictionary<ulong, Guid>();
+        foreach (var discordId in uniqueChannels)
+        {
+            var existing = await db.Channels
+                .Where(c => c.DiscordId == discordId)
+                .Select(c => c.Id)
+                .FirstOrDefaultAsync(ct);
+
+            if (existing != Guid.Empty)
+            {
+                resolvedChannelGuids[discordId] = existing;
+                continue;
+            }
+
+            try
+            {
+                var live = await client.GetChannelAsync(discordId);
+                if (live is not null)
+                {
+                    var id = await channelUpsert.UpsertChannelAsync(live, guildId);
+                    resolvedChannelGuids[discordId] = id;
+                    fetched++;
+                    logger.LogInformation("Backfilled channel {DiscordId} via Discord API as {Type}", discordId, live.Type);
+                    continue;
+                }
+            }
+            catch (Exception ex)
+            {
+                logger.LogWarning(ex,
+                    "Discord API GetChannelAsync failed for {DiscordId}; inserting placeholder",
+                    discordId);
+            }
+
+            var firstOrphan = orphans
+                .Where(o => orphanToChannel.TryGetValue(o.Id, out var c) && c == discordId)
+                .Min(o => o.FirstSeenUtc);
+            var placeholderId = await channelUpsert.InsertPlaceholderAsync(discordId, guildId, firstOrphan);
+            resolvedChannelGuids[discordId] = placeholderId;
+            placeholders++;
+        }
+
+        // Link orphans to their resolved channels.
+        int linked = 0;
+        foreach (var (orphanId, channelDiscordId) in orphanToChannel)
+        {
+            if (!resolvedChannelGuids.TryGetValue(channelDiscordId, out var channelGuid))
+            {
+                continue;
+            }
+
+            var rows = await db.Messages
+                .Where(m => m.Id == orphanId && m.ChannelId == null)
+                .ExecuteUpdateAsync(s => s.SetProperty(m => m.ChannelId, channelGuid), ct);
+            linked += rows;
+        }
+
+        var unresolved = orphans.Count - orphanToChannel.Count;
+        return new Result(orphans.Count, fetched, placeholders, linked, unresolved);
+    }
+}

--- a/src/DiscordEventService/Services/ThreadChannelBackfillService.cs
+++ b/src/DiscordEventService/Services/ThreadChannelBackfillService.cs
@@ -1,5 +1,6 @@
 using DiscordEventService.Data;
 using DSharpPlus;
+using DSharpPlus.Exceptions;
 using Microsoft.EntityFrameworkCore;
 
 namespace DiscordEventService.Services;
@@ -16,7 +17,7 @@ public class ThreadChannelBackfillService(
     {
         var orphans = await db.Messages
             .Where(m => m.ChannelId == null)
-            .Select(m => new { m.Id, m.DiscordId, m.FirstSeenUtc })
+            .Select(m => new { m.Id, m.DiscordId, m.FirstSeenUtc, m.GuildId })
             .ToListAsync(ct);
 
         if (orphans.Count == 0)
@@ -24,9 +25,10 @@ public class ThreadChannelBackfillService(
             return new Result(0, 0, 0, 0, 0);
         }
 
-        // Resolve each orphan's channel_discord_id deterministically: pick the MessageCreated
-        // raw event within ±2s whose received_at_utc is closest to the orphan's first_seen_utc.
-        var orphanToChannel = new Dictionary<Guid, ulong>();
+        // For each orphan, resolve both the missing channel_discord_id AND the guild_discord_id
+        // from the matching MessageCreated raw event (deterministic: nearest received_at_utc
+        // within ±2s). Carrying the guild_discord_id avoids the "pick an arbitrary guild" trap.
+        var orphanResolution = new Dictionary<Guid, (ulong ChannelDiscordId, ulong GuildDiscordId)>();
         foreach (var orphan in orphans)
         {
             var windowStart = orphan.FirstSeenUtc.AddSeconds(-2);
@@ -37,7 +39,7 @@ public class ThreadChannelBackfillService(
                     && r.ReceivedAtUtc >= windowStart
                     && r.ReceivedAtUtc <= windowEnd
                     && r.ChannelDiscordId != null)
-                .Select(r => new { r.ChannelDiscordId, r.ReceivedAtUtc })
+                .Select(r => new { r.ChannelDiscordId, r.GuildDiscordId, r.ReceivedAtUtc })
                 .ToListAsync(ct);
 
             var best = candidates
@@ -46,7 +48,7 @@ public class ThreadChannelBackfillService(
 
             if (best is { ChannelDiscordId: { } cid })
             {
-                orphanToChannel[orphan.Id] = cid;
+                orphanResolution[orphan.Id] = (cid, best.GuildDiscordId);
             }
             else
             {
@@ -56,56 +58,87 @@ public class ThreadChannelBackfillService(
             }
         }
 
-        var uniqueChannels = orphanToChannel.Values.Distinct().ToList();
-        var guildId = await db.Guilds.Select(g => g.Id).FirstAsync(ct);
+        // Group orphans by (channel, guild) so we upsert each channel under its own guild.
+        var uniqueChannels = orphanResolution
+            .Values
+            .GroupBy(v => v.ChannelDiscordId)
+            .Select(g => new
+            {
+                ChannelDiscordId = g.Key,
+                GuildDiscordIds = g.Select(v => v.GuildDiscordId).Distinct().ToList()
+            })
+            .ToList();
 
-        // Ensure each unique channel exists in `channels`. Try Discord API; fall back to placeholder.
         int fetched = 0;
         int placeholders = 0;
         var resolvedChannelGuids = new Dictionary<ulong, Guid>();
-        foreach (var discordId in uniqueChannels)
+        foreach (var entry in uniqueChannels)
         {
             var existing = await db.Channels
-                .Where(c => c.DiscordId == discordId)
+                .Where(c => c.DiscordId == entry.ChannelDiscordId)
                 .Select(c => c.Id)
                 .FirstOrDefaultAsync(ct);
 
             if (existing != Guid.Empty)
             {
-                resolvedChannelGuids[discordId] = existing;
+                resolvedChannelGuids[entry.ChannelDiscordId] = existing;
+                continue;
+            }
+
+            if (entry.GuildDiscordIds.Count != 1)
+            {
+                logger.LogWarning(
+                    "Orphan channel {ChannelId} appears under multiple guild_discord_ids ({Count}); using first",
+                    entry.ChannelDiscordId, entry.GuildDiscordIds.Count);
+            }
+            var guildDiscordId = entry.GuildDiscordIds[0];
+            var guildGuid = await db.Guilds
+                .Where(g => g.DiscordId == guildDiscordId)
+                .Select(g => g.Id)
+                .FirstOrDefaultAsync(ct);
+
+            if (guildGuid == Guid.Empty)
+            {
+                logger.LogError(
+                    "Guild {GuildDiscordId} for orphan channel {ChannelDiscordId} not present in DB; skipping",
+                    guildDiscordId, entry.ChannelDiscordId);
                 continue;
             }
 
             try
             {
-                var live = await client.GetChannelAsync(discordId);
-                if (live is not null)
-                {
-                    var id = await channelUpsert.UpsertChannelAsync(live, guildId);
-                    resolvedChannelGuids[discordId] = id;
-                    fetched++;
-                    logger.LogInformation("Backfilled channel {DiscordId} via Discord API as {Type}", discordId, live.Type);
-                    continue;
-                }
+                var live = await client.GetChannelAsync(entry.ChannelDiscordId);
+                var id = await channelUpsert.UpsertChannelAsync(live, guildGuid);
+                resolvedChannelGuids[entry.ChannelDiscordId] = id;
+                fetched++;
+                logger.LogInformation("Backfilled channel {DiscordId} via Discord API as {Type}", entry.ChannelDiscordId, live.Type);
+                continue;
             }
-            catch (Exception ex)
+            catch (NotFoundException)
             {
-                logger.LogWarning(ex,
-                    "Discord API GetChannelAsync failed for {DiscordId}; inserting placeholder",
-                    discordId);
+                // Channel genuinely gone from Discord's side — placeholder is the only honest option.
+                logger.LogWarning(
+                    "Discord 404 for {DiscordId}; inserting placeholder",
+                    entry.ChannelDiscordId);
+            }
+            catch (UnauthorizedException)
+            {
+                // Bot doesn't currently have permission — also placeholder territory, but log loud.
+                logger.LogWarning(
+                    "Discord 403 for {DiscordId}; inserting placeholder",
+                    entry.ChannelDiscordId);
             }
 
             var firstOrphan = orphans
-                .Where(o => orphanToChannel.TryGetValue(o.Id, out var c) && c == discordId)
+                .Where(o => orphanResolution.TryGetValue(o.Id, out var c) && c.ChannelDiscordId == entry.ChannelDiscordId)
                 .Min(o => o.FirstSeenUtc);
-            var placeholderId = await channelUpsert.InsertPlaceholderAsync(discordId, guildId, firstOrphan);
-            resolvedChannelGuids[discordId] = placeholderId;
+            var placeholderId = await channelUpsert.InsertPlaceholderAsync(entry.ChannelDiscordId, guildGuid, firstOrphan);
+            resolvedChannelGuids[entry.ChannelDiscordId] = placeholderId;
             placeholders++;
         }
 
-        // Link orphans to their resolved channels.
         int linked = 0;
-        foreach (var (orphanId, channelDiscordId) in orphanToChannel)
+        foreach (var (orphanId, (channelDiscordId, _)) in orphanResolution)
         {
             if (!resolvedChannelGuids.TryGetValue(channelDiscordId, out var channelGuid))
             {
@@ -118,7 +151,7 @@ public class ThreadChannelBackfillService(
             linked += rows;
         }
 
-        var unresolved = orphans.Count - orphanToChannel.Count;
+        var unresolved = orphans.Count - orphanResolution.Count;
         return new Result(orphans.Count, fetched, placeholders, linked, unresolved);
     }
 }


### PR DESCRIPTION
## Summary

Closes #109. Fixes the silent-NULL FK pattern that left 69 messages with `channel_id IS NULL` after the 2026-05-03 incident.

- **Root cause**: `MessageEventHandler.cs:44` did `FirstOrDefaultAsync` then wrote `channel?.Id` — null when the channel (a thread) wasn't yet in our DB. `ThreadEventHandler` never upserted threads into `channels`. Both gaps are now closed.
- **New services**: `ChannelUpsertService` + `GuildUpsertService` (ExecuteUpdate-then-23505-retry, mirrors `UserService` precedent).
- **Handlers**:
  - `ThreadEventHandler.Created/Updated/Deleted` now upsert the thread row into `channels` per [ADR-0003](https://github.com/wiktorkowalski/WojtusDiscord/blob/master/docs/adr/0003-threads-are-channels.md).
  - `MessageEventHandler` replaces silent `FirstOrDefault → null` with upsert-if-missing for guild + channel.
- **Backfill endpoint**: `POST /api/ops/backfill-thread-channels` resolves each orphan's `channel_discord_id` AND `guild_discord_id` from its matched `MessageCreated` raw event (nearest received_at within ±2s), fetches each unknown channel via DSharpPlus, falls back to a named placeholder only on `NotFoundException` / `UnauthorizedException` (transient errors propagate so the operator can retry).
- **Pre-existing raw-log loss closed**: explicit `SaveChangesAsync` after `SerializeAndLogAsync` so the staged `raw_event_logs` row is durable before any upsert's 23505 catch path clears the change tracker.

No EF migration — data fix only. Backfill is invoked once post-deploy.

Depends on docs PR #110 (CONTEXT.md + ADR-0003); fine to merge in either order.

## Data-loss check

- Inserts up to 2 channel rows + 69 message UPDATEs. Net info gain. **No row deletes, no NULL → loss.**

## Test plan

- [x] `dotnet build` green.
- [x] `VALIDATE_AND_EXIT=1` against local Docker Postgres passes (11 child-container services resolved, up from 9).
- [ ] Post-deploy: `curl -X POST 'http://homelab:8080/api/ops/backfill-thread-channels'` returns `{ OrphansScanned: 69, Placeholders: ≤2, MessagesLinked: 69, Unresolved: 0 }` on the first call, idempotent zero counts on the second.
- [ ] Post-deploy probe: `SELECT count(*) FROM messages WHERE channel_id IS NULL` returns 0.
- [ ] Post-deploy probe: `SELECT count(*) FROM channels WHERE type IN (10,11,12)` ≥ 3.
- [ ] One-week probe: no new NULL-channel_id rows.

## Out of scope (filed as follow-ups)

- Sweep of remaining silent-`FirstOrDefault → null` sites across other handlers (Voice/Reaction/Pin/Invite/Sticker/StageInstance/ScheduledEvent…) — Phase-4 audit.
- `DeletedAtUtc` population on soft-delete — handled by §P2.1 (#69).
- The pre-existing raw-log loss in `UserService.UpsertUserAsync`'s own 23505 path — same shape but not introduced here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)