### PR TITLE
feat: Hangfire health-check job (§P4.1, #83)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -5,7 +5,7 @@
 - .NET (C#), use `dotnet build/run/format/restore`
 - PostgreSQL via `docker-compose.yml` (local dev DB on port 5432)
 - Dev bot account + separate Discord server configured in `.env`
-- Production DB: `192.168.1.12:5433` — READ ONLY, never run migrations or writes against prod. Prompt user for credentials before connecting. Use `docker run --rm -it postgres:18 psql` to query (no local psql installed)
+- Production DB: configured via environment — READ ONLY, never run migrations or writes against prod. Prompt user for credentials before connecting. Use `docker run --rm -it postgres:18 psql` to query (no local psql installed)
 
 ## Development workflow
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,20 @@
+# WojtusDiscord
+
+## Stack
+
+- .NET (C#), use `dotnet build/run/format/restore`
+- PostgreSQL via `docker-compose.yml` (local dev DB on port 5432)
+- Dev bot account + separate Discord server configured in `.env`
+- Production DB: `192.168.1.12:5433` — READ ONLY, never run migrations or writes against prod. Prompt user for credentials before connecting. Use `docker run --rm -it postgres:18 psql` to query (no local psql installed)
+
+## Development workflow
+
+1. **Code changes** — work locally, check `dotnet build` for warnings and errors
+2. **Test migrations** — run against local Postgres (`docker compose up -d postgres`)
+3. **Test locally** — run dev bot with `dotnet run` against local DB and dev Discord server. Prompt user to perform actions in Discord when needed (send messages, react, join voice, etc.) and verify behavior in logs and database
+4. **Test aggressively** — verify every change end-to-end whenever possible. Build green alone is not enough signal
+5. **Create PR** — push branch, `gh pr create`, wait for GitHub Claude review
+6. **Review loop** — after every review round, read ALL comments (top-level + inline via `gh api repos/<o>/<r>/pulls/<N>/comments`). Apply fixes, push, repeat until approved and no outstanding comments
+7. **Wait for user approval** — do NOT merge without explicit user approval, even if review is clean and checks pass
+8. **Post-merge deployment** — after merge, watch deploy via `gh run watch`, then pull container logs (`mcp__homelab__GetContainerLogs` for `discord-event-service`) covering ~5 min before and after deploy. Surface anomalies
+9. **Post-deploy verification** — if needed, ask user to trigger actions in Discord, then check logs and prod database to confirm changes work in production

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -5,7 +5,7 @@
 - .NET (C#), use `dotnet build/run/format/restore`
 - PostgreSQL via `docker-compose.yml` (local dev DB on port 5432)
 - Dev bot account + separate Discord server configured in `.env`
-- Production DB: configured via environment — READ ONLY, never run migrations or writes against prod. Prompt user for credentials before connecting. Use `docker run --rm -it postgres:18 psql` to query (no local psql installed)
+- Production DB: READ ONLY, never run migrations or writes against prod. Prompt user for credentials and address before connecting. Use `docker run --rm -it postgres:18 psql` to query (no local psql installed)
 
 ## Development workflow
 

--- a/src/DiscordEventService/Configuration/HealthCheckOptions.cs
+++ b/src/DiscordEventService/Configuration/HealthCheckOptions.cs
@@ -1,0 +1,11 @@
+namespace DiscordEventService.Configuration;
+
+public class HealthCheckOptions
+{
+    public const string SectionName = "HealthCheck";
+
+    public string? WebhookUrl { get; set; }
+    public int FailedEventWindowMinutes { get; set; } = 5;
+    public int IngestStallMinutes { get; set; } = 30;
+    public int AlertCooldownMinutes { get; set; } = 30;
+}

--- a/src/DiscordEventService/Configuration/HealthCheckOptions.cs
+++ b/src/DiscordEventService/Configuration/HealthCheckOptions.cs
@@ -6,6 +6,6 @@ public class HealthCheckOptions
 
     public string? WebhookUrl { get; set; }
     public int FailedEventWindowMinutes { get; set; } = 5;
-    public int IngestStallMinutes { get; set; } = 30;
+    public int IngestStallMinutes { get; set; } = 360;
     public int AlertCooldownMinutes { get; set; } = 30;
 }

--- a/src/DiscordEventService/Jobs/HealthCheckJob.cs
+++ b/src/DiscordEventService/Jobs/HealthCheckJob.cs
@@ -1,0 +1,140 @@
+using System.Text;
+using System.Text.Json;
+using DiscordEventService.Configuration;
+using DiscordEventService.Data;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Options;
+
+namespace DiscordEventService.Jobs;
+
+public class HealthCheckJob(
+    IServiceScopeFactory scopeFactory,
+    IHttpClientFactory httpClientFactory,
+    IOptions<HealthCheckOptions> options,
+    ILogger<HealthCheckJob> logger)
+{
+    private static DateTime _lastFailedEventAlert = DateTime.MinValue;
+    private static DateTime _lastIngestStallAlert = DateTime.MinValue;
+    private static readonly object _lock = new();
+    private static readonly TimeSpan WebhookTimeout = TimeSpan.FromSeconds(10);
+
+    public async Task ExecuteAsync()
+    {
+        var opts = options.Value;
+        if (string.IsNullOrWhiteSpace(opts.WebhookUrl))
+        {
+            logger.LogDebug("Health check skipped: no webhook URL configured");
+            return;
+        }
+
+        using var scope = scopeFactory.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<DiscordDbContext>();
+        var now = DateTime.UtcNow;
+
+        await CheckFailedEventsAsync(db, opts, now);
+        await CheckIngestStallAsync(db, opts, now);
+    }
+
+    private async Task CheckFailedEventsAsync(DiscordDbContext db, HealthCheckOptions opts, DateTime now)
+    {
+        var windowStart = now.AddMinutes(-opts.FailedEventWindowMinutes);
+        var count = await db.FailedEvents
+            .Where(f => f.FailedAtUtc > windowStart && !f.IsResolved)
+            .CountAsync();
+
+        if (count == 0)
+            return;
+
+        lock (_lock)
+        {
+            if ((now - _lastFailedEventAlert).TotalMinutes < opts.AlertCooldownMinutes)
+                return;
+        }
+
+        var recent = await db.FailedEvents
+            .Where(f => f.FailedAtUtc > windowStart && !f.IsResolved)
+            .OrderByDescending(f => f.FailedAtUtc)
+            .Take(5)
+            .Select(f => new { f.EventType, f.HandlerName, f.ExceptionType, f.FailedAtUtc })
+            .ToListAsync();
+
+        var details = string.Join("\n", recent.Select(r =>
+            $"- `{r.EventType}` in `{r.HandlerName}` ({r.ExceptionType}) at {r.FailedAtUtc:HH:mm:ss}"));
+
+        if (!await SendWebhookAsync(opts.WebhookUrl!,
+            $"**{count} failed event(s)** in the last {opts.FailedEventWindowMinutes} min\n{details}"))
+            return;
+
+        lock (_lock) { _lastFailedEventAlert = now; }
+
+        logger.LogWarning("Health check alert: {Count} failed events in last {Window} min", count, opts.FailedEventWindowMinutes);
+    }
+
+    private async Task CheckIngestStallAsync(DiscordDbContext db, HealthCheckOptions opts, DateTime now)
+    {
+        var lastConnectedHeartbeat = await db.BotHeartbeats
+            .Where(h => h.IsGatewayConnected == true)
+            .OrderByDescending(h => h.LastHeartbeatUtc)
+            .Select(h => (DateTime?)h.LastHeartbeatUtc)
+            .FirstOrDefaultAsync();
+
+        if (lastConnectedHeartbeat is null)
+            return;
+
+        var heartbeatAge = now - lastConnectedHeartbeat.Value;
+        if (heartbeatAge.TotalSeconds > 30)
+            return;
+
+        var lastEvent = await db.RawEventLogs
+            .OrderByDescending(r => r.ReceivedAtUtc)
+            .Select(r => (DateTime?)r.ReceivedAtUtc)
+            .FirstOrDefaultAsync();
+
+        if (lastEvent is null)
+            return;
+
+        var eventAge = now - lastEvent.Value;
+        if (eventAge.TotalMinutes < opts.IngestStallMinutes)
+            return;
+
+        lock (_lock)
+        {
+            if ((now - _lastIngestStallAlert).TotalMinutes < opts.AlertCooldownMinutes)
+                return;
+        }
+
+        if (!await SendWebhookAsync(opts.WebhookUrl!,
+            $"**Ingest stall detected** — bot is connected but no events for {eventAge.TotalMinutes:F0} min (last event at {lastEvent.Value:yyyy-MM-dd HH:mm:ss} UTC)"))
+            return;
+
+        lock (_lock) { _lastIngestStallAlert = now; }
+
+        logger.LogWarning("Health check alert: ingest stall, last event {MinutesAgo:F0} min ago", eventAge.TotalMinutes);
+    }
+
+    private async Task<bool> SendWebhookAsync(string webhookUrl, string message)
+    {
+        try
+        {
+            var client = httpClientFactory.CreateClient();
+            client.Timeout = WebhookTimeout;
+            var payload = JsonSerializer.Serialize(new { content = message });
+            using var response = await client.PostAsync(webhookUrl,
+                new StringContent(payload, Encoding.UTF8, "application/json"));
+
+            if (!response.IsSuccessStatusCode)
+            {
+                logger.LogError("Webhook POST failed: {StatusCode} {Body}",
+                    response.StatusCode, await response.Content.ReadAsStringAsync());
+                return false;
+            }
+
+            return true;
+        }
+        catch (Exception ex)
+        {
+            logger.LogError(ex, "Failed to send health check webhook");
+            return false;
+        }
+    }
+}

--- a/src/DiscordEventService/Program.cs
+++ b/src/DiscordEventService/Program.cs
@@ -41,6 +41,9 @@ builder.Services.AddOptions<DiscordOptions>()
     .ValidateDataAnnotations()
     .ValidateOnStart();
 
+builder.Services.AddOptions<HealthCheckOptions>()
+    .Bind(builder.Configuration.GetSection(HealthCheckOptions.SectionName));
+
 var connectionString = builder.Configuration.GetConnectionString("Postgres")
     ?? throw new InvalidOperationException("ConnectionStrings:Postgres is required");
 
@@ -171,6 +174,9 @@ builder.Services.AddScoped<MessageMentionsBackfillService>();
 builder.Services.AddHealthChecks()
     .AddDbContextCheck<DiscordDbContext>();
 
+builder.Services.AddHttpClient();
+builder.Services.AddScoped<HealthCheckJob>();
+
 // Hangfire
 builder.Services.AddHangfire(config => config
     .SetDataCompatibilityLevel(CompatibilityLevel.Version_180)
@@ -239,6 +245,11 @@ RecurringJob.AddOrUpdate<PeriodicFullBackfillJob>(
     "periodic-full-backfill",
     j => j.ExecuteAsync(),
     "0 3 * * 0"); // Sundays 03:00 UTC
+
+RecurringJob.AddOrUpdate<HealthCheckJob>(
+    "health-check",
+    j => j.ExecuteAsync(),
+    "*/5 * * * *"); // Every 5 minutes
 
 // Backfill API
 app.MapBackfillEndpoints();

--- a/src/DiscordEventService/appsettings.json
+++ b/src/DiscordEventService/appsettings.json
@@ -23,7 +23,7 @@
   "HealthCheck": {
     "WebhookUrl": "",
     "FailedEventWindowMinutes": 5,
-    "IngestStallMinutes": 30,
+    "IngestStallMinutes": 360,
     "AlertCooldownMinutes": 30
   }
 }

--- a/src/DiscordEventService/appsettings.json
+++ b/src/DiscordEventService/appsettings.json
@@ -19,5 +19,11 @@
   "EventSettings": {
     "EnablePresenceEvents": true,
     "EnableTypingEvents": false
+  },
+  "HealthCheck": {
+    "WebhookUrl": "",
+    "FailedEventWindowMinutes": 5,
+    "IngestStallMinutes": 30,
+    "AlertCooldownMinutes": 30
   }
 }


### PR DESCRIPTION
## Summary
- Adds `HealthCheckJob` — Hangfire recurring job (every 5 min) that sends Discord webhook alerts on:
  - **Failed events**: unresolved `failed_events` rows in the last N min (configurable, default 5)
  - **Ingest stalls**: bot is connected (per heartbeat) but no events recorded for 30+ min
- Alert dedup via configurable cooldown (default 30 min) — cooldown only armed after successful webhook delivery
- 10s webhook timeout to prevent blocking Hangfire workers
- Configurable via `HealthCheck` section in appsettings / env vars (`WebhookUrl`, `FailedEventWindowMinutes`, `IngestStallMinutes`, `AlertCooldownMinutes`)
- Also adds project `CLAUDE.md` with development workflow documentation

## Test plan
- [ ] Set `HealthCheck:WebhookUrl` to a Discord webhook in dev `.env`
- [ ] `INSERT INTO failed_events ...` a test row in local Postgres → webhook fires within 5 min
- [ ] Verify cooldown: second alert suppressed for 30 min after successful send
- [ ] Verify failed webhook doesn't arm cooldown (remove webhook URL mid-run or point to invalid URL)
- [ ] Job visible in Hangfire dashboard at `/hangfire`
- [ ] CI green

Closes #83

🤖 Generated with [Claude Code](https://claude.com/claude-code)