### PR TITLE
hotfix: bypass DSharpPlus recursive converter to stop crash loop

### DIFF
--- a/src/DiscordEventService/Services/RawEventLogService.cs
+++ b/src/DiscordEventService/Services/RawEventLogService.cs
@@ -2,14 +2,28 @@ using DiscordEventService.Data;
 using DiscordEventService.Data.Entities.Events;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Serialization;
+using System.Reflection;
 
 namespace DiscordEventService.Services;
 
 public class RawEventLogService(DiscordDbContext dbContext, ILogger<RawEventLogService> logger)
 {
+    // #107 switched to Newtonsoft to fix System.Text.Json's
+    // KeyNotFoundException('deprecated') on DSharpPlus's [JsonProperty]-tagged
+    // properties (DiscordVoiceRegion.IsDeprecated). But Newtonsoft, when it
+    // finds [JsonConverter(SnowflakeArrayAsDictionaryJsonConverter)] on a
+    // DSharpPlus property, calls that converter's WriteJson which re-enters
+    // the same serializer → unbounded recursion → CLR StackOverflow
+    // (uncatchable) → container crash whenever a message-shaped event arrives.
+    //
+    // Fix: keep Newtonsoft (needed for [JsonProperty] handling) but use a
+    // contract resolver that strips that specific converter from the metadata,
+    // letting Newtonsoft fall back to default Dictionary serialization (the
+    // resulting JSON shape is a dict of snowflakes instead of an array — fine
+    // for raw_event_logs which is replay/debug, not a Discord-wire payload).
     private static readonly JsonSerializerSettings JsonSettings = new()
     {
-        ContractResolver = new CamelCasePropertyNamesContractResolver(),
+        ContractResolver = new BypassRecursiveConverterResolver(),
         ReferenceLoopHandling = ReferenceLoopHandling.Ignore,
         NullValueHandling = NullValueHandling.Ignore,
         MaxDepth = 32,
@@ -81,5 +95,33 @@ public class RawEventLogService(DiscordDbContext dbContext, ILogger<RawEventLogS
         var json = SerializeEvent(eventArgs);
         await LogRawEventAsync(eventType, json, guildId, channelId, userId);
         return json;
+    }
+
+    private sealed class BypassRecursiveConverterResolver : CamelCasePropertyNamesContractResolver
+    {
+        // DSharpPlus's converter re-enters serialization with the same settings
+        // (including itself as a [JsonConverter] attribute), causing unbounded
+        // recursion. Strip it so the default object/dictionary serializer runs.
+        private const string ProblemConverterName = "SnowflakeArrayAsDictionaryJsonConverter";
+
+        protected override JsonProperty CreateProperty(MemberInfo member, MemberSerialization memberSerialization)
+        {
+            var property = base.CreateProperty(member, memberSerialization);
+            if (property.Converter?.GetType().Name == ProblemConverterName)
+                property.Converter = null;
+            if (property.MemberConverter?.GetType().Name == ProblemConverterName)
+                property.MemberConverter = null;
+            if (property.ItemConverter?.GetType().Name == ProblemConverterName)
+                property.ItemConverter = null;
+            return property;
+        }
+
+        protected override JsonContract CreateContract(Type objectType)
+        {
+            var contract = base.CreateContract(objectType);
+            if (contract.Converter?.GetType().Name == ProblemConverterName)
+                contract.Converter = null;
+            return contract;
+        }
     }
 }


### PR DESCRIPTION
**URGENT — bot has been crash-looping for 10 days, dropping live message/reaction/typing/voice/member events.**

## Symptom

Live `MessageCreated`, `MessageUpdated`, `MessageDeleted`, `MessageReactionAdded`, `TypingStarted`, `VoiceStateUpdated`, `GuildMemberUpdated` events have been silent in prod since **2026-05-13 20:01:43 UTC** (10 days). `PresenceUpdated` kept working (does not transit `Guild.VoiceRegions`, doesn't hit the recursive converter).

Evidence: 3 `Stack overflow.` fatal logs in the last hour at 13:08:20, 13:09:03, 13:09:59 — each followed by container restart. New messages only landed in `messages` table via `MessagesBackfillJob` on each crash-recovery startup.

## Root cause

#107 switched `RawEventLogService` from `System.Text.Json` to `Newtonsoft.Json` to fix STJ's `KeyNotFoundException('deprecated')` on DSharpPlus's `[JsonProperty]`-tagged properties (`DiscordVoiceRegion.IsDeprecated`).

Newtonsoft, when it finds `[JsonConverter(SnowflakeArrayAsDictionaryJsonConverter)]` on a DSharpPlus type, calls that converter's `WriteJson` — which re-enters the same `JsonSerializer` with the same settings → unbounded recursion → **CLR StackOverflow (uncatchable)** → container crash whenever any message-shaped event arrives.

Stack trace from prod confirms: ~30 recurring `DSharpPlus.Net.Serialization.SnowflakeArrayAsDictionaryJsonConverter.WriteJson` frames just before each `Stack overflow.`.

## Fix

Keep Newtonsoft.Json (still required to handle DSharpPlus's `[JsonProperty]` attributes — the original #107 driver). Add a `BypassRecursiveConverterResolver : CamelCasePropertyNamesContractResolver` that strips `SnowflakeArrayAsDictionaryJsonConverter` from `Converter` / `MemberConverter` / `ItemConverter` / `Contract.Converter` slots. Newtonsoft then falls back to default Dictionary serialization.

The resulting raw_event_logs JSON shape changes for affected properties (dict-of-snowflakes instead of array-of-values), which is fine — `raw_event_logs` is for replay/debug, not a Discord-wire payload.

## Verification

**Local** — ran the bot against a dev guild with this fix; sent a test message; observed:
- `INSERT INTO messages` succeeded
- `INSERT INTO raw_event_logs` succeeded, **17,410 bytes of real payload** (vs the 144-byte error stubs that landed pre-#107)
- `flags = 0` (correct — no special flags on the test message)
- **No `Stack overflow.`**, no `Failed to serialize`, no `Error handling message`

## Test plan

- [x] `dotnet build` green
- [x] Local: bot connects to dev guild, processes presence + message events without SO
- [x] Local: live `MessageCreated` writes a real (17KB) raw_event_logs row
- [ ] **Post-deploy: confirm no `Stack overflow.` in container logs over 15 min**
- [ ] Post-deploy: send a test message in prod, confirm `MessageCreated` raw_event_logs row + `messages` row both land
- [ ] Post-deploy: investigate + backfill lost data from the 10-day window

🤖 Generated with [Claude Code](https://claude.com/claude-code)