### PR TITLE
fix: PresenceEventHandler upserts user before activity tracking

### DIFF
--- a/src/DiscordEventService/Services/EventHandlers/PresenceEventHandler.cs
+++ b/src/DiscordEventService/Services/EventHandlers/PresenceEventHandler.cs
@@ -1,6 +1,7 @@
 using DiscordEventService.Data;
 using DiscordEventService.Data.Entities.Core;
 using DiscordEventService.Data.Entities.Events;
+using DiscordEventService.Services;
 using DSharpPlus;
 using DSharpPlus.Entities;
 using DSharpPlus.EventArgs;
@@ -28,6 +29,7 @@ public class PresenceEventHandler(IServiceScopeFactory scopeFactory, ILogger<Pre
             using var scope = scopeFactory.CreateScope();
             var dbContext = scope.ServiceProvider.GetRequiredService<DiscordDbContext>();
             var rawEventService = scope.ServiceProvider.GetRequiredService<RawEventLogService>();
+            var userService = scope.ServiceProvider.GetRequiredService<UserService>();
 
             var guildId = args.PresenceAfter?.Guild?.Id ?? args.PresenceBefore?.Guild?.Id ?? 0;
 
@@ -79,18 +81,27 @@ public class PresenceEventHandler(IServiceScopeFactory scopeFactory, ILogger<Pre
 
             await dbContext.PresenceEvents.AddAsync(presenceEvent);
 
-            // Track activities in ActivityEntity table (requires User to exist)
-            var user = await dbContext.Users.FirstOrDefaultAsync(u => u.DiscordId == args.User.Id);
-            if (user != null)
+            // Flush before the user upsert so its 23505 catch path (ChangeTracker.Clear)
+            // can't discard the staged raw_event_logs + presence_events rows.
+            await dbContext.SaveChangesAsync();
+
+            // Track activities in ActivityEntity — upsert the user first so we never silently
+            // skip activity tracking for unknown users (87k presence events historically).
+            await userService.UpsertUserAsync(args.User);
+            var userGuid = await dbContext.Users
+                .Where(u => u.DiscordId == args.User.Id)
+                .Select(u => u.Id)
+                .FirstOrDefaultAsync();
+
+            if (userGuid != Guid.Empty)
             {
-                await UpdateActivityTracking(dbContext, user.Id, args.User.Id, args.PresenceBefore?.Activities, args.PresenceAfter?.Activities, now);
+                await UpdateActivityTracking(dbContext, userGuid, args.User.Id, args.PresenceBefore?.Activities, args.PresenceAfter?.Activities, now);
+                await dbContext.SaveChangesAsync();
             }
             else
             {
-                logger.LogDebug("Skipping activity tracking: User {UserId} not in database", args.User.Id);
+                logger.LogWarning("Skipping activity tracking: UpsertUserAsync did not produce a User row for {UserId}", args.User.Id);
             }
-
-            await dbContext.SaveChangesAsync();
 
             logger.LogDebug("Recorded presence event for user {UserId}", args.User.Id);
         }


### PR DESCRIPTION
## Summary

Follow-up to §P1.9 (#109). Closes the silent-null FK pattern in `PresenceEventHandler`:

- Before: `FirstOrDefaultAsync` on Users at line 83 could return null → activity tracking silently skipped at `LogDebug`. Across 87k historical presence events that's a lot of silent misses.
- After: `UpsertUserAsync` runs unconditionally, then `user.Id` is read back. The staged `raw_event_logs` + `presence_events` row is explicitly flushed *before* the upsert, so a 23505 race in `UserService`'s catch path (`ChangeTracker.Clear()`) can't drop them.

PresenceEventHandler is the highest-volume event handler in the codebase, so it's the highest-value site to fix first. Other handlers with the same silent-FK pattern (BanEventHandler, InviteEventHandler, ScheduledEventHandler, StageInstanceEventHandler, IntegrationEventHandler, AutoModRuleEventHandler, ChannelEventHandler, RoleEventHandler, EmojiEventHandler, StickerEventHandler) will be tackled one-at-a-time in follow-up PRs.

## Data-loss check

- Two SaveChangesAsync calls instead of one. If a transient DB error fires between them, the presence_event lands but activities don't — still a net improvement over the prior path that silently skipped activities for unknown users. **No row deletes. No worse than prior behaviour, strictly better when User upserts succeed.**

## Test plan

- [x] `dotnet build` green.
- [x] `VALIDATE_AND_EXIT=1` against local Docker Postgres passes (11 services resolved).
- [ ] Post-deploy: trigger a presence change in the test guild → `activities` row created for the upserted user.
- [ ] Post-deploy probe: `SELECT count(*) FROM presence_events WHERE received_at_utc > now() - interval '1 hour'` continues to grow.

## Out of scope (filed as follow-ups)

- Wider silent-null FK audit across remaining handlers — separate issues per family.
- VoiceEventHandler's voice-state upsert path — about to be ripped out in §P2.1 (voice_states drop).

🤖 Generated with [Claude Code](https://claude.com/claude-code)