### PR TITLE
feat: ChannelType.Unknown fallback for enum drift safety (§P2.2, #71)

### DIFF
--- a/src/DiscordEventService/Data/Entities/Core/ChannelEntity.cs
+++ b/src/DiscordEventService/Data/Entities/Core/ChannelEntity.cs
@@ -41,6 +41,12 @@ public class ChannelEntity : ITimestamped
 
 public enum ChannelType
 {
+    // Sentinel for Discord-side types we don't yet model. Direct casts
+    // ((ChannelType)channel.Type) preserve the raw int regardless of whether
+    // it's a known value, but downstream switches and mappers need a name to
+    // route on. Anything mapped via MapChannelType that isn't recognized
+    // becomes Unknown and logs a warning so drift is visible. See §P2.2 / #71.
+    Unknown = -1,
     Text = 0,
     Private = 1,
     Voice = 2,

--- a/src/DiscordEventService/Services/EventHandlers/GuildEventHandler.cs
+++ b/src/DiscordEventService/Services/EventHandlers/GuildEventHandler.cs
@@ -242,7 +242,7 @@ public class GuildEventHandler(IServiceScopeFactory scopeFactory, ILogger<GuildE
         }
     }
 
-    private static async Task UpsertChannelsAndRolesAsync(DiscordDbContext db, DiscordGuild guild, Guid guildGuid)
+    private async Task UpsertChannelsAndRolesAsync(DiscordDbContext db, DiscordGuild guild, Guid guildGuid)
     {
         // Batch load existing channels
         var channelIds = guild.Channels.Keys.ToList();
@@ -325,9 +325,14 @@ public class GuildEventHandler(IServiceScopeFactory scopeFactory, ILogger<GuildE
         }
     }
 
-    private static ChannelType MapChannelType(DiscordChannelType discordType)
+    private ChannelType MapChannelType(DiscordChannelType discordType)
     {
-        return discordType switch
+        // Add new DSharpPlus channel types here as they appear. Anything not
+        // listed becomes Unknown (with a warning log) instead of silently
+        // collapsing to Text. The int value is still preserved at the storage
+        // layer via (ChannelType)channel.Type casts elsewhere — Unknown is
+        // just the label.
+        var mapped = discordType switch
         {
             DiscordChannelType.Text => ChannelType.Text,
             DiscordChannelType.Private => ChannelType.Private,
@@ -339,7 +344,18 @@ public class GuildEventHandler(IServiceScopeFactory scopeFactory, ILogger<GuildE
             DiscordChannelType.PublicThread => ChannelType.PublicThread,
             DiscordChannelType.PrivateThread => ChannelType.PrivateThread,
             DiscordChannelType.Stage => ChannelType.Stage,
-            _ => ChannelType.Text
+            DiscordChannelType.GuildForum => ChannelType.Forum,
+            DiscordChannelType.GuildMedia => ChannelType.Media,
+            _ => ChannelType.Unknown
         };
+
+        if (mapped == ChannelType.Unknown)
+        {
+            logger.LogWarning(
+                "Unknown DiscordChannelType={DiscordType} (int={Int}); mapping to ChannelType.Unknown",
+                discordType, (int)discordType);
+        }
+
+        return mapped;
     }
 }


### PR DESCRIPTION
Closes #71.

## Summary

- Add `Unknown = -1` to `ChannelType` enum.
- Replace the silent `_ => ChannelType.Text` default in `GuildEventHandler.MapChannelType` with `_ => ChannelType.Unknown` + Warning log.
- Fill in the previously-missing `GuildForum → Forum` and `GuildMedia → Media` mappings.

## Why

If Discord adds a new channel type (or reuses an int we haven't mapped), the old code silently classified it as `Text` and continued. The new code emits a Warning log naming the unmapped `DiscordChannelType` and its int — so drift becomes visible in container logs instead of being silently miscategorized.

## Data-loss check

No loss. No migration. `channels.type` is `integer`; direct `(ChannelType)channel.Type` casts elsewhere preserve the raw int regardless of whether the value has a name. `Unknown` is just a label.

## Notes

- `DSharpPlus.DiscordChannelType.GuildDirectory` doesn't exist in the 5.0 nightly we use, so that entity value stays defined but isn't reachable from `MapChannelType` today.
- Other `(ChannelType)channel.Type` cast sites (`ChannelUpsertService`, `ChannelsBackfillJob`, `ChannelEventHandler`) already preserve the int via direct casts and don't need changes — they'd just yield an unnamed enum value for unknown ints. Consolidating those into the same mapper is a future cleanup; out of scope here.

## Test plan

- [x] `dotnet build` green
- [ ] Post-deploy: existing channels with known types continue to land as before; the Warning log fires if/when an unknown type appears

🤖 Generated with [Claude Code](https://claude.com/claude-code)