### PR TITLE
feat: MessageEventType.Backfilled marker (#122)

### DIFF
--- a/src/DiscordEventService/Data/Entities/Events/MessageEventEntity.cs
+++ b/src/DiscordEventService/Data/Entities/Events/MessageEventEntity.cs
@@ -7,7 +7,8 @@ public enum MessageEventType
     Created = 0,
     Updated = 1,
     Deleted = 2,
-    BulkDeleted = 3
+    BulkDeleted = 3,
+    Backfilled = 4
 }
 
 public class MessageEventEntity

--- a/src/DiscordEventService/Jobs/MessagesBackfillJob.cs
+++ b/src/DiscordEventService/Jobs/MessagesBackfillJob.cs
@@ -1,6 +1,7 @@
 using System.Text.Json;
 using DiscordEventService.Data;
 using DiscordEventService.Data.Entities.Core;
+using DiscordEventService.Data.Entities.Events;
 using DiscordEventService.Services;
 using DSharpPlus;
 using DSharpPlus.Entities;
@@ -214,6 +215,28 @@ public class MessagesBackfillJob(
                             Flags = (int)(message.Flags ?? 0),
                             CreatedAtUtc = message.Timestamp.UtcDateTime,
                             EditedAtUtc = message.EditedTimestamp?.UtcDateTime
+                        });
+
+                        // Symmetric provenance marker: every backfilled message gets a
+                        // message_events row with EventType=Backfilled. Mirrors
+                        // ReactionsBackfillJob's ReactionEventType.Backfilled pattern.
+                        // RawEventJson is null because backfill came via REST, not gateway.
+                        db.MessageEvents.Add(new MessageEventEntity
+                        {
+                            MessageDiscordId = message.Id,
+                            ChannelDiscordId = channel.Id,
+                            AuthorDiscordId = message.Author.Id,
+                            GuildDiscordId = guildEntity.DiscordId,
+                            EventType = MessageEventType.Backfilled,
+                            Content = message.Content,
+                            HasAttachments = message.Attachments.Count > 0,
+                            HasEmbeds = message.Embeds.Count > 0,
+                            ReplyToMessageDiscordId = message.ReferencedMessage?.Id,
+                            AttachmentsJson = attachmentsJson,
+                            EmbedsJson = embedsJson,
+                            EventTimestampUtc = message.Timestamp.UtcDateTime,
+                            ReceivedAtUtc = DateTime.UtcNow,
+                            RawEventJson = null
                         });
 
                         checkpoint.ProcessedCount++;


### PR DESCRIPTION
Closes #122.

## Summary

- Add `Backfilled = 4` to `MessageEventType` enum.
- `MessagesBackfillJob` now writes a paired `message_events` row (with `event_type = 4`) every time it inserts a new `MessageEntity`. Mirrors `ReactionsBackfillJob`'s existing `ReactionEventType.Backfilled` pattern.

## Why

Surfaced in #121 postmortem: classifying live-vs-backfilled messages from the 10-day blackout window required a fragile `NOT EXISTS (SELECT 1 FROM message_events WHERE event_type = 0)` subquery. With this PR it's simply `WHERE event_type = 4`.

## Data-loss check

No loss. Pure additive (new enum value + new rows on future backfills). Existing 3000+ backfilled `messages` rows stay unmarked (pre-this-PR). Knowable as "any messages row with no matching message_events row" if needed later.

## Test plan

- [x] `dotnet build` green
- [ ] Post-deploy: trigger a backfill OR wait for next auto-backfill; verify new `messages` rows have matching `message_events` row with `event_type = 4`
- [ ] Verify live `MessageCreated` path unchanged (still writes `event_type = 0`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)