### PR TITLE
feat: MemberRoleSnapshotEntity + maintenance on Updated (§P3.1, #75)

### DIFF
--- a/src/DiscordEventService/Data/DiscordDbContext.cs
+++ b/src/DiscordEventService/Data/DiscordDbContext.cs
@@ -26,6 +26,9 @@ public class DiscordDbContext(DbContextOptions<DiscordDbContext> options) : DbCo
     public DbSet<AutoModRuleEntity> AutoModRules => Set<AutoModRuleEntity>();
     public DbSet<ActivityEntity> Activities => Set<ActivityEntity>();
 
+    // Member role snapshots (SCD for historical role membership)
+    public DbSet<MemberRoleSnapshotEntity> MemberRoleSnapshots => Set<MemberRoleSnapshotEntity>();
+
     // Event entities - Messages & Reactions
     public DbSet<MessageEventEntity> MessageEvents => Set<MessageEventEntity>();
     public DbSet<ReactionEventEntity> ReactionEvents => Set<ReactionEventEntity>();
@@ -643,6 +646,23 @@ public class DiscordDbContext(DbContextOptions<DiscordDbContext> options) : DbCo
         // lookups via OrderByDescending(LastHeartbeatUtc).First() use this.
         modelBuilder.Entity<BotHeartbeatEntity>()
             .HasIndex(h => h.LastHeartbeatUtc);
+
+        // =====================================================
+        // MemberRoleSnapshot configuration (§P3.1)
+        // =====================================================
+        modelBuilder.Entity<MemberRoleSnapshotEntity>(b =>
+        {
+            b.HasOne(s => s.Member)
+                .WithMany()
+                .HasForeignKey(s => s.MemberId)
+                .OnDelete(DeleteBehavior.Restrict);
+
+            b.HasIndex(s => new { s.MemberId, s.RoleDiscordId, s.GrantedAtUtc });
+
+            b.HasIndex(s => new { s.MemberId, s.RoleDiscordId })
+                .IsUnique()
+                .HasFilter("revoked_at_utc IS NULL");
+        });
 
         // =====================================================
         // Soft-delete CHECK constraints (§P2.5)

--- a/src/DiscordEventService/Data/Entities/Core/MemberRoleSnapshotEntity.cs
+++ b/src/DiscordEventService/Data/Entities/Core/MemberRoleSnapshotEntity.cs
@@ -1,0 +1,14 @@
+namespace DiscordEventService.Data.Entities.Core;
+
+public class MemberRoleSnapshotEntity
+{
+    public Guid Id { get; set; }
+    public Guid MemberId { get; set; }
+    public ulong RoleDiscordId { get; set; }
+    public DateTime GrantedAtUtc { get; set; }
+    public DateTime? RevokedAtUtc { get; set; }
+    public Guid? SourceEventId { get; set; }
+
+    // Navigation properties
+    public MemberEntity Member { get; set; } = null!;
+}

--- a/src/DiscordEventService/Data/Migrations/20260523230241_P3_1_MemberRoleSnapshots.Designer.cs
+++ b/src/DiscordEventService/Data/Migrations/20260523230241_P3_1_MemberRoleSnapshots.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using DiscordEventService.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -11,9 +12,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace DiscordEventService.Data.Migrations
 {
     [DbContext(typeof(DiscordDbContext))]
-    partial class DiscordDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260523230241_P3_1_MemberRoleSnapshots")]
+    partial class P3_1_MemberRoleSnapshots
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/DiscordEventService/Data/Migrations/20260523230241_P3_1_MemberRoleSnapshots.cs
+++ b/src/DiscordEventService/Data/Migrations/20260523230241_P3_1_MemberRoleSnapshots.cs
@@ -1,0 +1,56 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace DiscordEventService.Data.Migrations
+{
+    /// <inheritdoc />
+    public partial class P3_1_MemberRoleSnapshots : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "member_role_snapshots",
+                columns: table => new
+                {
+                    id = table.Column<Guid>(type: "uuid", nullable: false, defaultValueSql: "uuidv7()"),
+                    member_id = table.Column<Guid>(type: "uuid", nullable: false),
+                    role_discord_id = table.Column<long>(type: "bigint", nullable: false),
+                    granted_at_utc = table.Column<DateTime>(type: "timestamp with time zone", nullable: false),
+                    revoked_at_utc = table.Column<DateTime>(type: "timestamp with time zone", nullable: true),
+                    source_event_id = table.Column<Guid>(type: "uuid", nullable: true)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("pk_member_role_snapshots", x => x.id);
+                    table.ForeignKey(
+                        name: "fk_member_role_snapshots_members_member_id",
+                        column: x => x.member_id,
+                        principalTable: "members",
+                        principalColumn: "id",
+                        onDelete: ReferentialAction.Restrict);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "ix_member_role_snapshots_member_id_role_discord_id",
+                table: "member_role_snapshots",
+                columns: new[] { "member_id", "role_discord_id" },
+                unique: true,
+                filter: "revoked_at_utc IS NULL");
+
+            migrationBuilder.CreateIndex(
+                name: "ix_member_role_snapshots_member_id_role_discord_id_granted_at_",
+                table: "member_role_snapshots",
+                columns: new[] { "member_id", "role_discord_id", "granted_at_utc" });
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "member_role_snapshots");
+        }
+    }
+}

