### PR TITLE
feat: boot quick-sync — messages + presence/activity snapshot on startup

### DIFF
--- a/src/DiscordEventService/Data/Entities/Events/PresenceEventEntity.cs
+++ b/src/DiscordEventService/Data/Entities/Events/PresenceEventEntity.cs
@@ -1,10 +1,17 @@
 namespace DiscordEventService.Data.Entities.Events;
 
+public enum PresenceEventType
+{
+    Updated = 0,
+    BootSnapshot = 1
+}
+
 public class PresenceEventEntity
 {
     public Guid Id { get; set; }
     public ulong UserDiscordId { get; set; }
     public ulong GuildDiscordId { get; set; }
+    public PresenceEventType EventType { get; set; }
 
     // Before status
     public int DesktopStatusBefore { get; set; }

--- a/src/DiscordEventService/Data/Migrations/20260524112318_AddPresenceEventType.Designer.cs
+++ b/src/DiscordEventService/Data/Migrations/20260524112318_AddPresenceEventType.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using DiscordEventService.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -11,9 +12,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace DiscordEventService.Data.Migrations
 {
     [DbContext(typeof(DiscordDbContext))]
-    partial class DiscordDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260524112318_AddPresenceEventType")]
+    partial class AddPresenceEventType
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/DiscordEventService/Data/Migrations/20260524112318_AddPresenceEventType.cs
+++ b/src/DiscordEventService/Data/Migrations/20260524112318_AddPresenceEventType.cs
@@ -1,0 +1,29 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace DiscordEventService.Data.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddPresenceEventType : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<int>(
+                name: "event_type",
+                table: "presence_events",
+                type: "integer",
+                nullable: false,
+                defaultValue: 0);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "event_type",
+                table: "presence_events");
+        }
+    }
+}

