### PR TITLE
feat: messages.{guild_id,channel_id,author_id} NOT NULL with FK Restrict (§P2.6, #74)

### DIFF
--- a/src/DiscordEventService/Data/DiscordDbContext.cs
+++ b/src/DiscordEventService/Data/DiscordDbContext.cs
@@ -180,6 +180,27 @@ public class DiscordDbContext(DbContextOptions<DiscordDbContext> options) : DbCo
             .Property(m => m.EmbedsJson)
             .HasColumnType("jsonb");
 
+        // §P2.6 / #74: messages.guild_id/channel_id/author_id are NOT NULL FKs,
+        // but we never hard-delete guilds/channels/users — they soft-delete with
+        // is_deleted+deleted_at_utc. Restrict (vs the EF default of Cascade)
+        // protects message history if a delete ever does happen (would surface
+        // as a constraint violation rather than silently nuking messages).
+        modelBuilder.Entity<MessageEntity>()
+            .HasOne(m => m.Guild)
+            .WithMany()
+            .HasForeignKey(m => m.GuildId)
+            .OnDelete(DeleteBehavior.Restrict);
+        modelBuilder.Entity<MessageEntity>()
+            .HasOne(m => m.Channel)
+            .WithMany()
+            .HasForeignKey(m => m.ChannelId)
+            .OnDelete(DeleteBehavior.Restrict);
+        modelBuilder.Entity<MessageEntity>()
+            .HasOne(m => m.Author)
+            .WithMany()
+            .HasForeignKey(m => m.AuthorId)
+            .OnDelete(DeleteBehavior.Restrict);
+
         // Message event indexes
         modelBuilder.Entity<MessageEventEntity>()
             .HasIndex(m => new { m.GuildDiscordId, m.EventTimestampUtc });

--- a/src/DiscordEventService/Data/Entities/Core/MessageEntity.cs
+++ b/src/DiscordEventService/Data/Entities/Core/MessageEntity.cs
@@ -6,9 +6,9 @@ public class MessageEntity : ITimestamped
 {
     public Guid Id { get; set; }
     public ulong DiscordId { get; set; }
-    public Guid? ChannelId { get; set; }
-    public Guid? GuildId { get; set; }
-    public Guid? AuthorId { get; set; }
+    public Guid ChannelId { get; set; }
+    public Guid GuildId { get; set; }
+    public Guid AuthorId { get; set; }
 
     public string? Content { get; set; }
     public ulong? ReplyToDiscordId { get; set; }
@@ -27,10 +27,10 @@ public class MessageEntity : ITimestamped
     public DateTime FirstSeenUtc { get; set; }
     public DateTime LastUpdatedUtc { get; set; }
 
-    // Navigation properties - Core (nullable since FKs are nullable)
-    public GuildEntity? Guild { get; set; }
-    public ChannelEntity? Channel { get; set; }
-    public UserEntity? Author { get; set; }
+    // Navigation properties - Core (FKs now NOT NULL per §P2.6)
+    public GuildEntity Guild { get; set; } = null!;
+    public ChannelEntity Channel { get; set; } = null!;
+    public UserEntity Author { get; set; } = null!;
 
     // Navigation properties - Events (soft relations)
     public ICollection<MessageEventEntity> MessageEvents { get; set; } = [];

--- a/src/DiscordEventService/Data/Migrations/20260523154901_P2_6_MessageFksNotNull.Designer.cs
+++ b/src/DiscordEventService/Data/Migrations/20260523154901_P2_6_MessageFksNotNull.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using DiscordEventService.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -11,9 +12,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace DiscordEventService.Data.Migrations
 {
     [DbContext(typeof(DiscordDbContext))]
-    partial class DiscordDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260523154901_P2_6_MessageFksNotNull")]
+    partial class P2_6_MessageFksNotNull
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/DiscordEventService/Data/Migrations/20260523154901_P2_6_MessageFksNotNull.cs
+++ b/src/DiscordEventService/Data/Migrations/20260523154901_P2_6_MessageFksNotNull.cs
@@ -1,0 +1,142 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace DiscordEventService.Data.Migrations
+{
+    /// <inheritdoc />
+    public partial class P2_6_MessageFksNotNull : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropForeignKey(
+                name: "fk_messages_channels_channel_id",
+                table: "messages");
+
+            migrationBuilder.DropForeignKey(
+                name: "fk_messages_guilds_guild_id",
+                table: "messages");
+
+            migrationBuilder.DropForeignKey(
+                name: "fk_messages_users_author_id",
+                table: "messages");
+
+            migrationBuilder.AlterColumn<Guid>(
+                name: "guild_id",
+                table: "messages",
+                type: "uuid",
+                nullable: false,
+                defaultValue: new Guid("00000000-0000-0000-0000-000000000000"),
+                oldClrType: typeof(Guid),
+                oldType: "uuid",
+                oldNullable: true);
+
+            migrationBuilder.AlterColumn<Guid>(
+                name: "channel_id",
+                table: "messages",
+                type: "uuid",
+                nullable: false,
+                defaultValue: new Guid("00000000-0000-0000-0000-000000000000"),
+                oldClrType: typeof(Guid),
+                oldType: "uuid",
+                oldNullable: true);
+
+            migrationBuilder.AlterColumn<Guid>(
+                name: "author_id",
+                table: "messages",
+                type: "uuid",
+                nullable: false,
+                defaultValue: new Guid("00000000-0000-0000-0000-000000000000"),
+                oldClrType: typeof(Guid),
+                oldType: "uuid",
+                oldNullable: true);
+
+            migrationBuilder.AddForeignKey(
+                name: "fk_messages_channels_channel_id",
+                table: "messages",
+                column: "channel_id",
+                principalTable: "channels",
+                principalColumn: "id",
+                onDelete: ReferentialAction.Restrict);
+
+            migrationBuilder.AddForeignKey(
+                name: "fk_messages_guilds_guild_id",
+                table: "messages",
+                column: "guild_id",
+                principalTable: "guilds",
+                principalColumn: "id",
+                onDelete: ReferentialAction.Restrict);
+
+            migrationBuilder.AddForeignKey(
+                name: "fk_messages_users_author_id",
+                table: "messages",
+                column: "author_id",
+                principalTable: "users",
+                principalColumn: "id",
+                onDelete: ReferentialAction.Restrict);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropForeignKey(
+                name: "fk_messages_channels_channel_id",
+                table: "messages");
+
+            migrationBuilder.DropForeignKey(
+                name: "fk_messages_guilds_guild_id",
+                table: "messages");
+
+            migrationBuilder.DropForeignKey(
+                name: "fk_messages_users_author_id",
+                table: "messages");
+
+            migrationBuilder.AlterColumn<Guid>(
+                name: "guild_id",
+                table: "messages",
+                type: "uuid",
+                nullable: true,
+                oldClrType: typeof(Guid),
+                oldType: "uuid");
+
+            migrationBuilder.AlterColumn<Guid>(
+                name: "channel_id",
+                table: "messages",
+                type: "uuid",
+                nullable: true,
+                oldClrType: typeof(Guid),
+                oldType: "uuid");
+
+            migrationBuilder.AlterColumn<Guid>(
+                name: "author_id",
+                table: "messages",
+                type: "uuid",
+                nullable: true,
+                oldClrType: typeof(Guid),
+                oldType: "uuid");
+
+            migrationBuilder.AddForeignKey(
+                name: "fk_messages_channels_channel_id",
+                table: "messages",
+                column: "channel_id",
+                principalTable: "channels",
+                principalColumn: "id");
+
+            migrationBuilder.AddForeignKey(
+                name: "fk_messages_guilds_guild_id",
+                table: "messages",
+                column: "guild_id",
+                principalTable: "guilds",
+                principalColumn: "id");
+
+            migrationBuilder.AddForeignKey(
+                name: "fk_messages_users_author_id",
+                table: "messages",
+                column: "author_id",
+                principalTable: "users",
+                principalColumn: "id");
+        }
+    }
+}

--- a/src/DiscordEventService/Jobs/MessagesBackfillJob.cs
+++ b/src/DiscordEventService/Jobs/MessagesBackfillJob.cs
@@ -215,6 +215,17 @@ public class MessagesBackfillJob(
                     var exists = await db.Messages.AnyAsync(m => m.DiscordId == message.Id, cancellationToken);
                     if (!exists)
                     {
+                        // §P2.6: MessageEntity.ChannelId/GuildId/AuthorId are NOT NULL. Skip
+                        // if any required FK row hasn't been backfilled yet — next run of
+                        // the corresponding backfill job + the next MessagesBackfillJob will
+                        // pick it up.
+                        if (channelEntity is null || authorEntity is null)
+                        {
+                            logger.LogWarning(
+                                "Skipping backfill insert for message {MessageId}: channelEntity={ChannelPresent} authorEntity={AuthorPresent}",
+                                message.Id, channelEntity is not null, authorEntity is not null);
+                            continue;
+                        }
                         var attachmentsJson = message.Attachments.Count > 0
                             ? JsonSerializer.Serialize(message.Attachments.Select(a => new { a.Id, a.Url, a.FileName, a.FileSize }))
                             : null;
@@ -225,9 +236,9 @@ public class MessagesBackfillJob(
                         db.Messages.Add(new MessageEntity
                         {
                             DiscordId = message.Id,
-                            ChannelId = channelEntity?.Id,
+                            ChannelId = channelEntity.Id,
                             GuildId = guildEntity.Id,
-                            AuthorId = authorEntity?.Id,
+                            AuthorId = authorEntity.Id,
                             Content = message.Content,
                             ReplyToDiscordId = message.ReferencedMessage?.Id,
                             HasAttachments = message.Attachments.Count > 0,

--- a/src/DiscordEventService/Services/EventHandlers/MessageEventHandler.cs
+++ b/src/DiscordEventService/Services/EventHandlers/MessageEventHandler.cs
@@ -49,13 +49,30 @@ public class MessageEventHandler(IServiceScopeFactory scopeFactory, ILogger<Mess
 
             // Resolve FKs via upsert-if-missing. The 2026-05-03 incident left 69 messages with
             // channel_id IS NULL because the prior FirstOrDefault path silently wrote null when
-            // the channel (a thread) wasn't yet in our DB. §P1.9 closes that hole.
+            // the channel (a thread) wasn't yet in our DB. §P1.9 closes that hole; §P2.6 (#74)
+            // makes the FKs NOT NULL so any regression in the upsert services becomes a loud
+            // skip + FailedEvent instead of a silent NULL FK row.
             var guildId = await guildUpsert.UpsertGuildAsync(e.Guild);
             var channelId = await channelUpsert.UpsertChannelAsync(e.Channel, guildId);
             var authorId = await db.Users
                 .Where(u => u.DiscordId == e.Author.Id)
                 .Select(u => u.Id)
                 .FirstOrDefaultAsync();
+
+            if (guildId == Guid.Empty || channelId == Guid.Empty || authorId == Guid.Empty)
+            {
+                logger.LogError(
+                    "MessageCreated: could not resolve required FKs for MessageId={MessageId} (guildId={GuildId} channelId={ChannelId} authorId={AuthorId}); skipping insert",
+                    e.Message.Id, guildId, channelId, authorId);
+                using var fkFailScope = scopeFactory.CreateScope();
+                var failedEventService = fkFailScope.ServiceProvider.GetRequiredService<FailedEventService>();
+                await failedEventService.RecordFailureAsync(
+                    "MessageCreated", nameof(MessageEventHandler),
+                    new InvalidOperationException(
+                        $"Required FK not resolved: guild={guildId} channel={channelId} author={authorId}"),
+                    e.Guild?.Id, e.Channel.Id, e.Author.Id, rawJson);
+                return;
+            }
 
             MessageEventEntity NewMessageEvent() => new()
             {
@@ -87,9 +104,9 @@ public class MessageEventHandler(IServiceScopeFactory scopeFactory, ILogger<Mess
                 db.Messages.Add(new MessageEntity
                 {
                     DiscordId = e.Message.Id,
-                    ChannelId = channelId != Guid.Empty ? channelId : null,
-                    GuildId = guildId != Guid.Empty ? guildId : null,
-                    AuthorId = authorId != Guid.Empty ? authorId : null,
+                    ChannelId = channelId,
+                    GuildId = guildId,
+                    AuthorId = authorId,
                     Content = e.Message.Content,
                     ReplyToDiscordId = e.Message.ReferencedMessage?.Id,
                     HasAttachments = e.Message.Attachments.Count > 0,


### PR DESCRIPTION
Closes #74.

## Summary

Locks down the `messages` FK schema after §P1.9 (#109) repaired the pre-existing NULL rows.

- `MessageEntity.GuildId/ChannelId/AuthorId`: `Guid?` → `Guid`.
- FK behavior: explicit `OnDelete: Restrict` (EF defaults to `Cascade` for required FKs; `Restrict` preserves message history if a guild/channel/user is ever hard-deleted).
- Migration: `AlterColumn nullable: false` + re-add FKs with `Restrict`.
- Handler updates so a regression in the upsert path becomes a loud skip + `FailedEventService` row instead of a silent NULL.

## Prod precheck

\`\`\`
SELECT COUNT(*) FROM messages
 WHERE guild_id IS NULL OR channel_id IS NULL OR author_id IS NULL  -- 0
\`\`\`

\`\`\`
-- orphan FKs (point to missing channel/guild/user) -- all 0
SELECT COUNT(*) FROM messages m WHERE m.channel_id IS NOT NULL
 AND NOT EXISTS (SELECT 1 FROM channels c WHERE c.id = m.channel_id)
\`\`\`

Both queries returned 0 against prod (29,255 messages). The migration's `defaultValue: '00000000-...'` never fires; the re-add FK with `Restrict` succeeds.

## Handler changes

**MessageEventHandler.MessageCreated** drops the vestigial `channelId != Guid.Empty ? channelId : null` ternaries (post-§P1.9 the upserts guarantee non-empty). If any FK is still Empty after upsert, logs an error + records a `FailedEventService` row + returns early.

**MessagesBackfillJob** drops the `channelEntity?.Id` / `authorEntity?.Id` fallbacks. Skips the insert with a warning if either entity is missing (next channels/users backfill + next messages backfill catches up).

## Data-loss check

No loss. Pre-check is clean. Defensive paths added so any future upsert regression surfaces loudly.

## Test plan

- [x] `dotnet build` green
- [x] Local smoke: migration applies cleanly after deleting 2 stale dev-DB orphans; all 3 columns now `NOT NULL`
- [x] Prod precheck: 0 NULL FKs + 0 orphan FKs
- [ ] Post-deploy: confirm migration applies on prod (no constraint violation on AlterColumn or AddForeignKey)
- [ ] Send a live test message to confirm the new code path

🤖 Generated with [Claude Code](https://claude.com/claude-code)