### PR TITLE
feat: long-gap full backfill + weekly periodic safety net (#124)

### DIFF
--- a/src/DiscordEventService/Jobs/PeriodicFullBackfillJob.cs
+++ b/src/DiscordEventService/Jobs/PeriodicFullBackfillJob.cs
@@ -1,0 +1,48 @@
+using DiscordEventService.Data;
+using DiscordEventService.Data.Entities.Core;
+using Microsoft.EntityFrameworkCore;
+
+namespace DiscordEventService.Jobs;
+
+/// <summary>
+/// Weekly safety-net backfill. Reconnect-backfill is windowed by `lastAlive`,
+/// so anything older than the most recent crash/reconnect can be missed by it
+/// (see #124 postmortem). This job walks every known guild's full history each
+/// week with `afterTimestampUtc = null` so any drift is eventually caught.
+///
+/// Skips guilds with an InProgress checkpoint to avoid stepping on the
+/// reconnect path or the operator-triggered /api/backfill endpoint.
+/// </summary>
+public class PeriodicFullBackfillJob(
+    IServiceScopeFactory scopeFactory,
+    ILogger<PeriodicFullBackfillJob> logger)
+{
+    public async Task ExecuteAsync()
+    {
+        using var scope = scopeFactory.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<DiscordDbContext>();
+        var orchestrator = scope.ServiceProvider.GetRequiredService<GuildBackfillOrchestrator>();
+
+        var guildIds = await db.Guilds.Select(g => g.DiscordId).ToListAsync();
+        var inProgress = await db.BackfillCheckpoints
+            .Where(c => c.Status == BackfillStatus.InProgress)
+            .Select(c => c.GuildDiscordId)
+            .Distinct()
+            .ToListAsync();
+        var inProgressSet = inProgress.ToHashSet();
+
+        foreach (var guildId in guildIds)
+        {
+            if (inProgressSet.Contains(guildId))
+            {
+                logger.LogInformation(
+                    "Periodic full backfill skipped for guild {GuildId}: backfill already in progress",
+                    guildId);
+                continue;
+            }
+
+            logger.LogInformation("Periodic full backfill enqueued for guild {GuildId}", guildId);
+            orchestrator.StartBackfill(guildId);
+        }
+    }
+}

--- a/src/DiscordEventService/Jobs/PeriodicFullBackfillJob.cs
+++ b/src/DiscordEventService/Jobs/PeriodicFullBackfillJob.cs
@@ -23,7 +23,13 @@ public class PeriodicFullBackfillJob(
         var db = scope.ServiceProvider.GetRequiredService<DiscordDbContext>();
         var orchestrator = scope.ServiceProvider.GetRequiredService<GuildBackfillOrchestrator>();
 
-        var guildIds = await db.Guilds.Select(g => g.DiscordId).ToListAsync();
+        // Only currently-joined guilds. Guilds we've left would fail at
+        // GetGuildAsync in RolesBackfillJob, marking the checkpoint Failed
+        // every Sunday.
+        var guildIds = await db.Guilds
+            .Where(g => g.LeftAtUtc == null)
+            .Select(g => g.DiscordId)
+            .ToListAsync();
         var inProgress = await db.BackfillCheckpoints
             .Where(c => c.Status == BackfillStatus.InProgress)
             .Select(c => c.GuildDiscordId)

--- a/src/DiscordEventService/Program.cs
+++ b/src/DiscordEventService/Program.cs
@@ -191,6 +191,7 @@ builder.Services.AddScoped<MembersBackfillJob>();
 builder.Services.AddScoped<MessagesBackfillJob>();
 builder.Services.AddScoped<ReactionsBackfillJob>();
 builder.Services.AddScoped<GuildBackfillOrchestrator>();
+builder.Services.AddScoped<PeriodicFullBackfillJob>();
 
 var app = builder.Build();
 
@@ -228,6 +229,13 @@ app.MapHealthChecks("/health");
 
 // Hangfire dashboard
 app.MapHangfireDashboard("/hangfire");
+
+// Weekly full backfill safety net — catches anything reconnect-backfill misses
+// due to its windowed semantics. See #124 postmortem.
+RecurringJob.AddOrUpdate<PeriodicFullBackfillJob>(
+    "periodic-full-backfill",
+    j => j.ExecuteAsync(),
+    "0 3 * * 0"); // Sundays 03:00 UTC
 
 // Backfill API
 app.MapBackfillEndpoints();

--- a/src/DiscordEventService/Services/EventHandlers/SocketLifecycleHandler.cs
+++ b/src/DiscordEventService/Services/EventHandlers/SocketLifecycleHandler.cs
@@ -16,6 +16,13 @@ public class SocketLifecycleHandler(
 {
     private static readonly TimeSpan ReconnectGapThreshold = TimeSpan.FromSeconds(30);
     private static readonly TimeSpan ReconnectBackfillBuffer = TimeSpan.FromMinutes(5);
+    // When the bot was down longer than this, the windowed reconnect-backfill
+    // (which scrolls only until messages older than `lastAlive - buffer`) isn't
+    // enough — switch to a full deep walk (no afterTimestampUtc) so all messages
+    // sent during the outage land in the DB. See #124 postmortem: a 10-day
+    // outage went unnoticed in part because reconnect-backfill kept short-window
+    // backfilling on each crash-restart, never walking far enough back.
+    private static readonly TimeSpan FullBackfillGapThreshold = TimeSpan.FromHours(24);
 
     public async Task HandleEventAsync(DiscordClient sender, SocketClosedEventArgs e)
     {
@@ -109,6 +116,7 @@ public class SocketLifecycleHandler(
             // Per user guidance: scan all known channels in every guild, overshoot
             // the window rather than risk missing events.
             var afterTimestamp = lastAlive.Value - ReconnectBackfillBuffer;
+            var useFullBackfill = gap >= FullBackfillGapThreshold;
 
             var inProgressGuilds = await db.BackfillCheckpoints
                 .Where(c => c.Status == BackfillStatus.InProgress)
@@ -127,10 +135,20 @@ public class SocketLifecycleHandler(
                     continue;
                 }
 
-                logger.LogInformation(
-                    "Reconnect backfill enqueued for guild {GuildId} after gap {Gap:c} (afterTimestampUtc={After:O})",
-                    guildId, gap, afterTimestamp);
-                orchestrator.EnqueueBackfillFrom(guildId, afterTimestamp);
+                if (useFullBackfill)
+                {
+                    logger.LogInformation(
+                        "Full backfill enqueued for guild {GuildId} after long gap {Gap:c} (>= {Threshold:c}); ignoring afterTimestampUtc",
+                        guildId, gap, FullBackfillGapThreshold);
+                    orchestrator.StartBackfill(guildId);
+                }
+                else
+                {
+                    logger.LogInformation(
+                        "Reconnect backfill enqueued for guild {GuildId} after gap {Gap:c} (afterTimestampUtc={After:O})",
+                        guildId, gap, afterTimestamp);
+                    orchestrator.EnqueueBackfillFrom(guildId, afterTimestamp);
+                }
             }
         }
         catch (Exception ex)


### PR DESCRIPTION
Closes #124.

## Summary

Two complementary fixes for the design gap exposed in #124 (windowed reconnect-backfill missed 26k+ historical messages because every reconnect was scoped by a recent \`lastAlive\`).

### 1. Long-gap detection (real-time)

\`SocketLifecycleHandler.GuildDownloadCompleted\` now branches on outage length:

- gap < \`ReconnectGapThreshold\` (30s) → skip backfill (no-op reconnect)
- gap < \`FullBackfillGapThreshold\` (24h) → \`EnqueueBackfillFrom(afterTimestamp)\` (windowed, existing behavior)
- gap >= \`FullBackfillGapThreshold\` → \`StartBackfill(guildId)\` (full deep walk, no \`afterTimestampUtc\`)

So if the bot was down >24h, the next reconnect performs a deep walk instead of accepting whatever short window reconnect-backfill would have used.

### 2. Weekly periodic full backfill (drift catch)

New \`PeriodicFullBackfillJob\` registered as a Hangfire recurring job at Sundays 03:00 UTC. Iterates every known guild, calls \`orchestrator.StartBackfill\` per guild, skips guilds with \`InProgress\` checkpoints to avoid colliding with reconnect-driven or operator-triggered runs.

Catches anything reconnect-backfill misses regardless of cause (bug, permission change, etc).

## Why both

- (1) reacts to a specific outage. Useful when the outage was significant.
- (2) covers the slow-drift case where reconnect-backfill quietly under-walks for non-outage reasons (e.g. a bug like the original #107 SO + reconnect-buffer combo).

## Data-loss check

No loss. Both paths just trigger backfills (which only \`INSERT\` missing rows). Adding rows, never removing or changing.

## Test plan

- [x] \`dotnet build\` green
- [ ] Post-deploy: container restart simulates a fresh \`GuildDownloadCompleted\`. Since \`lastAlive\` will be just minutes ago, gap < 24h, the existing \`EnqueueBackfillFrom\` path is exercised. Expected: same windowed behavior as today.
- [ ] Long-gap path can't be exercised without a real 24h+ outage. Code is straightforward (single \`if\` branch); verified by review.
- [ ] Periodic job: confirm \`/hangfire\` dashboard shows the \`periodic-full-backfill\` recurring job registered with cron \`0 3 * * 0\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)