--- a/src/DiscordEventService/Program.cs
+++ b/src/DiscordEventService/Program.cs
@@ -88,6 +88,7 @@ builder.Services.AddSingleton(rootSp =>
         // GuildBackfillOrchestrator; it resolves from the DSharpPlus child
         // container, so the orchestrator must be registered here too.
         services.AddScoped<GuildBackfillOrchestrator>();
+        services.AddScoped<BootQuickSyncService>();
         // IBackgroundJobClient forwards to the root container's registration.
         // Hangfire registers IBackgroundJobClient as Transient with DI-based
         // JobStorage resolution; using `new BackgroundJobClient()` directly

--- a/src/DiscordEventService/Services/BootQuickSyncService.cs
+++ b/src/DiscordEventService/Services/BootQuickSyncService.cs
@@ -68,21 +68,21 @@ public class BootQuickSyncService(
                     .ToListAsync();
                 var existingSet = existingDiscordIds.ToHashSet();
 
-                var newMessages = messages.Where(m => !existingSet.Contains(m.Id)).ToList();
+                var newMessages = messages.Where(m => !existingSet.Contains(m.Id) && m.Author is not null).ToList();
                 if (newMessages.Count == 0) continue;
 
-                var uniqueAuthors = newMessages.Select(m => m.Author).DistinctBy(a => a.Id).ToList();
+                var uniqueAuthors = newMessages.Select(m => m.Author!).DistinctBy(a => a.Id).ToList();
                 foreach (var author in uniqueAuthors)
                     await userService.UpsertUserAsync(author);
 
-                var authorDiscordIds = newMessages.Select(m => m.Author.Id).Distinct().ToList();
+                var authorDiscordIds = newMessages.Select(m => m.Author!.Id).Distinct().ToList();
                 var authorLookup = await db.Users
                     .Where(u => authorDiscordIds.Contains(u.DiscordId))
                     .ToDictionaryAsync(u => u.DiscordId, u => u.Id);
 
                 foreach (var message in newMessages)
                 {
-                    if (!authorLookup.TryGetValue(message.Author.Id, out var authorId))
+                    if (!authorLookup.TryGetValue(message.Author!.Id, out var authorId))
                         continue;
 
                     var attachmentsJson = message.Attachments.Count > 0

--- a/src/DiscordEventService/Services/BootQuickSyncService.cs
+++ b/src/DiscordEventService/Services/BootQuickSyncService.cs
@@ -1,0 +1,265 @@
+using DiscordEventService.Data;
+using DiscordEventService.Data.Entities.Core;
+using DiscordEventService.Data.Entities.Events;
+using DSharpPlus;
+using DSharpPlus.Entities;
+using Microsoft.EntityFrameworkCore;
+using System.Text.Json;
+
+namespace DiscordEventService.Services;
+
+public class BootQuickSyncService(
+    IServiceScopeFactory scopeFactory,
+    DiscordClient discordClient,
+    ILogger<BootQuickSyncService> logger)
+{
+    private static readonly JsonSerializerOptions JsonOptions = new()
+    {
+        PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+        WriteIndented = false
+    };
+
+    public async Task SyncAsync(ulong guildId)
+    {
+        logger.LogInformation("Boot quick-sync starting for guild {GuildId}", guildId);
+
+        var guild = await discordClient.GetGuildAsync(guildId);
+        var messagesInserted = await SyncRecentMessagesAsync(guild);
+        var (presenceSnapshots, activitiesInserted) = await SyncPresencesAsync(guild);
+
+        logger.LogInformation(
+            "Boot quick-sync completed for guild {GuildId}: {Messages} messages, {Presences} presence snapshots, {Activities} new activities",
+            guildId, messagesInserted, presenceSnapshots, activitiesInserted);
+    }
+
+    private async Task<int> SyncRecentMessagesAsync(DiscordGuild guild)
+    {
+        var channels = await guild.GetChannelsAsync();
+        var textChannels = channels
+            .Where(c => c.Type is DiscordChannelType.Text or DiscordChannelType.News)
+            .ToList();
+
+        int totalInserted = 0;
+
+        foreach (var channel in textChannels)
+        {
+            try
+            {
+                var messages = new List<DiscordMessage>();
+                await foreach (var msg in channel.GetMessagesAsync(50))
+                {
+                    messages.Add(msg);
+                }
+
+                if (messages.Count == 0) continue;
+
+                using var scope = scopeFactory.CreateScope();
+                var db = scope.ServiceProvider.GetRequiredService<DiscordDbContext>();
+                var userService = scope.ServiceProvider.GetRequiredService<UserService>();
+                var guildUpsert = scope.ServiceProvider.GetRequiredService<GuildUpsertService>();
+                var channelUpsert = scope.ServiceProvider.GetRequiredService<ChannelUpsertService>();
+
+                var guildId = await guildUpsert.UpsertGuildAsync(guild);
+                var channelId = await channelUpsert.UpsertChannelAsync(channel, guildId);
+
+                var existingDiscordIds = await db.Messages
+                    .Where(m => messages.Select(msg => msg.Id).Contains(m.DiscordId))
+                    .Select(m => m.DiscordId)
+                    .ToListAsync();
+                var existingSet = existingDiscordIds.ToHashSet();
+
+                var newMessages = messages.Where(m => !existingSet.Contains(m.Id)).ToList();
+
+                foreach (var message in newMessages)
+                {
+                    try
+                    {
+                        await userService.UpsertUserAsync(message.Author);
+                        var authorId = await db.Users
+                            .Where(u => u.DiscordId == message.Author.Id)
+                            .Select(u => u.Id)
+                            .FirstOrDefaultAsync();
+
+                        if (authorId == Guid.Empty) continue;
+
+                        var attachmentsJson = message.Attachments.Count > 0
+                            ? JsonSerializer.Serialize(message.Attachments.Select(a => new { a.Id, a.Url, a.FileName, a.FileSize }))
+                            : null;
+                        var embedsJson = message.Embeds.Count > 0
+                            ? JsonSerializer.Serialize(message.Embeds)
+                            : null;
+
+                        db.Messages.Add(new MessageEntity
+                        {
+                            DiscordId = message.Id,
+                            ChannelId = channelId,
+                            GuildId = guildId,
+                            AuthorId = authorId,
+                            Content = message.Content,
+                            ReplyToDiscordId = message.ReferencedMessage?.Id,
+                            HasAttachments = message.Attachments.Count > 0,
+                            HasEmbeds = message.Embeds.Count > 0,
+                            AttachmentsJson = attachmentsJson,
+                            EmbedsJson = embedsJson,
+                            Flags = (int)(message.Flags ?? 0),
+                            CreatedAtUtc = message.Timestamp.UtcDateTime,
+                            EditedAtUtc = message.EditedTimestamp?.UtcDateTime
+                        });
+
+                        db.MessageEvents.Add(new MessageEventEntity
+                        {
+                            MessageDiscordId = message.Id,
+                            ChannelDiscordId = channel.Id,
+                            AuthorDiscordId = message.Author.Id,
+                            GuildDiscordId = guild.Id,
+                            EventType = MessageEventType.Backfilled,
+                            Content = message.Content,
+                            HasAttachments = message.Attachments.Count > 0,
+                            HasEmbeds = message.Embeds.Count > 0,
+                            ReplyToMessageDiscordId = message.ReferencedMessage?.Id,
+                            AttachmentsJson = attachmentsJson,
+                            EmbedsJson = embedsJson,
+                            EventTimestampUtc = message.Timestamp.UtcDateTime,
+                            ReceivedAtUtc = DateTime.UtcNow
+                        });
+
+                        totalInserted++;
+                    }
+                    catch (DbUpdateException ex) when (ex.InnerException is Npgsql.PostgresException { SqlState: "23505" })
+                    {
+                        db.ChangeTracker.Clear();
+                    }
+                }
+
+                if (newMessages.Count > 0)
+                    await db.SaveChangesAsync();
+            }
+            catch (DSharpPlus.Exceptions.UnauthorizedException)
+            {
+                logger.LogDebug("Quick-sync: no permission to read channel {ChannelId}, skipping", channel.Id);
+            }
+            catch (DSharpPlus.Exceptions.NotFoundException)
+            {
+                logger.LogDebug("Quick-sync: channel {ChannelId} not found, skipping", channel.Id);
+            }
+            catch (Exception ex)
+            {
+                logger.LogWarning(ex, "Quick-sync: failed to sync messages for channel {ChannelId}, continuing", channel.Id);
+            }
+        }
+
+        return totalInserted;
+    }
+
+    private async Task<(int presenceSnapshots, int activitiesInserted)> SyncPresencesAsync(DiscordGuild guild)
+    {
+        using var scope = scopeFactory.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<DiscordDbContext>();
+        var userService = scope.ServiceProvider.GetRequiredService<UserService>();
+
+        int presenceSnapshots = 0;
+        int activitiesInserted = 0;
+        var now = DateTime.UtcNow;
+
+        var members = new List<DiscordMember>();
+        await foreach (var member in guild.GetAllMembersAsync())
+        {
+            members.Add(member);
+        }
+
+        foreach (var member in members)
+        {
+            try
+            {
+                var presence = member.Presence;
+                if (presence is null) continue;
+
+                await userService.UpsertUserAsync(member);
+                var userGuid = await db.Users
+                    .Where(u => u.DiscordId == member.Id)
+                    .Select(u => u.Id)
+                    .FirstOrDefaultAsync();
+
+                if (userGuid == Guid.Empty) continue;
+
+                var activitiesJson = SerializeActivities(presence.Activities);
+
+                db.PresenceEvents.Add(new PresenceEventEntity
+                {
+                    UserDiscordId = member.Id,
+                    GuildDiscordId = guild.Id,
+                    EventType = PresenceEventType.BootSnapshot,
+                    DesktopStatusBefore = (int)DiscordUserStatus.Offline,
+                    MobileStatusBefore = (int)DiscordUserStatus.Offline,
+                    WebStatusBefore = (int)DiscordUserStatus.Offline,
+                    DesktopStatusAfter = GetStatusValue(presence.ClientStatus?.Desktop),
+                    MobileStatusAfter = GetStatusValue(presence.ClientStatus?.Mobile),
+                    WebStatusAfter = GetStatusValue(presence.ClientStatus?.Web),
+                    ActivitiesAfterJson = activitiesJson,
+                    EventTimestampUtc = now,
+                    ReceivedAtUtc = now
+                });
+                presenceSnapshots++;
+
+                if (presence.Activities is { Count: > 0 })
+                {
+                    foreach (var activity in presence.Activities)
+                    {
+                        var hasActive = await db.Activities
+                            .AnyAsync(a => a.UserId == userGuid && a.IsActive
+                                && a.Name == activity.Name && a.ActivityType == (int)activity.ActivityType);
+
+                        if (!hasActive)
+                        {
+                            db.Activities.Add(new ActivityEntity
+                            {
+                                UserId = userGuid,
+                                GuildId = await db.Guilds
+                                    .Where(g => g.DiscordId == guild.Id)
+                                    .Select(g => g.Id)
+                                    .FirstAsync(),
+                                ActivityType = (int)activity.ActivityType,
+                                Name = activity.Name,
+                                StreamUrl = activity.StreamUrl,
+                                IsActive = true,
+                                FirstSeenAtUtc = now,
+                                LastSeenAtUtc = now
+                            });
+                            activitiesInserted++;
+                        }
+                    }
+                }
+
+                await db.SaveChangesAsync();
+            }
+            catch (Exception ex)
+            {
+                logger.LogWarning(ex, "Quick-sync: failed to snapshot presence for member {MemberId}, continuing", member.Id);
+            }
+        }
+
+        return (presenceSnapshots, activitiesInserted);
+    }
+
+    private static int GetStatusValue(Optional<DiscordUserStatus>? status)
+    {
+        if (status?.HasValue == true)
+            return (int)status.Value.Value;
+        return (int)DiscordUserStatus.Offline;
+    }
+
+    private static string? SerializeActivities(IReadOnlyList<DiscordActivity>? activities)
+    {
+        if (activities == null || activities.Count == 0)
+            return null;
+
+        var activityData = activities.Select(a => new
+        {
+            a.Name,
+            Type = (int)a.ActivityType,
+            a.StreamUrl
+        }).ToList();
+
+        return JsonSerializer.Serialize(activityData, JsonOptions);
+    }
+}

--- a/src/DiscordEventService/Services/BootQuickSyncService.cs
+++ b/src/DiscordEventService/Services/BootQuickSyncService.cs
@@ -69,70 +69,74 @@ public class BootQuickSyncService(
                 var existingSet = existingDiscordIds.ToHashSet();
 
                 var newMessages = messages.Where(m => !existingSet.Contains(m.Id)).ToList();
+                if (newMessages.Count == 0) continue;
+
+                var uniqueAuthors = newMessages.Select(m => m.Author).DistinctBy(a => a.Id).ToList();
+                foreach (var author in uniqueAuthors)
+                    await userService.UpsertUserAsync(author);
+
+                var authorDiscordIds = newMessages.Select(m => m.Author.Id).Distinct().ToList();
+                var authorLookup = await db.Users
+                    .Where(u => authorDiscordIds.Contains(u.DiscordId))
+                    .ToDictionaryAsync(u => u.DiscordId, u => u.Id);
 
                 foreach (var message in newMessages)
                 {
-                    try
+                    if (!authorLookup.TryGetValue(message.Author.Id, out var authorId))
+                        continue;
+
+                    var attachmentsJson = message.Attachments.Count > 0
+                        ? JsonSerializer.Serialize(message.Attachments.Select(a => new { a.Id, a.Url, a.FileName, a.FileSize }))
+                        : null;
+                    var embedsJson = message.Embeds.Count > 0
+                        ? JsonSerializer.Serialize(message.Embeds)
+                        : null;
+
+                    db.Messages.Add(new MessageEntity
                     {
-                        await userService.UpsertUserAsync(message.Author);
-                        var authorId = await db.Users
-                            .Where(u => u.DiscordId == message.Author.Id)
-                            .Select(u => u.Id)
-                            .FirstOrDefaultAsync();
+                        DiscordId = message.Id,
+                        ChannelId = channelId,
+                        GuildId = guildId,
+                        AuthorId = authorId,
+                        Content = message.Content,
+                        ReplyToDiscordId = message.ReferencedMessage?.Id,
+                        HasAttachments = message.Attachments.Count > 0,
+                        HasEmbeds = message.Embeds.Count > 0,
+                        AttachmentsJson = attachmentsJson,
+                        EmbedsJson = embedsJson,
+                        Flags = (int)(message.Flags ?? 0),
+                        CreatedAtUtc = message.Timestamp.UtcDateTime,
+                        EditedAtUtc = message.EditedTimestamp?.UtcDateTime
+                    });
 
-                        if (authorId == Guid.Empty) continue;
-
-                        var attachmentsJson = message.Attachments.Count > 0
-                            ? JsonSerializer.Serialize(message.Attachments.Select(a => new { a.Id, a.Url, a.FileName, a.FileSize }))
-                            : null;
-                        var embedsJson = message.Embeds.Count > 0
-                            ? JsonSerializer.Serialize(message.Embeds)
-                            : null;
-
-                        db.Messages.Add(new MessageEntity
-                        {
-                            DiscordId = message.Id,
-                            ChannelId = channelId,
-                            GuildId = guildId,
-                            AuthorId = authorId,
-                            Content = message.Content,
-                            ReplyToDiscordId = message.ReferencedMessage?.Id,
-                            HasAttachments = message.Attachments.Count > 0,
-                            HasEmbeds = message.Embeds.Count > 0,
-                            AttachmentsJson = attachmentsJson,
-                            EmbedsJson = embedsJson,
-                            Flags = (int)(message.Flags ?? 0),
-                            CreatedAtUtc = message.Timestamp.UtcDateTime,
-                            EditedAtUtc = message.EditedTimestamp?.UtcDateTime
-                        });
-
-                        db.MessageEvents.Add(new MessageEventEntity
-                        {
-                            MessageDiscordId = message.Id,
-                            ChannelDiscordId = channel.Id,
-                            AuthorDiscordId = message.Author.Id,
-                            GuildDiscordId = guild.Id,
-                            EventType = MessageEventType.Backfilled,
-                            Content = message.Content,
-                            HasAttachments = message.Attachments.Count > 0,
-                            HasEmbeds = message.Embeds.Count > 0,
-                            ReplyToMessageDiscordId = message.ReferencedMessage?.Id,
-                            AttachmentsJson = attachmentsJson,
-                            EmbedsJson = embedsJson,
-                            EventTimestampUtc = message.Timestamp.UtcDateTime,
-                            ReceivedAtUtc = DateTime.UtcNow
-                        });
-
-                        totalInserted++;
-                    }
-                    catch (DbUpdateException ex) when (ex.InnerException is Npgsql.PostgresException { SqlState: "23505" })
+                    db.MessageEvents.Add(new MessageEventEntity
                     {
-                        db.ChangeTracker.Clear();
-                    }
+                        MessageDiscordId = message.Id,
+                        ChannelDiscordId = channel.Id,
+                        AuthorDiscordId = message.Author.Id,
+                        GuildDiscordId = guild.Id,
+                        EventType = MessageEventType.Backfilled,
+                        Content = message.Content,
+                        HasAttachments = message.Attachments.Count > 0,
+                        HasEmbeds = message.Embeds.Count > 0,
+                        ReplyToMessageDiscordId = message.ReferencedMessage?.Id,
+                        AttachmentsJson = attachmentsJson,
+                        EmbedsJson = embedsJson,
+                        EventTimestampUtc = message.Timestamp.UtcDateTime,
+                        ReceivedAtUtc = DateTime.UtcNow
+                    });
+
+                    totalInserted++;
                 }
 
-                if (newMessages.Count > 0)
+                try
+                {
                     await db.SaveChangesAsync();
+                }
+                catch (DbUpdateException ex) when (ex.InnerException is Npgsql.PostgresException { SqlState: "23505" })
+                {
+                    db.ChangeTracker.Clear();
+                }
             }
             catch (DSharpPlus.Exceptions.UnauthorizedException)
             {
@@ -160,6 +164,13 @@ public class BootQuickSyncService(
         int presenceSnapshots = 0;
         int activitiesInserted = 0;
         var now = DateTime.UtcNow;
+
+        var guildGuid = await db.Guilds
+            .Where(g => g.DiscordId == guild.Id)
+            .Select(g => g.Id)
+            .FirstOrDefaultAsync();
+
+        if (guildGuid == Guid.Empty) return (0, 0);
 
         var members = new List<DiscordMember>();
         await foreach (var member in guild.GetAllMembersAsync())
@@ -214,10 +225,7 @@ public class BootQuickSyncService(
                             db.Activities.Add(new ActivityEntity
                             {
                                 UserId = userGuid,
-                                GuildId = await db.Guilds
-                                    .Where(g => g.DiscordId == guild.Id)
-                                    .Select(g => g.Id)
-                                    .FirstAsync(),
+                                GuildId = guildGuid,
                                 ActivityType = (int)activity.ActivityType,
                                 Name = activity.Name,
                                 StreamUrl = activity.StreamUrl,

--- a/src/DiscordEventService/Services/EventHandlers/SocketLifecycleHandler.cs
+++ b/src/DiscordEventService/Services/EventHandlers/SocketLifecycleHandler.cs
@@ -9,6 +9,7 @@ namespace DiscordEventService.Services.EventHandlers;
 
 public class SocketLifecycleHandler(
     IServiceScopeFactory scopeFactory,
+    BootQuickSyncService quickSyncService,
     ILogger<SocketLifecycleHandler> logger) :
     IEventHandler<SocketClosedEventArgs>,
     IEventHandler<SessionResumedEventArgs>,
@@ -105,8 +106,12 @@ public class SocketLifecycleHandler(
             if (gap < ReconnectGapThreshold)
             {
                 logger.LogInformation(
-                    "GuildDownloadCompleted: gap {Gap:c} below threshold, skipping reconnect backfill",
+                    "GuildDownloadCompleted: gap {Gap:c} below threshold, running quick-sync only",
                     gap);
+                foreach (var guildId in e.Guilds.Keys)
+                {
+                    await quickSyncService.SyncAsync(guildId);
+                }
                 return;
             }
 

--- a/src/DiscordEventService/Services/StartupValidator.cs
+++ b/src/DiscordEventService/Services/StartupValidator.cs
@@ -29,6 +29,7 @@ public static class StartupValidator
         typeof(IBackgroundJobClient),
         typeof(IHostEnvironment),
         typeof(IMemoryCache),
+        typeof(BootQuickSyncService),
     ];
 
     public static void ValidateChildContainer(IServiceProvider childProvider, ILogger logger)


### PR DESCRIPTION
## Summary
- On short-gap reconnects (< 30s), runs lightweight quick-sync instead of skipping
- Grabs last 50 messages per text channel, upserts any we don't have
- Snapshots all members' current presence (online/idle/DND + activities)
- Inserts new `ActivityEntity` rows for currently-active activities (never closes stale ones)
- New `PresenceEventType` enum (`Updated=0`, `BootSnapshot=1`) distinguishes snapshot rows
- Registered in DSharpPlus child container + startup validator

## Test plan
- [x] Short-gap restart → "running quick-sync only" log, 6 presence snapshots, 2 new activities
- [x] `presence_events` table shows `event_type=1` for boot snapshots, `event_type=0` for real events
- [x] Completes in ~4 seconds
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)