--- a/src/DiscordEventService/Services/EventHandlers/MemberEventHandler.cs
+++ b/src/DiscordEventService/Services/EventHandlers/MemberEventHandler.cs
@@ -251,8 +251,7 @@ public class MemberEventHandler(IServiceScopeFactory scopeFactory, ILogger<Membe
             var closed = await db.MemberRoleSnapshots
                 .Where(s => s.MemberId == member.Id && s.RoleDiscordId == roleId && s.RevokedAtUtc == null)
                 .ExecuteUpdateAsync(s => s
-                    .SetProperty(x => x.RevokedAtUtc, eventTime)
-                    .SetProperty(x => x.SourceEventId, sourceEventId));
+                    .SetProperty(x => x.RevokedAtUtc, eventTime));
 
             if (closed == 0)
             {

--- a/src/DiscordEventService/Services/EventHandlers/MemberEventHandler.cs
+++ b/src/DiscordEventService/Services/EventHandlers/MemberEventHandler.cs
@@ -1,7 +1,9 @@
 using DiscordEventService.Data;
+using DiscordEventService.Data.Entities.Core;
 using DiscordEventService.Data.Entities.Events;
 using DSharpPlus;
 using DSharpPlus.EventArgs;
+using Microsoft.EntityFrameworkCore;
 using System.Text.Json;
 
 namespace DiscordEventService.Services.EventHandlers;
@@ -146,37 +148,53 @@ public class MemberEventHandler(IServiceScopeFactory scopeFactory, ILogger<Membe
             if (nicknameChanged || rolesAdded.Any() || rolesRemoved.Any() || timeoutChanged
                 || avatarHashChanged || pendingChanged || premiumChanged || mutedChanged || deafenedChanged)
             {
-                var memberEvent = new MemberEventEntity
+                var strategy = db.Database.CreateExecutionStrategy();
+                await strategy.ExecuteAsync(async () =>
                 {
-                    UserDiscordId = e.Member.Id,
-                    GuildDiscordId = e.Guild.Id,
-                    EventType = MemberEventType.Updated,
-                    NicknameBefore = e.NicknameBefore,
-                    NicknameAfter = e.NicknameAfter,
-                    RolesAddedJson = rolesAdded.Any()
-                        ? JsonSerializer.Serialize(rolesAdded)
-                        : null,
-                    RolesRemovedJson = rolesRemoved.Any()
-                        ? JsonSerializer.Serialize(rolesRemoved)
-                        : null,
-                    TimeoutUntilUtc = e.CommunicationDisabledUntilAfter?.UtcDateTime,
-                    PremiumSinceBefore = premiumBefore?.UtcDateTime,
-                    PremiumSinceAfter = premiumAfter?.UtcDateTime,
-                    GuildAvatarHashBefore = e.GuildAvatarHashBefore,
-                    GuildAvatarHashAfter = e.GuildAvatarHashAfter,
-                    IsPendingBefore = e.PendingBefore,
-                    IsPendingAfter = e.PendingAfter,
-                    IsMutedBefore = mutedBefore,
-                    IsMutedAfter = mutedAfter,
-                    IsDeafenedBefore = deafenedBefore,
-                    IsDeafenedAfter = deafenedAfter,
-                    EventTimestampUtc = receivedAt,
-                    ReceivedAtUtc = receivedAt,
-                    RawEventJson = rawJson
-                };
+                    db.ChangeTracker.Clear();
+                    await using var tx = await db.Database.BeginTransactionAsync();
 
-                db.MemberEvents.Add(memberEvent);
-                await db.SaveChangesAsync();
+                    var memberEvent = new MemberEventEntity
+                    {
+                        UserDiscordId = e.Member.Id,
+                        GuildDiscordId = e.Guild.Id,
+                        EventType = MemberEventType.Updated,
+                        NicknameBefore = e.NicknameBefore,
+                        NicknameAfter = e.NicknameAfter,
+                        RolesAddedJson = rolesAdded.Any()
+                            ? JsonSerializer.Serialize(rolesAdded)
+                            : null,
+                        RolesRemovedJson = rolesRemoved.Any()
+                            ? JsonSerializer.Serialize(rolesRemoved)
+                            : null,
+                        TimeoutUntilUtc = e.CommunicationDisabledUntilAfter?.UtcDateTime,
+                        PremiumSinceBefore = premiumBefore?.UtcDateTime,
+                        PremiumSinceAfter = premiumAfter?.UtcDateTime,
+                        GuildAvatarHashBefore = e.GuildAvatarHashBefore,
+                        GuildAvatarHashAfter = e.GuildAvatarHashAfter,
+                        IsPendingBefore = e.PendingBefore,
+                        IsPendingAfter = e.PendingAfter,
+                        IsMutedBefore = mutedBefore,
+                        IsMutedAfter = mutedAfter,
+                        IsDeafenedBefore = deafenedBefore,
+                        IsDeafenedAfter = deafenedAfter,
+                        EventTimestampUtc = receivedAt,
+                        ReceivedAtUtc = receivedAt,
+                        RawEventJson = rawJson
+                    };
+
+                    db.MemberEvents.Add(memberEvent);
+                    await db.SaveChangesAsync();
+
+                    if ((rolesAdded.Any() || rolesRemoved.Any())
+                        && e.RolesBefore is not null && e.RolesAfter is not null)
+                    {
+                        await MaintainRoleSnapshotsAsync(db, e.Member.Id, e.Guild.Id,
+                            rolesAdded, rolesRemoved, receivedAt, memberEvent.Id);
+                    }
+
+                    await tx.CommitAsync();
+                });
             }
         }
         catch (Exception ex)
