### PR TITLE
feat: add starter_message_discord_id to thread_events (§P3.5, #81)

### DIFF
--- a/src/DiscordEventService/Data/Entities/Events/ThreadEventEntity.cs
+++ b/src/DiscordEventService/Data/Entities/Events/ThreadEventEntity.cs
@@ -17,6 +17,7 @@ public class ThreadEventEntity
     public ThreadEventType EventType { get; set; }
     public string? Name { get; set; }
     public ulong? OwnerDiscordId { get; set; }
+    public ulong? StarterMessageDiscordId { get; set; }
     public bool IsArchived { get; set; }
     public bool IsLocked { get; set; }
     public string? MembersAddedJson { get; set; }

--- a/src/DiscordEventService/Data/Migrations/20260524163657_P3_5_ThreadStarterMessageId.Designer.cs
+++ b/src/DiscordEventService/Data/Migrations/20260524163657_P3_5_ThreadStarterMessageId.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using DiscordEventService.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -11,9 +12,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace DiscordEventService.Data.Migrations
 {
     [DbContext(typeof(DiscordDbContext))]
-    partial class DiscordDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260524163657_P3_5_ThreadStarterMessageId")]
+    partial class P3_5_ThreadStarterMessageId
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/DiscordEventService/Data/Migrations/20260524163657_P3_5_ThreadStarterMessageId.cs
+++ b/src/DiscordEventService/Data/Migrations/20260524163657_P3_5_ThreadStarterMessageId.cs
@@ -1,0 +1,39 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace DiscordEventService.Data.Migrations
+{
+    /// <inheritdoc />
+    public partial class P3_5_ThreadStarterMessageId : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<long>(
+                name: "starter_message_discord_id",
+                table: "thread_events",
+                type: "bigint",
+                nullable: true);
+
+            migrationBuilder.Sql("""
+                UPDATE thread_events te
+                SET starter_message_discord_id = te.thread_discord_id
+                WHERE te.event_type = 0
+                  AND te.starter_message_discord_id IS NULL
+                  AND EXISTS (
+                    SELECT 1 FROM messages m
+                    WHERE m.discord_id = te.thread_discord_id
+                  );
+                """);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "starter_message_discord_id",
+                table: "thread_events");
+        }
+    }
+}

--- a/src/DiscordEventService/Services/EventHandlers/ThreadEventHandler.cs
+++ b/src/DiscordEventService/Services/EventHandlers/ThreadEventHandler.cs
@@ -2,6 +2,7 @@ using System.Text.Json;
 using DiscordEventService.Data;
 using DiscordEventService.Data.Entities.Events;
 using DSharpPlus;
+using DSharpPlus.Entities;
 using DSharpPlus.EventArgs;
 
 namespace DiscordEventService.Services.EventHandlers;
@@ -35,6 +36,9 @@ public class ThreadEventHandler(IServiceScopeFactory scopeFactory, ILogger<Threa
             var guildId = await guildUpsert.UpsertGuildAsync(e.Guild);
             await channelUpsert.UpsertChannelAsync(e.Thread, guildId);
 
+            // For message threads (parent is text/news), thread ID == starter message ID
+            var isMessageThread = e.Parent?.Type is DiscordChannelType.Text or DiscordChannelType.News;
+
             var threadEvent = new ThreadEventEntity
             {
                 ThreadDiscordId = e.Thread.Id,
@@ -43,6 +47,7 @@ public class ThreadEventHandler(IServiceScopeFactory scopeFactory, ILogger<Threa
                 EventType = ThreadEventType.Created,
                 Name = e.Thread.Name,
                 OwnerDiscordId = e.Thread.CreatorId,
+                StarterMessageDiscordId = isMessageThread ? e.Thread.Id : null,
                 IsArchived = e.Thread.ThreadMetadata?.IsArchived ?? false,
                 IsLocked = e.Thread.ThreadMetadata?.IsLocked ?? false,
                 EventTimestampUtc = DateTime.UtcNow,


### PR DESCRIPTION
## Summary
- New `starter_message_discord_id` nullable column on `thread_events`
- Forward path: on `ThreadCreated`, if the parent channel is text/news (message thread), sets `starter_message_discord_id = e.Thread.Id` (Discord's snowflake equality convention)
- Migration backfills existing 3 ThreadCreated rows by matching `thread_discord_id` against the `messages` table
- Forum/media thread posts leave the column null (starter message arrives as a separate MessageCreated event)

Closes #81

## Test plan
- [ ] Create a thread from a message → `starter_message_discord_id` populated
- [ ] `SELECT starter_message_discord_id FROM thread_events WHERE event_type = 0` shows values for existing threads
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)