### PR TITLE
fix: pre-check in role snapshot backfill to avoid noisy 23505 logs

### DIFF
--- a/src/DiscordEventService/Services/MemberRoleSnapshotBackfillService.cs
+++ b/src/DiscordEventService/Services/MemberRoleSnapshotBackfillService.cs
@@ -68,6 +68,11 @@ public class MemberRoleSnapshotBackfillService(
 
             foreach (var roleId in rolesAdded)
             {
+                var alreadyOpen = await db.MemberRoleSnapshots
+                    .AnyAsync(s => s.MemberId == memberId && s.RoleDiscordId == roleId && s.RevokedAtUtc == null, ct);
+                if (alreadyOpen)
+                    continue;
+
                 try
                 {
                     db.MemberRoleSnapshots.Add(new MemberRoleSnapshotEntity


### PR DESCRIPTION
## Summary
- Add `AnyAsync` pre-check before inserting in the event replay loop of `MemberRoleSnapshotBackfillService`
- Matches the pattern already used in `SeedCurrentRolesAsync`
- Eliminates EF Core `fail`-level log noise from expected duplicate key violations on idempotent re-runs
- 23505 catch kept as race-condition safety net

## Test plan
- [ ] Run backfill twice on prod — second run should produce 0 EF Core error logs
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)