@@ -187,6 +205,60 @@ public class MemberEventHandler(IServiceScopeFactory scopeFactory, ILogger<Membe
             await failedEventService.RecordFailureAsync(
                 "GuildMemberUpdated", nameof(MemberEventHandler), ex,
                 e.Guild?.Id, null, e.Member.Id, rawJson);
+        }
+    }
+
+    private async Task MaintainRoleSnapshotsAsync(
+        DiscordDbContext db, ulong userDiscordId, ulong guildDiscordId,
+        List<ulong> rolesAdded, List<ulong> rolesRemoved,
+        DateTime eventTime, Guid sourceEventId)
+    {
+        var member = await db.Members
+            .Where(m => m.User.DiscordId == userDiscordId && m.Guild.DiscordId == guildDiscordId)
+            .Select(m => new { m.Id })
+            .FirstOrDefaultAsync();
+
+        if (member is null)
+        {
+            logger.LogWarning("Cannot maintain role snapshots: member not found for User={UserDiscordId} Guild={GuildDiscordId}",
+                userDiscordId, guildDiscordId);
+            return;
+        }
+
+        foreach (var roleId in rolesAdded)
+        {
+            try
+            {
+                db.MemberRoleSnapshots.Add(new MemberRoleSnapshotEntity
+                {
+                    MemberId = member.Id,
+                    RoleDiscordId = roleId,
+                    GrantedAtUtc = eventTime,
+                    SourceEventId = sourceEventId
+                });
+                await db.SaveChangesAsync();
+            }
+            catch (DbUpdateException ex) when (ex.InnerException is Npgsql.PostgresException { SqlState: "23505" })
+            {
+                db.ChangeTracker.Clear();
+                logger.LogDebug("Duplicate role snapshot skipped: Member={MemberId} Role={RoleDiscordId}",
+                    member.Id, roleId);
+            }
+        }
+
+        foreach (var roleId in rolesRemoved)
+        {
+            var closed = await db.MemberRoleSnapshots
+                .Where(s => s.MemberId == member.Id && s.RoleDiscordId == roleId && s.RevokedAtUtc == null)
+                .ExecuteUpdateAsync(s => s
+                    .SetProperty(x => x.RevokedAtUtc, eventTime)
+                    .SetProperty(x => x.SourceEventId, sourceEventId));
+
+            if (closed == 0)
+            {
+                logger.LogDebug("No open role snapshot to close: Member={MemberId} Role={RoleDiscordId}",
+                    member.Id, roleId);
+            }
         }
     }
 


### PR DESCRIPTION
## Summary
- New `MemberRoleSnapshotEntity` SCD table tracking member-role membership over time (granted/revoked timestamps)
- Maintained automatically in `MemberEventHandler` Updated path: inserts open snapshots for granted roles, closes them on revoke
- Unique partial index on `(member_id, role_discord_id) WHERE revoked_at_utc IS NULL` prevents duplicate open rows and handles gateway redelivery via 23505 catch
- Transaction wrapped in `CreateExecutionStrategy` to match existing `EnableRetryOnFailure` pattern
- Guards on both `RolesBefore` and `RolesAfter` being non-null to avoid spurious snapshots from cache misses

Closes #75

## Test plan
- [ ] Run dev bot locally, add a role to a test user → verify `member_role_snapshots` row with `granted_at_utc` set, `revoked_at_utc = NULL`
- [ ] Remove the role → verify that row's `revoked_at_utc` is set
- [ ] Verify historical query: `SELECT role_discord_id FROM member_role_snapshots WHERE member_id = ? AND granted_at_utc <= ? AND (revoked_at_utc IS NULL OR revoked_at_utc > ?)`
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)