### PR TITLE
fix: scope backfill time windows — reconnect ≤2d, weekly ≤2w

### DIFF
--- a/src/DiscordEventService/Jobs/PeriodicFullBackfillJob.cs
+++ b/src/DiscordEventService/Jobs/PeriodicFullBackfillJob.cs
@@ -5,10 +5,9 @@ using Microsoft.EntityFrameworkCore;
 namespace DiscordEventService.Jobs;
 
 /// <summary>
-/// Weekly safety-net backfill. Reconnect-backfill is windowed by `lastAlive`,
-/// so anything older than the most recent crash/reconnect can be missed by it
-/// (see #124 postmortem). This job walks every known guild's full history each
-/// week with `afterTimestampUtc = null` so any drift is eventually caught.
+/// Weekly safety-net backfill. Reconnect-backfill is capped to 2 days,
+/// so anything older needs this periodic sweep. Scoped to the last 2 weeks
+/// to avoid full-history crawls that take hours on large guilds.
 ///
 /// Skips guilds with an InProgress checkpoint to avoid stepping on the
 /// reconnect path or the operator-triggered /api/backfill endpoint.
@@ -17,15 +16,14 @@ public class PeriodicFullBackfillJob(
     IServiceScopeFactory scopeFactory,
     ILogger<PeriodicFullBackfillJob> logger)
 {
+    private static readonly TimeSpan BackfillWindow = TimeSpan.FromDays(14);
+
     public async Task ExecuteAsync()
     {
         using var scope = scopeFactory.CreateScope();
         var db = scope.ServiceProvider.GetRequiredService<DiscordDbContext>();
         var orchestrator = scope.ServiceProvider.GetRequiredService<GuildBackfillOrchestrator>();
 
-        // Only currently-joined guilds. Guilds we've left would fail at
-        // GetGuildAsync in RolesBackfillJob, marking the checkpoint Failed
-        // every Sunday.
         var guildIds = await db.Guilds
             .Where(g => g.LeftAtUtc == null)
             .Select(g => g.DiscordId)
@@ -37,18 +35,21 @@ public class PeriodicFullBackfillJob(
             .ToListAsync();
         var inProgressSet = inProgress.ToHashSet();
 
+        var afterTimestamp = DateTime.UtcNow - BackfillWindow;
+
         foreach (var guildId in guildIds)
         {
             if (inProgressSet.Contains(guildId))
             {
                 logger.LogInformation(
-                    "Periodic full backfill skipped for guild {GuildId}: backfill already in progress",
+                    "Periodic backfill skipped for guild {GuildId}: backfill already in progress",
                     guildId);
                 continue;
             }
 
-            logger.LogInformation("Periodic full backfill enqueued for guild {GuildId}", guildId);
-            orchestrator.StartBackfill(guildId);
+            logger.LogInformation("Periodic backfill enqueued for guild {GuildId} (window={Window}d, after={After:O})",
+                guildId, BackfillWindow.TotalDays, afterTimestamp);
+            orchestrator.EnqueueBackfillFrom(guildId, afterTimestamp);
         }
     }
 }

--- a/src/DiscordEventService/Services/EventHandlers/SocketLifecycleHandler.cs
+++ b/src/DiscordEventService/Services/EventHandlers/SocketLifecycleHandler.cs
@@ -16,13 +16,10 @@ public class SocketLifecycleHandler(
 {
     private static readonly TimeSpan ReconnectGapThreshold = TimeSpan.FromSeconds(30);
     private static readonly TimeSpan ReconnectBackfillBuffer = TimeSpan.FromMinutes(5);
-    // When the bot was down longer than this, the windowed reconnect-backfill
-    // (which scrolls only until messages older than `lastAlive - buffer`) isn't
-    // enough — switch to a full deep walk (no afterTimestampUtc) so all messages
-    // sent during the outage land in the DB. See #124 postmortem: a 10-day
-    // outage went unnoticed in part because reconnect-backfill kept short-window
-    // backfilling on each crash-restart, never walking far enough back.
-    private static readonly TimeSpan FullBackfillGapThreshold = TimeSpan.FromHours(24);
+    // Cap reconnect backfill to 2 days max. Longer gaps are covered by the
+    // weekly periodic backfill (2-week window). Prevents 30-minute reaction
+    // crawls on every deploy after a long outage.
+    private static readonly TimeSpan MaxReconnectBackfillWindow = TimeSpan.FromDays(2);
 
     public async Task HandleEventAsync(DiscordClient sender, SocketClosedEventArgs e)
     {
@@ -113,10 +110,15 @@ public class SocketLifecycleHandler(
                 return;
             }
 
-            // Per user guidance: scan all known channels in every guild, overshoot
-            // the window rather than risk missing events.
+            var earliestAllowed = now - MaxReconnectBackfillWindow;
             var afterTimestamp = lastAlive.Value - ReconnectBackfillBuffer;
-            var useFullBackfill = gap >= FullBackfillGapThreshold;
+            if (afterTimestamp < earliestAllowed)
+            {
+                logger.LogInformation(
+                    "Reconnect backfill window capped to {Window} (gap was {Gap:c}, capped from {Original:O} to {Capped:O})",
+                    MaxReconnectBackfillWindow, gap, afterTimestamp, earliestAllowed);
+                afterTimestamp = earliestAllowed;
+            }
 
             var inProgressGuilds = await db.BackfillCheckpoints
                 .Where(c => c.Status == BackfillStatus.InProgress)
@@ -135,20 +137,10 @@ public class SocketLifecycleHandler(
                     continue;
                 }
 
-                if (useFullBackfill)
-                {
-                    logger.LogInformation(
-                        "Full backfill enqueued for guild {GuildId} after long gap {Gap:c} (>= {Threshold:c}); ignoring afterTimestampUtc",
-                        guildId, gap, FullBackfillGapThreshold);
-                    orchestrator.StartBackfill(guildId);
-                }
-                else
-                {
-                    logger.LogInformation(
-                        "Reconnect backfill enqueued for guild {GuildId} after gap {Gap:c} (afterTimestampUtc={After:O})",
-                        guildId, gap, afterTimestamp);
-                    orchestrator.EnqueueBackfillFrom(guildId, afterTimestamp);
-                }
+                logger.LogInformation(
+                    "Reconnect backfill enqueued for guild {GuildId} after gap {Gap:c} (afterTimestampUtc={After:O})",
+                    guildId, gap, afterTimestamp);
+                orchestrator.EnqueueBackfillFrom(guildId, afterTimestamp);
             }
         }
         catch (Exception ex)


### PR DESCRIPTION
## Summary
- Reconnect backfill: `afterTimestampUtc` capped to max 2 days ago, even if the gap was longer
- Weekly periodic backfill: scoped to last 14 days instead of full history (`afterTimestampUtc = null`)
- Removes the `FullBackfillGapThreshold` (24h) branch that triggered unlimited full-history crawls
- Full-history backfills remain available via `POST /api/backfill/{guildId}` for manual use

## Test plan
- [ ] Deploy with gap > 2 days → reconnect backfill only covers last 2 days
- [ ] Weekly job scopes to 14 days
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)