### PR TITLE
fix: don't auto-retry backfill jobs on deploy cancellation

### DIFF
--- a/src/DiscordEventService/Jobs/ChannelsBackfillJob.cs
+++ b/src/DiscordEventService/Jobs/ChannelsBackfillJob.cs
@@ -95,6 +95,11 @@ public class ChannelsBackfillJob(
             await MarkCompletedAsync(db, checkpoint);
             logger.LogInformation("Channels backfill completed for guild {GuildId}: {Count} channels", guildId, checkpoint.ProcessedCount);
         }
+        catch (OperationCanceledException ex)
+        {
+            logger.LogWarning("Channels backfill cancelled for guild {GuildId} (likely deploy restart)", guildId);
+            await MarkFailedAsync(db, checkpoint, ex);
+        }
         catch (Exception ex)
         {
             logger.LogError(ex, "Channels backfill failed for guild {GuildId}", guildId);

--- a/src/DiscordEventService/Jobs/EmojisBackfillJob.cs
+++ b/src/DiscordEventService/Jobs/EmojisBackfillJob.cs
@@ -82,6 +82,11 @@ public class EmojisBackfillJob(
             await MarkCompletedAsync(db, checkpoint);
             logger.LogInformation("Emojis backfill completed for guild {GuildId}: {Count} emojis", guildId, checkpoint.ProcessedCount);
         }
+        catch (OperationCanceledException ex)
+        {
+            logger.LogWarning("Emojis backfill cancelled for guild {GuildId} (likely deploy restart)", guildId);
+            await MarkFailedAsync(db, checkpoint, ex);
+        }
         catch (Exception ex)
         {
             logger.LogError(ex, "Emojis backfill failed for guild {GuildId}", guildId);

--- a/src/DiscordEventService/Jobs/MembersBackfillJob.cs
+++ b/src/DiscordEventService/Jobs/MembersBackfillJob.cs
@@ -71,6 +71,11 @@ public class MembersBackfillJob(
             await MarkCompletedAsync(db, checkpoint);
             logger.LogInformation("Members backfill completed for guild {GuildId}: {Count} members", guildId, checkpoint.ProcessedCount);
         }
+        catch (OperationCanceledException ex)
+        {
+            logger.LogWarning("Members backfill cancelled for guild {GuildId} (likely deploy restart)", guildId);
+            await MarkFailedAsync(db, checkpoint, ex);
+        }
         catch (Exception ex)
         {
             logger.LogError(ex, "Members backfill failed for guild {GuildId}", guildId);

--- a/src/DiscordEventService/Jobs/MessagesBackfillJob.cs
+++ b/src/DiscordEventService/Jobs/MessagesBackfillJob.cs
@@ -112,6 +112,11 @@ public class MessagesBackfillJob(
             await MarkCompletedAsync(db, checkpoint);
             logger.LogInformation("Messages backfill completed for guild {GuildId}: {Count} messages", guildId, checkpoint.ProcessedCount);
         }
+        catch (OperationCanceledException ex)
+        {
+            logger.LogWarning("Messages backfill cancelled for guild {GuildId} (likely deploy restart)", guildId);
+            await MarkFailedAsync(db, checkpoint, ex);
+        }
         catch (Exception ex)
         {
             logger.LogError(ex, "Messages backfill failed for guild {GuildId}", guildId);

--- a/src/DiscordEventService/Jobs/ReactionsBackfillJob.cs
+++ b/src/DiscordEventService/Jobs/ReactionsBackfillJob.cs
@@ -103,6 +103,11 @@ public class ReactionsBackfillJob(
             await MarkCompletedAsync(db, checkpoint);
             logger.LogInformation("Reactions backfill completed for guild {GuildId}: {Count} reactions", guildId, checkpoint.ProcessedCount);
         }
+        catch (OperationCanceledException ex)
+        {
+            logger.LogWarning("Reactions backfill cancelled for guild {GuildId} (likely deploy restart)", guildId);
+            await MarkFailedAsync(db, checkpoint, ex);
+        }
         catch (Exception ex)
         {
             logger.LogError(ex, "Reactions backfill failed for guild {GuildId}", guildId);

--- a/src/DiscordEventService/Jobs/RolesBackfillJob.cs
+++ b/src/DiscordEventService/Jobs/RolesBackfillJob.cs
@@ -92,6 +92,11 @@ public class RolesBackfillJob(
             await MarkCompletedAsync(db, checkpoint);
             logger.LogInformation("Roles backfill completed for guild {GuildId}: {Count} roles", guildId, checkpoint.ProcessedCount);
         }
+        catch (OperationCanceledException ex)
+        {
+            logger.LogWarning("Roles backfill cancelled for guild {GuildId} (likely deploy restart)", guildId);
+            await MarkFailedAsync(db, checkpoint, ex);
+        }
         catch (Exception ex)
         {
             logger.LogError(ex, "Roles backfill failed for guild {GuildId}", guildId);

--- a/src/DiscordEventService/Jobs/StickersBackfillJob.cs
+++ b/src/DiscordEventService/Jobs/StickersBackfillJob.cs
@@ -91,6 +91,11 @@ public class StickersBackfillJob(
             await MarkCompletedAsync(db, checkpoint);
             logger.LogInformation("Stickers backfill completed for guild {GuildId}: {Count} stickers", guildId, checkpoint.ProcessedCount);
         }
+        catch (OperationCanceledException ex)
+        {
+            logger.LogWarning("Stickers backfill cancelled for guild {GuildId} (likely deploy restart)", guildId);
+            await MarkFailedAsync(db, checkpoint, ex);
+        }
         catch (Exception ex)
         {
             logger.LogError(ex, "Stickers backfill failed for guild {GuildId}", guildId);


### PR DESCRIPTION
## Summary
- Catch `OperationCanceledException` separately in all 7 backfill jobs
- On cancellation (deploy restart), mark checkpoint as Failed but don't re-throw
- Prevents Hangfire auto-retry loop where a killed reactions job restarts from scratch every deploy
- Real errors still re-throw for Hangfire visibility

## Test plan
- [ ] Deploy should no longer trigger 25-minute reactions backfill retry loop
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)