### PR TITLE
feat: backfill message mentions via regex (§P3.2, #78)

### DIFF
--- a/src/DiscordEventService/Endpoints/OpsEndpoints.cs
+++ b/src/DiscordEventService/Endpoints/OpsEndpoints.cs
@@ -26,6 +26,10 @@ public static class OpsEndpoints
         group.MapPost("/backfill-role-snapshots", BackfillRoleSnapshots)
             .WithName("BackfillRoleSnapshots")
             .Produces<MemberRoleSnapshotBackfillService.Result>(StatusCodes.Status200OK);
+
+        group.MapPost("/backfill-message-mentions", BackfillMessageMentions)
+            .WithName("BackfillMessageMentions")
+            .Produces<MessageMentionsBackfillService.Result>(StatusCodes.Status200OK);
     }
 
     private static async Task<IResult> StartDowntime(
@@ -75,6 +79,14 @@ public static class OpsEndpoints
 
     private static async Task<IResult> BackfillRoleSnapshots(
         MemberRoleSnapshotBackfillService svc,
+        CancellationToken ct)
+    {
+        var result = await svc.BackfillAsync(ct);
+        return Results.Ok(result);
+    }
+
+    private static async Task<IResult> BackfillMessageMentions(
+        MessageMentionsBackfillService svc,
         CancellationToken ct)
     {
         var result = await svc.BackfillAsync(ct);

--- a/src/DiscordEventService/Program.cs
+++ b/src/DiscordEventService/Program.cs
@@ -165,6 +165,7 @@ builder.Services.AddScoped<DowntimeTrackerService>();
 builder.Services.AddScoped<OrphanReplayService>();
 builder.Services.AddScoped<ThreadChannelBackfillService>();
 builder.Services.AddScoped<MemberRoleSnapshotBackfillService>();
+builder.Services.AddScoped<MessageMentionsBackfillService>();
 
 // Health checks
 builder.Services.AddHealthChecks()

--- a/src/DiscordEventService/Services/MessageMentionsBackfillService.cs
+++ b/src/DiscordEventService/Services/MessageMentionsBackfillService.cs
@@ -1,0 +1,126 @@
+using System.Text.RegularExpressions;
+using DiscordEventService.Data;
+using DiscordEventService.Data.Entities.Core;
+using Microsoft.EntityFrameworkCore;
+
+namespace DiscordEventService.Services;
+
+public partial class MessageMentionsBackfillService(
+    DiscordDbContext db,
+    ILogger<MessageMentionsBackfillService> logger)
+{
+    public record Result(
+        int MessagesScanned,
+        int MessagesSkipped,
+        int MessagesProcessed,
+        int MentionsCreated);
+
+    [GeneratedRegex(@"<@!?(\d+)>")]
+    private static partial Regex UserMentionRegex();
+
+    [GeneratedRegex(@"<@&(\d+)>")]
+    private static partial Regex RoleMentionRegex();
+
+    [GeneratedRegex(@"<#(\d+)>")]
+    private static partial Regex ChannelMentionRegex();
+
+    public async Task<Result> BackfillAsync(CancellationToken ct)
+    {
+        var alreadyProcessed = await db.MessageMentions
+            .Select(m => m.MessageId)
+            .Distinct()
+            .ToHashSetAsync(ct);
+
+        var messages = await db.Messages
+            .Where(m => !m.IsDeleted && m.Content != null && m.Content != "")
+            .Select(m => new { m.Id, m.Content })
+            .ToListAsync(ct);
+
+        logger.LogInformation("Mention backfill: {Total} messages with content, {Skipped} already have mentions",
+            messages.Count, alreadyProcessed.Count);
+
+        int scanned = messages.Count;
+        int skipped = 0;
+        int processed = 0;
+        int mentionsCreated = 0;
+
+        foreach (var msg in messages)
+        {
+            ct.ThrowIfCancellationRequested();
+
+            if (alreadyProcessed.Contains(msg.Id))
+            {
+                skipped++;
+                continue;
+            }
+
+            var mentions = ExtractMentions(msg.Id, msg.Content!);
+            if (mentions.Count == 0)
+                continue;
+
+            db.MessageMentions.AddRange(mentions);
+            await db.SaveChangesAsync(ct);
+            db.ChangeTracker.Clear();
+            processed++;
+            mentionsCreated += mentions.Count;
+        }
+
+        logger.LogInformation("Mention backfill done: {Processed} messages processed, {Created} mentions created",
+            processed, mentionsCreated);
+
+        return new Result(scanned, skipped, processed, mentionsCreated);
+    }
+
+    private static List<MessageMentionEntity> ExtractMentions(Guid messageId, string content)
+    {
+        var mentions = new List<MessageMentionEntity>();
+        var seen = new HashSet<(MessageMentionType, ulong?)>();
+
+        foreach (Match match in UserMentionRegex().Matches(content))
+        {
+            if (ulong.TryParse(match.Groups[1].Value, out var userId) && seen.Add((MessageMentionType.User, userId)))
+            {
+                mentions.Add(new MessageMentionEntity
+                {
+                    MessageId = messageId,
+                    MentionedUserDiscordId = userId,
+                    MentionType = MessageMentionType.User
+                });
+            }
+        }
+
+        foreach (Match match in RoleMentionRegex().Matches(content))
+        {
+            if (ulong.TryParse(match.Groups[1].Value, out var roleId) && seen.Add((MessageMentionType.Role, roleId)))
+            {
+                mentions.Add(new MessageMentionEntity
+                {
+                    MessageId = messageId,
+                    MentionedRoleDiscordId = roleId,
+                    MentionType = MessageMentionType.Role
+                });
+            }
+        }
+
+        foreach (Match match in ChannelMentionRegex().Matches(content))
+        {
+            if (ulong.TryParse(match.Groups[1].Value, out var channelId) && seen.Add((MessageMentionType.Channel, channelId)))
+            {
+                mentions.Add(new MessageMentionEntity
+                {
+                    MessageId = messageId,
+                    MentionedChannelDiscordId = channelId,
+                    MentionType = MessageMentionType.Channel
+                });
+            }
+        }
+
+        if (content.Contains("@everyone", StringComparison.Ordinal))
+            mentions.Add(new MessageMentionEntity { MessageId = messageId, MentionType = MessageMentionType.Everyone });
+
+        if (content.Contains("@here", StringComparison.Ordinal))
+            mentions.Add(new MessageMentionEntity { MessageId = messageId, MentionType = MessageMentionType.Here });
+
+        return mentions;
+    }
+}


### PR DESCRIPTION
## Summary
- Adds `POST /api/ops/backfill-message-mentions` one-shot endpoint that regex-parses stored `messages.content` to retroactively populate `message_mentions` rows
- Patterns: `<@!?ID>` (user), `<@&ID>` (role), `<#ID>` (channel), `@everyone`, `@here`
- Idempotent: skips messages that already have mention rows; deduplicates within each message via HashSet
- Excludes soft-deleted messages; clears EF ChangeTracker after each save

Closes #78

## Test plan
- [ ] Deploy and call `POST /api/ops/backfill-message-mentions`
- [ ] Verify `SELECT count(DISTINCT message_id) FROM message_mentions` is non-zero and plausible
- [ ] Re-run endpoint — should return `MessagesSkipped` matching prior `MessagesProcessed`, `MentionsCreated = 0`
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)