### PR TITLE
docs: phase-1 retro + Phase-2 HANDOFF.md

### DIFF
--- a/HANDOFF.md
+++ b/HANDOFF.md
@@ -1,0 +1,76 @@
+# Handoff — Phase 2 of epic #53
+
+> **One-shot doc.** Read it, then delete it (`rm HANDOFF.md && git add -A && git commit -m "chore: consume HANDOFF.md"`) so a future handoff isn't confused with this one. If you're not actively starting Phase 2, ignore this file and leave it be.
+
+You're picking up after Phase 1 + the §P1.9 hotfix landed. **Don't re-read the prior conversation** — everything load-bearing was pushed into durable artifacts. Read those instead.
+
+## Read in this order
+
+1. **`docs/phase-1-retro.md`** — what we learned in Phase 1, why decisions were made, surprises worth remembering.
+2. **Epic #53** — read the body, then the `2026-05-22 Grilling session` comment. The comment is the source of truth for current state, sequencing, open OD#s, and scope refinements.
+3. **`CONTEXT.md`** + **`docs/adr/0001-drop-voice-states-snapshot.md`**, **0002**, **0003** — vocabulary + load-bearing decisions.
+4. **Issue #69 (§P2.1)** — your starting point. Body already updated with refined scope (skip bans/activities, drop voice_states, trivial backfill).
+
+## In-flight at handoff
+
+- **PR #116** (this retro doc) — open, awaiting GH Claude review + merge.
+- **#115** — open consolidated checklist for the silent-null FK audit across 10 remaining handlers (Ban, Invite, ScheduledEvent, StageInstance, Integration, AutoModRule, Channel, Role, Emoji, Sticker). One PR per handler, follow the §P1.9 / #114 pattern exactly. Not a Phase 2 blocker.
+
+Everything else from this session is **merged**:
+- #110 docs grilling, #111 §P1.9 hotfix, #113 backfill robustness, #114 PresenceEventHandler fix.
+
+## Phase 2 execution order (locked)
+
+1. **#69 §P2.1** — add `deleted_at_utc` to 10 entities, drop `voice_states`. Unblocks #70.
+2. **#70 §P2.5** — CHECK constraint `is_deleted ↔ deleted_at_utc IS NOT NULL`.
+3. **#71 §P2.2, #72 §P2.3, #73 §P2.4** — parallel-safe.
+4. **#74 §P2.6** — NOT NULL on Message FKs (depends on §P1.9 which is done + #61 which is merged).
+
+## Critical patterns to preserve
+
+The retro doc covers these in detail; quick pointers:
+
+- **Early-flush rule**: any handler that calls `RawEventLogService.SerializeAndLogAsync` and then any `*UpsertService` MUST `await db.SaveChangesAsync()` between them, or the staged raw event log is at risk on 23505 race. See `MessageEventHandler.cs:38`, `ThreadEventHandler.cs:31/81/128`, `PresenceEventHandler.cs:86`.
+- **Reference convention**: snowflakes in event tables, Guids in core entities (ADR-0002). §P2.3 drops Guid FKs from event tables (100% NULL in prod — vestigial).
+- **Soft-delete vs lifecycle-fact**: don't shoehorn `bans.is_active` or `activities.is_active` into the soft-delete convention (CONTEXT.md flagged ambiguity).
+- **Threads-as-channels** (ADR-0003): no separate `threads` table. Already realised by §P1.9.
+
+## User preferences worth remembering up-front
+
+In `~/.claude/projects/-Users-wiktorkowalski-dev-WojtusDiscord/memory/MEMORY.md` (auto-loaded), but the load-bearing ones for Phase 2:
+
+- **No data loss** in migrations. Before each one, state explicitly whether any meaningful data is lost (column drops, NULL backfills, etc.). Note "column loss, no info loss" when a JOIN preserves the info (relevant for §P2.3).
+- **Never test against prod DB**. Local Docker postgres for `dotnet run` smoke tests. Prod is read-only via direct psql (Docker `postgres:18` container — pattern is in this session's bash history, easy to crib).
+- **Bulk operations one-by-one with verification** — for issue/PR creation. Don't batch-script.
+- **Pre-deploy + post-deploy + post-backfill log baselines** — capture all three with `mcp__homelab__CountErrors` + `mcp__homelab__search_logs`. Most "errors after deploy" are actually old-container shutdown noise in the 7-second window before the new container comes up; cross-check timestamps before raising alarm.
+
+## Bot operational
+
+- Hosted at `https://wojtusdiscord.home.vicio.ovh` (admin endpoints under `/api/ops/`).
+- Prod DB at `192.168.1.12:5433` (creds in user's `.env`; container access via `docker run --rm postgres:18 psql -h 192.168.1.12 -p 5433 -U postgres -d discord_event_service`).
+- Container: `discord-event-service` (logs via `mcp__homelab__GetContainerLogs`).
+- Deploy: master push → GH Actions `Build and Deploy` workflow → dockge restarts the container.
+
+## Suggested skills for Phase 2 work
+
+- **`grill-with-docs`** if you need to challenge any assumption before writing code. The CONTEXT.md + ADRs are already populated, so the skill mostly *consults* them rather than building from scratch.
+- **`code-review`** (effort `medium`) before push on each Phase 2 PR. The user's pre-commit memory mandates it.
+- **`verify`** if you want to manually exercise a feature after deploy — useful for §P2.5 (verify the CHECK actually rejects bad inserts).
+- **`diagnose`** only if Phase 2 surfaces another live-DB bug like 2026-05-03. Otherwise overkill.
+- **Don't invoke `to-issues` for Phase 2** — the issues already exist with refined scope.
+
+## Pause points (user cadence)
+
+The user's `~/.claude/CLAUDE.md` defines the default cadence. The pause points relevant for Phase 2:
+
+1. Build green + code-review passes → commit + push + PR → cadence continues automatically through GH Claude review + comment addressing.
+2. **PAUSE** before `gh pr merge --squash --delete-branch`. Summarise + ask.
+3. After merge → `gh run watch` the deploy → ~30s wait → pull container logs over last ~5 min → surface anomalies (not just error counts; look for unexpected patterns).
+4. If a step fails (build red, review blocks, deploy fails) → STOP and surface, don't retry blindly.
+
+## What NOT to do
+
+- Don't fold the §P115 silent-null sweep into Phase 2 PRs. They're separate work.
+- Don't re-pick the OD#4 / threads / snowflake-vs-Guid decisions — they're ADR'd.
+- Don't write to `voice_states` in any Phase 2 PR — it's being dropped in §P2.1.
+- Don't merge any Phase 2 PR without explicit user approval at the pause point. The user's cadence is firm on this.

--- a/HANDOFF.md
+++ b/HANDOFF.md
@@ -46,8 +46,8 @@ In `~/.claude/projects/-Users-wiktorkowalski-dev-WojtusDiscord/memory/MEMORY.md`
 
 ## Bot operational
 
-- Hosted at `https://wojtusdiscord.home.vicio.ovh` (admin endpoints under `/api/ops/`).
-- Prod DB at `192.168.1.12:5433` (creds in user's `.env`; container access via `docker run --rm postgres:18 psql -h 192.168.1.12 -p 5433 -U postgres -d discord_event_service`).
+- Bot reachable via the user's homelab hostname (ask the user; not in this doc — admin endpoints are currently unauthenticated and the repo is public).
+- Prod DB: ask the user for the connection string. Read-only via `psql` from a throwaway `postgres:18` container; never run smoke tests against it.
 - Container: `discord-event-service` (logs via `mcp__homelab__GetContainerLogs`).
 - Deploy: master push → GH Actions `Build and Deploy` workflow → dockge restarts the container.
 

--- a/docs/phase-1-retro.md
+++ b/docs/phase-1-retro.md
@@ -1,0 +1,64 @@
+# Phase 1 retro — what we learned
+
+Captured 2026-05-22 after epic #53 Phase 1 + §P1.9 hotfix shipped.
+
+## The incident that surfaced the systemic bug
+
+**2026-05-03**: 69 messages persisted with `channel_id IS NULL` over a 5h26m window. Phase 1 had landed `§P1.4` transactions (#61) two weeks earlier, but transactions didn't help — the handler **didn't throw**, it silently wrote `channel_id = null`:
+
+```csharp
+var channel = await db.Channels.FirstOrDefaultAsync(c => c.DiscordId == e.Channel.Id);
+// ...
+ChannelId = channel?.Id,  // ← silently null
+```
+
+The channel in question was a thread DSharpPlus emitted `ThreadCreated` for, but `ThreadEventHandler` only wrote to `thread_events` — never upserted the thread into `channels`. So the message handler's lookup found nothing, and the FK silently went `NULL`.
+
+The same silent-null pattern existed in ~15 other handlers. The 2026-05-03 incident only hit `messages` because threads are created on the fly; other entities (guilds, users, regular channels) are usually known at lookup time.
+
+## Three load-bearing decisions captured as ADRs
+
+- **ADR-0001** drop `voice_states` snapshot table. Live audit found it empty for 2.7 months despite 743 events — the upsert path had been broken since day one and nobody missed it. Current state derivable from `voice_state_events` via `DISTINCT ON`.
+- **ADR-0002** snowflakes canonical in event tables, Guids canonical in core entities. Confirmed by a live probe: **100%** of event-table `Guid?` FK columns are NULL. Vestigial. Drop them in §P2.3.
+- **ADR-0003** threads are channels (`type ∈ {10, 11, 12}`). Not a separate `threads` table. `ThreadEventHandler` upserts into `channels` so messages always have a valid `channel_id`.
+
+## The "early-flush" pattern — load-bearing for any handler
+
+The §P1.9 fix introduced `ChannelUpsertService` + `GuildUpsertService` with the canonical `ExecuteUpdate → 23505-retry-with-Add` shape (mirrors `UserService`). The catch path calls `ChangeTracker.Clear()` to drop the failed-insert entity. But if the handler had previously staged a `RawEventLog` row via `SerializeAndLogAsync` (which doesn't save, just adds to tracker), the `Clear()` discards it too — the raw event log is permanently lost.
+
+**Rule**: in any handler that calls `SerializeAndLogAsync` and then any upsert service, add an explicit `await db.SaveChangesAsync()` **between** them. Otherwise the staged raw log is at risk on any 23505 race.
+
+The pattern landed in MessageEventHandler, ThreadEventHandler (×3 paths), and PresenceEventHandler. Apply it to every handler in #115's audit list.
+
+## Backfill ergonomics
+
+- `POST /api/ops/backfill-thread-channels` is the operator's hand-tool. Idempotent (matches `WHERE channel_id IS NULL`). Returns counts so the operator can sanity-check.
+- For the 2026-05-03 orphans the raw event JSON was stub-fallback (pre-#99 serializer bug — `{"error": "Serialization failed"...}`). Match by `raw_event_logs.channel_discord_id` (column, not JSON) within ±2s of the orphan's `first_seen_utc`. For future orphans with intact JSON the hybrid resolver added in #113 prefers a deterministic `event_json->'message'->>'id'` match.
+- **Placeholder policy**: only insert a `[unknown thread …]` row if Discord API returns `NotFoundException` / `UnauthorizedException`. Let transient errors propagate so the operator can retry — don't permanently materialise a 429 as a placeholder.
+- One thing we missed initially: the original §P1.9 backfill picked `db.Guilds.First()` as the placeholder's guild — fine for single-guild bot but wrong-by-construction. #113 fix derives guild per-orphan from the matched raw event's `guild_discord_id`.
+
+## Surprises worth remembering
+
+- The **Feb-15 private thread** that already existed in `channels` (`1472568996745449614`) got there via a **guild-channels backfill on 2026-04-26**, two months after the thread was created — not via the original ThreadCreated handler. That's why "some threads ended up in channels, most didn't" — purely incidental, depending on whether they were still visible to the listing API by the next backfill.
+- Discord let us re-fetch both archived May-3 threads via `GetChannelAsync` even though they were no longer in the listing API. Recovered both with real names + parents. We allocated `placeholders=0`.
+- The Feb-15 thread's `type` changed from `12` (PrivateThread) to `11` (PublicThread) after we re-fetched it in #113. Either Discord made it public sometime in the past 3 months, or our original ThreadCreated payload stored the wrong type. Either way, refreshing from live API is the right behaviour.
+- Half the bot-downtime infrastructure was landed (#64, 2026-04-27) but not wired (#65, 2026-05-12) when 2026-05-03 incident happened. The "no downtime row exists in that window" was therefore *not* evidence the bot was up — just evidence the tracking wasn't recording yet. Be careful with that argument in future investigations.
+
+## Phase 2 sequencing locked
+
+After §P1.9 (#109) landed:
+
+1. **§P2.1 (#69)** — add `deleted_at_utc` to 10 entities + drop `voice_states`. Unblocks §P2.5.
+2. **§P2.5 (#70)** — CHECK constraint `is_deleted ↔ deleted_at_utc IS NOT NULL`.
+3. **§P2.2 (#71), §P2.3 (#72), §P2.4 (#73)** — parallel-safe.
+4. **§P2.6 (#74)** — NOT NULL on Message FKs. Pre-requires §P1.9 (now done) + #61.
+
+Open follow-ups: **#112** (hybrid JSON match — done in #113), **#115** (silent-null FK audit across 10 remaining handlers; PR #114 did Presence as the first).
+
+## Open decisions still on Epic #53
+
+- **OD#1** historical-gap backfill — not blocking; revisit after Phase 2.
+- **OD#5** `failed_events` replay strategy — affects §P4.2 only.
+- **OD#6** empty-content normalization — affects §P4.5 only.
+
+OD#2 (no dedup), OD#3 (filter widened in #63), OD#4 (drop voice_states, ADR-0001) are resolved.

--- a/docs/phase-1-retro.md
+++ b/docs/phase-1-retro.md
@@ -32,7 +32,7 @@ The pattern landed in MessageEventHandler, ThreadEventHandler (×3 paths), and P
 
 ## Backfill ergonomics
 
-- `POST /api/ops/backfill-thread-channels` is the operator's hand-tool. Idempotent (matches `WHERE channel_id IS NULL`). Returns counts so the operator can sanity-check.
+- The thread-channel backfill endpoint added in §P1.9 is the operator's hand-tool. Idempotent (matches `WHERE channel_id IS NULL`). Returns counts so the operator can sanity-check. Exact path lives in `Endpoints/OpsEndpoints.cs` and is intentionally not named here — admin endpoints are presently unauthenticated, and this is a public repo.
 - For the 2026-05-03 orphans the raw event JSON was stub-fallback (pre-#99 serializer bug — `{"error": "Serialization failed"...}`). Match by `raw_event_logs.channel_discord_id` (column, not JSON) within ±2s of the orphan's `first_seen_utc`. For future orphans with intact JSON the hybrid resolver added in #113 prefers a deterministic `event_json->'message'->>'id'` match.
 - **Placeholder policy**: only insert a `[unknown thread …]` row if Discord API returns `NotFoundException` / `UnauthorizedException`. Let transient errors propagate so the operator can retry — don't permanently materialise a 429 as a placeholder.
 - One thing we missed initially: the original §P1.9 backfill picked `db.Guilds.First()` as the placeholder's guild — fine for single-guild bot but wrong-by-construction. #113 fix derives guild per-orphan from the matched raw event's `guild_discord_id`.


### PR DESCRIPTION
## Summary

Two session-doc artifacts for the next agent picking up Phase 2:

- **`docs/phase-1-retro.md`** — permanent record of what we learned during epic #53 Phase 1 + §P1.9 hotfix (2026-05-03 incident root cause, silent-null pattern as a class, early-flush rule for upsert-using handlers, backfill placeholder policy, Feb-15 thread provenance, downtime infra timing gap).
- **`HANDOFF.md`** — one-shot doc at repo root. Tells the next agent which durable artefacts to read in what order, captures in-flight PR/issue state, Phase 2 sequencing, critical patterns, user preferences worth front-loading. **Self-destruct directive in the header** — the consumer is instructed to delete the file after reading so a future handoff isn't confused with this one.

The retro and the handoff don't overlap — retro is "what happened, why", handoff is "what to do next, in what order, with what context".

## Test plan

- [ ] Docs only, no build/CI impact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)