### PR TITLE
diag: instrument MessagesBackfillJob per-channel/per-batch (#124)

### DIFF
--- a/src/DiscordEventService/Jobs/MessagesBackfillJob.cs
+++ b/src/DiscordEventService/Jobs/MessagesBackfillJob.cs
@@ -138,10 +138,20 @@ public class MessagesBackfillJob(
 
         ulong? beforeId = checkpoint.LastProcessedId;
         bool hasMore = true;
+        int batchNum = 0;
+        int totalInserted = 0;
+        string exitReason = "unknown";
+
+        // #124 diagnostic: trace exactly why per-channel loops terminated at ~one batch
+        // in auto-startup runs but went deep when manually triggered.
+        logger.LogInformation(
+            "[bf-diag] Channel {ChannelName} ({ChannelId}) starting; initial beforeId={BeforeId}",
+            channel.Name, channel.Id, beforeId);
 
         while (hasMore)
         {
             cancellationToken.ThrowIfCancellationRequested();
+            batchNum++;
 
             List<DiscordMessage> messages;
             try
@@ -160,20 +170,32 @@ public class MessagesBackfillJob(
             {
                 logger.LogWarning("No permission to read messages in channel {ChannelId}", channel.Id);
                 await RecordErrorAsync(db, checkpoint, ex);
+                exitReason = "UnauthorizedException";
                 break;
             }
             catch (DSharpPlus.Exceptions.NotFoundException ex)
             {
                 logger.LogWarning("Channel {ChannelId} not found (may have been deleted)", channel.Id);
                 await RecordErrorAsync(db, checkpoint, ex);
+                exitReason = "NotFoundException";
                 break;
             }
 
             if (messages.Count == 0)
             {
+                logger.LogInformation(
+                    "[bf-diag] Channel {ChannelName} batch {BatchNum}: API returned 0 messages with beforeId={BeforeId} — terminating loop",
+                    channel.Name, batchNum, beforeId);
                 hasMore = false;
+                exitReason = "API returned 0";
                 break;
             }
+
+            logger.LogInformation(
+                "[bf-diag] Channel {ChannelName} batch {BatchNum}: got {Count} messages, newest={NewestId} ({NewestTs:O}), oldest={OldestId} ({OldestTs:O})",
+                channel.Name, batchNum, messages.Count,
+                messages.First().Id, messages.First().Timestamp.UtcDateTime,
+                messages.Last().Id, messages.Last().Timestamp.UtcDateTime);
 
             foreach (var message in messages)
             {
@@ -240,6 +262,7 @@ public class MessagesBackfillJob(
                         });
 
                         checkpoint.ProcessedCount++;
+                        totalInserted++;
                     }
                 }
                 catch (Exception ex)
@@ -260,11 +283,16 @@ public class MessagesBackfillJob(
                 messages.Min(m => m.Timestamp).UtcDateTime < afterTimestampUtc.Value)
             {
                 hasMore = false;
+                exitReason = $"afterTimestampUtc reached ({afterTimestampUtc:O})";
                 break;
             }
 
             // Respect rate limits
             await Task.Delay(DelayBetweenBatches, cancellationToken);
         }
+
+        logger.LogInformation(
+            "[bf-diag] Channel {ChannelName} ({ChannelId}) done: batches={BatchCount}, inserted={Inserted}, exit_reason={ExitReason}, final_beforeId={BeforeId}",
+            channel.Name, channel.Id, batchNum, totalInserted, exitReason, beforeId);
     }
 }


### PR DESCRIPTION
Part of #124.

## Summary

Pure observability change — adds `[bf-diag]` Info logs to `MessagesBackfillJob.BackfillChannelMessagesAsync` so the next backfill run reveals where the per-channel loop terminates early:

- **Start of channel**: name, ID, initial `beforeId` cursor
- **Per batch**: batch number, count, newest + oldest message ID + Discord timestamp
- **End of channel**: batch count, inserted count, exit reason, final `beforeId`

No logic changes. Pure log additions.

## Why

Discovered in #123 verification: auto-startup `MessagesBackfillJob` runs had been stopping at ~one batch (100 messages) per channel, while a manual `POST /api/backfill/{guildId}` walked all the way to channel creation in 2017 — recovering 26,431 historical messages. Root cause unknown; #124 lists hypotheses (Hangfire timeout, cancellation propagation, DSharpPlus rate-limit edge case, etc).

These logs will surface which loop iteration terminated, with what `beforeId`, and whether the next API call genuinely returned 0 or if some other path bailed.

## Test plan

- [x] `dotnet build` green
- [ ] Post-deploy: trigger `POST /api/backfill/341531063920754700`, grep `[bf-diag]` over the next ~5 min of container logs
- [ ] Confirm log structure is useful + open follow-up PR with the actual fix once root cause identified

🤖 Generated with [Claude Code](https://claude.com/claude-code)