### PR TITLE
feat: UserNameHistoryEntity + diff capture in UserService (§P3.3, #79)

### DIFF
--- a/src/DiscordEventService/Data/DiscordDbContext.cs
+++ b/src/DiscordEventService/Data/DiscordDbContext.cs
@@ -30,6 +30,9 @@ public class DiscordDbContext(DbContextOptions<DiscordDbContext> options) : DbCo
     // Member role snapshots (SCD for historical role membership)
     public DbSet<MemberRoleSnapshotEntity> MemberRoleSnapshots => Set<MemberRoleSnapshotEntity>();
 
+    // User name history
+    public DbSet<UserNameHistoryEntity> UserNameHistory => Set<UserNameHistoryEntity>();
+
     // Event entities - Messages & Reactions
     public DbSet<MessageEventEntity> MessageEvents => Set<MessageEventEntity>();
     public DbSet<ReactionEventEntity> ReactionEvents => Set<ReactionEventEntity>();
@@ -685,6 +688,17 @@ public class DiscordDbContext(DbContextOptions<DiscordDbContext> options) : DbCo
             b.HasIndex(s => new { s.MemberId, s.RoleDiscordId })
                 .IsUnique()
                 .HasFilter("revoked_at_utc IS NULL");
+        });
+
+        modelBuilder.Entity<UserNameHistoryEntity>(b =>
+        {
+            b.HasOne(h => h.User)
+                .WithMany()
+                .HasForeignKey(h => h.UserId)
+                .OnDelete(DeleteBehavior.Restrict);
+
+            b.HasIndex(h => h.UserId);
+            b.HasIndex(h => h.ChangedAtUtc);
         });
 
         // =====================================================

--- a/src/DiscordEventService/Data/Entities/Core/UserNameHistoryEntity.cs
+++ b/src/DiscordEventService/Data/Entities/Core/UserNameHistoryEntity.cs
@@ -1,0 +1,14 @@
+namespace DiscordEventService.Data.Entities.Core;
+
+public class UserNameHistoryEntity
+{
+    public Guid Id { get; set; }
+    public Guid UserId { get; set; }
+    public string? UsernameBefore { get; set; }
+    public string? UsernameAfter { get; set; }
+    public string? GlobalNameBefore { get; set; }
+    public string? GlobalNameAfter { get; set; }
+    public DateTime ChangedAtUtc { get; set; }
+
+    public UserEntity User { get; set; } = null!;
+}

--- a/src/DiscordEventService/Data/Migrations/20260524134121_P3_3_UserNameHistory.Designer.cs
+++ b/src/DiscordEventService/Data/Migrations/20260524134121_P3_3_UserNameHistory.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using DiscordEventService.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -11,9 +12,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace DiscordEventService.Data.Migrations
 {
     [DbContext(typeof(DiscordDbContext))]
-    partial class DiscordDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260524134121_P3_3_UserNameHistory")]
+    partial class P3_3_UserNameHistory
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/DiscordEventService/Data/Migrations/20260524134121_P3_3_UserNameHistory.cs
+++ b/src/DiscordEventService/Data/Migrations/20260524134121_P3_3_UserNameHistory.cs
@@ -1,0 +1,55 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace DiscordEventService.Data.Migrations
+{
+    /// <inheritdoc />
+    public partial class P3_3_UserNameHistory : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "user_name_history",
+                columns: table => new
+                {
+                    id = table.Column<Guid>(type: "uuid", nullable: false, defaultValueSql: "uuidv7()"),
+                    user_id = table.Column<Guid>(type: "uuid", nullable: false),
+                    username_before = table.Column<string>(type: "text", nullable: true),
+                    username_after = table.Column<string>(type: "text", nullable: true),
+                    global_name_before = table.Column<string>(type: "text", nullable: true),
+                    global_name_after = table.Column<string>(type: "text", nullable: true),
+                    changed_at_utc = table.Column<DateTime>(type: "timestamp with time zone", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("pk_user_name_history", x => x.id);
+                    table.ForeignKey(
+                        name: "fk_user_name_history_users_user_id",
+                        column: x => x.user_id,
+                        principalTable: "users",
+                        principalColumn: "id",
+                        onDelete: ReferentialAction.Restrict);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "ix_user_name_history_changed_at_utc",
+                table: "user_name_history",
+                column: "changed_at_utc");
+
+            migrationBuilder.CreateIndex(
+                name: "ix_user_name_history_user_id",
+                table: "user_name_history",
+                column: "user_id");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "user_name_history");
+        }
+    }
+}

--- a/src/DiscordEventService/Services/UserService.cs
+++ b/src/DiscordEventService/Services/UserService.cs
@@ -9,15 +9,48 @@ public class UserService(DiscordDbContext db, ILogger<UserService> logger)
 {
     public async Task UpsertUserAsync(DiscordUser user)
     {
-        var rowsAffected = await db.Users
+        var existing = await db.Users
             .Where(u => u.DiscordId == user.Id)
-            .ExecuteUpdateAsync(s => s
-                .SetProperty(u => u.Username, user.Username)
-                .SetProperty(u => u.GlobalName, user.GlobalName)
-                .SetProperty(u => u.Discriminator, user.Discriminator)
-                .SetProperty(u => u.AvatarHash, user.AvatarHash));
+            .Select(u => new { u.Id, u.Username, u.GlobalName })
+            .FirstOrDefaultAsync();
 
-        if (rowsAffected == 0)
+        if (existing is not null)
+        {
+            await db.Users
+                .Where(u => u.DiscordId == user.Id)
+                .ExecuteUpdateAsync(s => s
+                    .SetProperty(u => u.Username, user.Username)
+                    .SetProperty(u => u.GlobalName, user.GlobalName)
+                    .SetProperty(u => u.Discriminator, user.Discriminator)
+                    .SetProperty(u => u.AvatarHash, user.AvatarHash));
+
+            var usernameChanged = existing.Username != user.Username;
+            var globalNameChanged = existing.GlobalName != user.GlobalName;
+
+            if (usernameChanged || globalNameChanged)
+            {
+                db.UserNameHistory.Add(new UserNameHistoryEntity
+                {
+                    UserId = existing.Id,
+                    UsernameBefore = usernameChanged ? existing.Username : null,
+                    UsernameAfter = usernameChanged ? user.Username : null,
+                    GlobalNameBefore = globalNameChanged ? existing.GlobalName : null,
+                    GlobalNameAfter = globalNameChanged ? user.GlobalName : null,
+                    ChangedAtUtc = DateTime.UtcNow
+                });
+                await db.SaveChangesAsync();
+                db.ChangeTracker.Clear();
+
+                logger.LogInformation(
+                    "User name changed for {DiscordId}: username {OldUser} → {NewUser}, globalName {OldGlobal} → {NewGlobal}",
+                    user.Id,
+                    usernameChanged ? existing.Username : "(unchanged)",
+                    usernameChanged ? user.Username : "(unchanged)",
+                    globalNameChanged ? existing.GlobalName : "(unchanged)",
+                    globalNameChanged ? user.GlobalName : "(unchanged)");
+            }
+        }
+        else
         {
             try
             {
@@ -35,7 +68,8 @@ public class UserService(DiscordDbContext db, ILogger<UserService> logger)
             }
             catch (DbUpdateException ex) when (ex.InnerException is Npgsql.PostgresException { SqlState: "23505" })
             {
-                // Unique constraint violation - race condition, another request inserted first
+                // Race: another thread inserted first — update to latest values.
+                // No history row: we have no reliable "before" to compare against.
                 db.ChangeTracker.Clear();
                 await db.Users
                     .Where(u => u.DiscordId == user.Id)


### PR DESCRIPTION
## Summary
- New `UserNameHistoryEntity` with FK to `users`, indexes on `user_id` and `changed_at_utc`
- Modified `UserService.UpsertUserAsync` to pre-fetch current username/globalName, compare after update, and insert a history row on change
- Skips history capture in the 23505 race fallback path (no reliable "before" values)
- EF migration creates `user_name_history` table with `uuidv7()` PK

Closes #79

## Test plan
- [ ] Change a test user's username or display name in Discord → row appears in `user_name_history`
- [ ] Same values observed again → no duplicate history row
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)