### PR TITLE
feat: correlation IDs across handler logs (§P4.3, #85)

### DIFF
--- a/src/DiscordEventService/Data/Entities/Events/FailedEventEntity.cs
+++ b/src/DiscordEventService/Data/Entities/Events/FailedEventEntity.cs
@@ -91,4 +91,6 @@ public class FailedEventEntity
     /// Notes about resolution
     /// </summary>
     public string? ResolutionNotes { get; set; }
+
+    public Guid? CorrelationId { get; set; }
 }

--- a/src/DiscordEventService/Data/Entities/Events/RawEventLogEntity.cs
+++ b/src/DiscordEventService/Data/Entities/Events/RawEventLogEntity.cs
@@ -46,4 +46,6 @@ public class RawEventLogEntity
     /// When the event was received
     /// </summary>
     public DateTime ReceivedAtUtc { get; set; } = DateTime.UtcNow;
+
+    public Guid? CorrelationId { get; set; }
 }

--- a/src/DiscordEventService/Data/Migrations/20260524205032_P4_3_CorrelationIds.Designer.cs
+++ b/src/DiscordEventService/Data/Migrations/20260524205032_P4_3_CorrelationIds.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using DiscordEventService.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -11,9 +12,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace DiscordEventService.Data.Migrations
 {
     [DbContext(typeof(DiscordDbContext))]
-    partial class DiscordDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260524205032_P4_3_CorrelationIds")]
+    partial class P4_3_CorrelationIds
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/DiscordEventService/Data/Migrations/20260524205032_P4_3_CorrelationIds.cs
+++ b/src/DiscordEventService/Data/Migrations/20260524205032_P4_3_CorrelationIds.cs
@@ -1,0 +1,39 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace DiscordEventService.Data.Migrations
+{
+    /// <inheritdoc />
+    public partial class P4_3_CorrelationIds : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<Guid>(
+                name: "correlation_id",
+                table: "raw_event_logs",
+                type: "uuid",
+                nullable: true);
+
+            migrationBuilder.AddColumn<Guid>(
+                name: "correlation_id",
+                table: "failed_events",
+                type: "uuid",
+                nullable: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "correlation_id",
+                table: "raw_event_logs");
+
+            migrationBuilder.DropColumn(
+                name: "correlation_id",
+                table: "failed_events");
+        }
+    }
+}

--- a/src/DiscordEventService/Services/EventHandlers/AuditLogEventHandler.cs
+++ b/src/DiscordEventService/Services/EventHandlers/AuditLogEventHandler.cs
@@ -10,42 +10,46 @@ public class AuditLogEventHandler(IServiceScopeFactory scopeFactory, ILogger<Aud
 {
     public async Task HandleEventAsync(DiscordClient sender, GuildAuditLogCreatedEventArgs e)
     {
-        string? rawJson = null;
-        try
+        var correlationId = Guid.NewGuid();
+        using (logger.BeginScope(new Dictionary<string, object> { ["CorrelationId"] = correlationId }))
         {
-            var now = DateTime.UtcNow;
-            using var scope = scopeFactory.CreateScope();
-            var db = scope.ServiceProvider.GetRequiredService<DiscordDbContext>();
-            var rawEventService = scope.ServiceProvider.GetRequiredService<RawEventLogService>();
-
-            rawJson = await rawEventService.SerializeAndLogAsync(
-                e, "GuildAuditLogCreated", e.Guild.Id, null, e.AuditLogEntry.UserResponsible?.Id);
-
-            db.AuditLogEvents.Add(new AuditLogEventEntity
+            string? rawJson = null;
+            try
             {
-                AuditLogDiscordId = e.AuditLogEntry.Id,
-                GuildDiscordId = e.Guild.Id,
-                UserDiscordId = e.AuditLogEntry.UserResponsible?.Id,
-                TargetDiscordId = null,
-                ActionType = (int)e.AuditLogEntry.ActionType,
-                Reason = e.AuditLogEntry.Reason,
-                ChangesJson = null,
-                OptionsJson = null,
-                EventTimestampUtc = now,
-                ReceivedAtUtc = now,
-                RawEventJson = rawJson
-            });
+                var now = DateTime.UtcNow;
+                using var scope = scopeFactory.CreateScope();
+                var db = scope.ServiceProvider.GetRequiredService<DiscordDbContext>();
+                var rawEventService = scope.ServiceProvider.GetRequiredService<RawEventLogService>();
 
-            await db.SaveChangesAsync();
-        }
-        catch (Exception ex)
-        {
-            logger.LogError(ex, "Error handling audit log entry");
-            using var failureScope = scopeFactory.CreateScope();
-            var failedEventService = failureScope.ServiceProvider.GetRequiredService<FailedEventService>();
-            await failedEventService.RecordFailureAsync(
-                "GuildAuditLogCreated", nameof(AuditLogEventHandler), ex,
-                e.Guild?.Id, null, e.AuditLogEntry?.UserResponsible?.Id, rawJson);
+                rawJson = await rawEventService.SerializeAndLogAsync(
+                    e, "GuildAuditLogCreated", e.Guild.Id, null, e.AuditLogEntry.UserResponsible?.Id, correlationId: correlationId);
+
+                db.AuditLogEvents.Add(new AuditLogEventEntity
+                {
+                    AuditLogDiscordId = e.AuditLogEntry.Id,
+                    GuildDiscordId = e.Guild.Id,
+                    UserDiscordId = e.AuditLogEntry.UserResponsible?.Id,
+                    TargetDiscordId = null,
+                    ActionType = (int)e.AuditLogEntry.ActionType,
+                    Reason = e.AuditLogEntry.Reason,
+                    ChangesJson = null,
+                    OptionsJson = null,
+                    EventTimestampUtc = now,
+                    ReceivedAtUtc = now,
+                    RawEventJson = rawJson
+                });
+
+                await db.SaveChangesAsync();
+            }
+            catch (Exception ex)
+            {
+                logger.LogError(ex, "Error handling audit log entry");
+                using var failureScope = scopeFactory.CreateScope();
+                var failedEventService = failureScope.ServiceProvider.GetRequiredService<FailedEventService>();
+                await failedEventService.RecordFailureAsync(
+                    "GuildAuditLogCreated", nameof(AuditLogEventHandler), ex,
+                    e.Guild?.Id, null, e.AuditLogEntry?.UserResponsible?.Id, rawJson, correlationId: correlationId);
+            }
         }
     }
 }

--- a/src/DiscordEventService/Services/EventHandlers/AutoModEventHandler.cs
+++ b/src/DiscordEventService/Services/EventHandlers/AutoModEventHandler.cs
@@ -13,170 +13,186 @@ public class AutoModEventHandler(IServiceScopeFactory scopeFactory, ILogger<Auto
 {
     public async Task HandleEventAsync(DiscordClient sender, AutoModerationRuleCreatedEventArgs e)
     {
-        string? rawJson = null;
-        try
+        var correlationId = Guid.NewGuid();
+        using (logger.BeginScope(new Dictionary<string, object> { ["CorrelationId"] = correlationId }))
         {
-            if (e.Rule?.Guild is null) return;
-
-            var now = DateTime.UtcNow;
-            using var scope = scopeFactory.CreateScope();
-            var db = scope.ServiceProvider.GetRequiredService<DiscordDbContext>();
-            var rawEventService = scope.ServiceProvider.GetRequiredService<RawEventLogService>();
-
-            rawJson = await rawEventService.SerializeAndLogAsync(
-                e, "AutoModRuleCreated", e.Rule.Guild.Id, null, e.Rule.Creator?.Id);
-
-            var entity = new AutoModEventEntity
+            string? rawJson = null;
+            try
             {
-                GuildDiscordId = e.Rule.Guild.Id,
-                RuleDiscordId = e.Rule.Id,
-                EventType = AutoModEventType.RuleCreated,
-                RuleName = e.Rule.Name,
-                TriggerType = (int)e.Rule.TriggerType,
-                EventTimestampUtc = now,
-                ReceivedAtUtc = now,
-                RawEventJson = rawJson
-            };
+                if (e.Rule?.Guild is null) return;
 
-            db.AutoModEvents.Add(entity);
-            await db.SaveChangesAsync();
-        }
-        catch (Exception ex)
-        {
-            logger.LogError(ex, "Error handling automod rule created");
-            using var failureScope = scopeFactory.CreateScope();
-            var failedEventService = failureScope.ServiceProvider.GetRequiredService<FailedEventService>();
-            await failedEventService.RecordFailureAsync(
-                "AutoModRuleCreated", nameof(AutoModEventHandler), ex,
-                e.Rule?.Guild?.Id, null, e.Rule?.Creator?.Id, rawJson);
+                var now = DateTime.UtcNow;
+                using var scope = scopeFactory.CreateScope();
+                var db = scope.ServiceProvider.GetRequiredService<DiscordDbContext>();
+                var rawEventService = scope.ServiceProvider.GetRequiredService<RawEventLogService>();
+
+                rawJson = await rawEventService.SerializeAndLogAsync(
+                    e, "AutoModRuleCreated", e.Rule.Guild.Id, null, e.Rule.Creator?.Id, correlationId: correlationId);
+
+                var entity = new AutoModEventEntity
+                {
+                    GuildDiscordId = e.Rule.Guild.Id,
+                    RuleDiscordId = e.Rule.Id,
+                    EventType = AutoModEventType.RuleCreated,
+                    RuleName = e.Rule.Name,
+                    TriggerType = (int)e.Rule.TriggerType,
+                    EventTimestampUtc = now,
+                    ReceivedAtUtc = now,
+                    RawEventJson = rawJson
+                };
+
+                db.AutoModEvents.Add(entity);
+                await db.SaveChangesAsync();
+            }
+            catch (Exception ex)
+            {
+                logger.LogError(ex, "Error handling automod rule created");
+                using var failureScope = scopeFactory.CreateScope();
+                var failedEventService = failureScope.ServiceProvider.GetRequiredService<FailedEventService>();
+                await failedEventService.RecordFailureAsync(
+                    "AutoModRuleCreated", nameof(AutoModEventHandler), ex,
+                    e.Rule?.Guild?.Id, null, e.Rule?.Creator?.Id, rawJson, correlationId: correlationId);
+            }
         }
     }
 
     public async Task HandleEventAsync(DiscordClient sender, AutoModerationRuleUpdatedEventArgs e)
     {
-        string? rawJson = null;
-        try
+        var correlationId = Guid.NewGuid();
+        using (logger.BeginScope(new Dictionary<string, object> { ["CorrelationId"] = correlationId }))
         {
-            if (e.Rule?.Guild is null) return;
-
-            var now = DateTime.UtcNow;
-            using var scope = scopeFactory.CreateScope();
-            var db = scope.ServiceProvider.GetRequiredService<DiscordDbContext>();
-            var rawEventService = scope.ServiceProvider.GetRequiredService<RawEventLogService>();
-
-            rawJson = await rawEventService.SerializeAndLogAsync(
-                e, "AutoModRuleUpdated", e.Rule.Guild.Id, null, e.Rule.Creator?.Id);
-
-            var entity = new AutoModEventEntity
+            string? rawJson = null;
+            try
             {
-                GuildDiscordId = e.Rule.Guild.Id,
-                RuleDiscordId = e.Rule.Id,
-                EventType = AutoModEventType.RuleUpdated,
-                RuleName = e.Rule.Name,
-                TriggerType = (int)e.Rule.TriggerType,
-                EventTimestampUtc = now,
-                ReceivedAtUtc = now,
-                RawEventJson = rawJson
-            };
+                if (e.Rule?.Guild is null) return;
 
-            db.AutoModEvents.Add(entity);
-            await db.SaveChangesAsync();
-        }
-        catch (Exception ex)
-        {
-            logger.LogError(ex, "Error handling automod rule updated");
-            using var failureScope = scopeFactory.CreateScope();
-            var failedEventService = failureScope.ServiceProvider.GetRequiredService<FailedEventService>();
-            await failedEventService.RecordFailureAsync(
-                "AutoModRuleUpdated", nameof(AutoModEventHandler), ex,
-                e.Rule?.Guild?.Id, null, e.Rule?.Creator?.Id, rawJson);
+                var now = DateTime.UtcNow;
+                using var scope = scopeFactory.CreateScope();
+                var db = scope.ServiceProvider.GetRequiredService<DiscordDbContext>();
+                var rawEventService = scope.ServiceProvider.GetRequiredService<RawEventLogService>();
+
+                rawJson = await rawEventService.SerializeAndLogAsync(
+                    e, "AutoModRuleUpdated", e.Rule.Guild.Id, null, e.Rule.Creator?.Id, correlationId: correlationId);
+
+                var entity = new AutoModEventEntity
+                {
+                    GuildDiscordId = e.Rule.Guild.Id,
+                    RuleDiscordId = e.Rule.Id,
+                    EventType = AutoModEventType.RuleUpdated,
+                    RuleName = e.Rule.Name,
+                    TriggerType = (int)e.Rule.TriggerType,
+                    EventTimestampUtc = now,
+                    ReceivedAtUtc = now,
+                    RawEventJson = rawJson
+                };
+
+                db.AutoModEvents.Add(entity);
+                await db.SaveChangesAsync();
+            }
+            catch (Exception ex)
+            {
+                logger.LogError(ex, "Error handling automod rule updated");
+                using var failureScope = scopeFactory.CreateScope();
+                var failedEventService = failureScope.ServiceProvider.GetRequiredService<FailedEventService>();
+                await failedEventService.RecordFailureAsync(
+                    "AutoModRuleUpdated", nameof(AutoModEventHandler), ex,
+                    e.Rule?.Guild?.Id, null, e.Rule?.Creator?.Id, rawJson, correlationId: correlationId);
+            }
         }
     }
 
     public async Task HandleEventAsync(DiscordClient sender, AutoModerationRuleDeletedEventArgs e)
     {
-        string? rawJson = null;
-        try
+        var correlationId = Guid.NewGuid();
+        using (logger.BeginScope(new Dictionary<string, object> { ["CorrelationId"] = correlationId }))
         {
-            if (e.Rule?.Guild is null) return;
-
-            var now = DateTime.UtcNow;
-            using var scope = scopeFactory.CreateScope();
-            var db = scope.ServiceProvider.GetRequiredService<DiscordDbContext>();
-            var rawEventService = scope.ServiceProvider.GetRequiredService<RawEventLogService>();
-
-            rawJson = await rawEventService.SerializeAndLogAsync(
-                e, "AutoModRuleDeleted", e.Rule.Guild.Id, null, e.Rule.Creator?.Id);
-
-            var entity = new AutoModEventEntity
+            string? rawJson = null;
+            try
             {
-                GuildDiscordId = e.Rule.Guild.Id,
-                RuleDiscordId = e.Rule.Id,
-                EventType = AutoModEventType.RuleDeleted,
-                RuleName = e.Rule.Name,
-                TriggerType = (int)e.Rule.TriggerType,
-                EventTimestampUtc = now,
-                ReceivedAtUtc = now,
-                RawEventJson = rawJson
-            };
+                if (e.Rule?.Guild is null) return;
 
-            db.AutoModEvents.Add(entity);
-            await db.SaveChangesAsync();
-        }
-        catch (Exception ex)
-        {
-            logger.LogError(ex, "Error handling automod rule deleted");
-            using var failureScope = scopeFactory.CreateScope();
-            var failedEventService = failureScope.ServiceProvider.GetRequiredService<FailedEventService>();
-            await failedEventService.RecordFailureAsync(
-                "AutoModRuleDeleted", nameof(AutoModEventHandler), ex,
-                e.Rule?.Guild?.Id, null, e.Rule?.Creator?.Id, rawJson);
+                var now = DateTime.UtcNow;
+                using var scope = scopeFactory.CreateScope();
+                var db = scope.ServiceProvider.GetRequiredService<DiscordDbContext>();
+                var rawEventService = scope.ServiceProvider.GetRequiredService<RawEventLogService>();
+
+                rawJson = await rawEventService.SerializeAndLogAsync(
+                    e, "AutoModRuleDeleted", e.Rule.Guild.Id, null, e.Rule.Creator?.Id, correlationId: correlationId);
+
+                var entity = new AutoModEventEntity
+                {
+                    GuildDiscordId = e.Rule.Guild.Id,
+                    RuleDiscordId = e.Rule.Id,
+                    EventType = AutoModEventType.RuleDeleted,
+                    RuleName = e.Rule.Name,
+                    TriggerType = (int)e.Rule.TriggerType,
+                    EventTimestampUtc = now,
+                    ReceivedAtUtc = now,
+                    RawEventJson = rawJson
+                };
+
+                db.AutoModEvents.Add(entity);
+                await db.SaveChangesAsync();
+            }
+            catch (Exception ex)
+            {
+                logger.LogError(ex, "Error handling automod rule deleted");
+                using var failureScope = scopeFactory.CreateScope();
+                var failedEventService = failureScope.ServiceProvider.GetRequiredService<FailedEventService>();
+                await failedEventService.RecordFailureAsync(
+                    "AutoModRuleDeleted", nameof(AutoModEventHandler), ex,
+                    e.Rule?.Guild?.Id, null, e.Rule?.Creator?.Id, rawJson, correlationId: correlationId);
+            }
         }
     }
 
     public async Task HandleEventAsync(DiscordClient sender, AutoModerationRuleExecutedEventArgs e)
     {
-        string? rawJson = null;
-        try
+        var correlationId = Guid.NewGuid();
+        using (logger.BeginScope(new Dictionary<string, object> { ["CorrelationId"] = correlationId }))
         {
-            var now = DateTime.UtcNow;
-            using var scope = scopeFactory.CreateScope();
-            var db = scope.ServiceProvider.GetRequiredService<DiscordDbContext>();
-            var rawEventService = scope.ServiceProvider.GetRequiredService<RawEventLogService>();
-
-            rawJson = await rawEventService.SerializeAndLogAsync(
-                e, "AutoModActionExecuted", e.Rule.GuildId, e.Rule.ChannelId, e.Rule.UserId);
-
-            // Note: e.Rule is actually DiscordAutoModerationActionExecution
-            var entity = new AutoModEventEntity
+            string? rawJson = null;
+            try
             {
-                GuildDiscordId = e.Rule.GuildId,
-                RuleDiscordId = e.Rule.RuleId,
-                EventType = AutoModEventType.ActionExecuted,
-                TriggerType = (int)e.Rule.TriggerType,
-                UserDiscordId = e.Rule.UserId,
-                ChannelDiscordId = e.Rule.ChannelId,
-                MessageDiscordId = e.Rule.MessageId,
-                AlertSystemMessageDiscordId = e.Rule.AlertSystemMessageId,
-                Content = e.Rule.Content,
-                MatchedKeyword = e.Rule.MatchedKeyword,
-                MatchedContent = e.Rule.MatchedContent,
-                EventTimestampUtc = now,
-                ReceivedAtUtc = now,
-                RawEventJson = rawJson
-            };
+                var now = DateTime.UtcNow;
+                using var scope = scopeFactory.CreateScope();
+                var db = scope.ServiceProvider.GetRequiredService<DiscordDbContext>();
+                var rawEventService = scope.ServiceProvider.GetRequiredService<RawEventLogService>();
 
-            db.AutoModEvents.Add(entity);
-            await db.SaveChangesAsync();
-        }
-        catch (Exception ex)
-        {
-            logger.LogError(ex, "Error handling automod action executed");
-            using var failureScope = scopeFactory.CreateScope();
-            var failedEventService = failureScope.ServiceProvider.GetRequiredService<FailedEventService>();
-            await failedEventService.RecordFailureAsync(
-                "AutoModActionExecuted", nameof(AutoModEventHandler), ex,
-                e.Rule?.GuildId, e.Rule?.ChannelId, e.Rule?.UserId, rawJson);
+                rawJson = await rawEventService.SerializeAndLogAsync(
+                    e, "AutoModActionExecuted", e.Rule.GuildId, e.Rule.ChannelId, e.Rule.UserId, correlationId: correlationId);
+
+                // Note: e.Rule is actually DiscordAutoModerationActionExecution
+                var entity = new AutoModEventEntity
+                {
+                    GuildDiscordId = e.Rule.GuildId,
+                    RuleDiscordId = e.Rule.RuleId,
+                    EventType = AutoModEventType.ActionExecuted,
+                    TriggerType = (int)e.Rule.TriggerType,
+                    UserDiscordId = e.Rule.UserId,
+                    ChannelDiscordId = e.Rule.ChannelId,
+                    MessageDiscordId = e.Rule.MessageId,
+                    AlertSystemMessageDiscordId = e.Rule.AlertSystemMessageId,
+                    Content = e.Rule.Content,
+                    MatchedKeyword = e.Rule.MatchedKeyword,
+                    MatchedContent = e.Rule.MatchedContent,
+                    EventTimestampUtc = now,
+                    ReceivedAtUtc = now,
+                    RawEventJson = rawJson
+                };
+
+                db.AutoModEvents.Add(entity);
+                await db.SaveChangesAsync();
+            }
+            catch (Exception ex)
+            {
+                logger.LogError(ex, "Error handling automod action executed");
+                using var failureScope = scopeFactory.CreateScope();
+                var failedEventService = failureScope.ServiceProvider.GetRequiredService<FailedEventService>();
+                await failedEventService.RecordFailureAsync(
+                    "AutoModActionExecuted", nameof(AutoModEventHandler), ex,
+                    e.Rule?.GuildId, e.Rule?.ChannelId, e.Rule?.UserId, rawJson, correlationId: correlationId);
+            }
         }
     }
 }

--- a/src/DiscordEventService/Services/EventHandlers/AutoModRuleEventHandler.cs
+++ b/src/DiscordEventService/Services/EventHandlers/AutoModRuleEventHandler.cs
@@ -15,152 +15,164 @@ public class AutoModRuleEventHandler(IServiceScopeFactory scopeFactory, ILogger<
 {
     public async Task HandleEventAsync(DiscordClient sender, AutoModerationRuleCreatedEventArgs e)
     {
-        try
+        var correlationId = Guid.NewGuid();
+        using (logger.BeginScope(new Dictionary<string, object> { ["CorrelationId"] = correlationId }))
         {
-            var now = DateTime.UtcNow;
-            using var scope = scopeFactory.CreateScope();
-            var db = scope.ServiceProvider.GetRequiredService<DiscordDbContext>();
-            var rawEventService = scope.ServiceProvider.GetRequiredService<RawEventLogService>();
-
-            var guildDiscordId = e.Rule.Guild?.Id ?? 0UL;
-            var creatorDiscordId = e.Rule.Creator?.Id ?? 0UL;
-
-            var rawJson = await rawEventService.SerializeAndLogAsync(
-                e, "AutoModRuleCreatedRule", guildDiscordId, null, creatorDiscordId);
-
-            // Look up Guid FKs
-            var guild = await db.Guilds.FirstOrDefaultAsync(g => g.DiscordId == guildDiscordId);
-            var creator = await db.Users.FirstOrDefaultAsync(u => u.DiscordId == creatorDiscordId);
-
-            db.AutoModRules.Add(new AutoModRuleEntity
+            try
             {
-                DiscordId = e.Rule.Id,
-                GuildId = guild?.Id,
-                CreatorId = creator?.Id,
-                Name = e.Rule.Name ?? string.Empty,
-                EventType = (int)e.Rule.EventType,
-                TriggerType = (int)e.Rule.TriggerType,
-                IsEnabled = e.Rule.IsEnabled,
-                ActionsJson = e.Rule.Actions != null ? JsonSerializer.Serialize(e.Rule.Actions) : null
-            });
+                var now = DateTime.UtcNow;
+                using var scope = scopeFactory.CreateScope();
+                var db = scope.ServiceProvider.GetRequiredService<DiscordDbContext>();
+                var rawEventService = scope.ServiceProvider.GetRequiredService<RawEventLogService>();
 
-            db.AutoModRuleEvents.Add(new AutoModRuleEventEntity
+                var guildDiscordId = e.Rule.Guild?.Id ?? 0UL;
+                var creatorDiscordId = e.Rule.Creator?.Id ?? 0UL;
+
+                var rawJson = await rawEventService.SerializeAndLogAsync(
+                    e, "AutoModRuleCreatedRule", guildDiscordId, null, creatorDiscordId, correlationId: correlationId);
+
+                // Look up Guid FKs
+                var guild = await db.Guilds.FirstOrDefaultAsync(g => g.DiscordId == guildDiscordId);
+                var creator = await db.Users.FirstOrDefaultAsync(u => u.DiscordId == creatorDiscordId);
+
+                db.AutoModRules.Add(new AutoModRuleEntity
+                {
+                    DiscordId = e.Rule.Id,
+                    GuildId = guild?.Id,
+                    CreatorId = creator?.Id,
+                    Name = e.Rule.Name ?? string.Empty,
+                    EventType = (int)e.Rule.EventType,
+                    TriggerType = (int)e.Rule.TriggerType,
+                    IsEnabled = e.Rule.IsEnabled,
+                    ActionsJson = e.Rule.Actions != null ? JsonSerializer.Serialize(e.Rule.Actions) : null
+                });
+
+                db.AutoModRuleEvents.Add(new AutoModRuleEventEntity
+                {
+                    RuleDiscordId = e.Rule.Id,
+                    GuildDiscordId = guildDiscordId,
+                    CreatorDiscordId = creatorDiscordId,
+                    EventType = AutoModRuleEventType.Created,
+                    Name = e.Rule.Name ?? string.Empty,
+                    TriggerType = (int)e.Rule.TriggerType,
+                    IsEnabled = e.Rule.IsEnabled,
+                    EventTimestampUtc = now,
+                    ReceivedAtUtc = now,
+                    RawEventJson = rawJson
+                });
+
+                await db.SaveChangesAsync();
+            }
+            catch (Exception ex)
             {
-                RuleDiscordId = e.Rule.Id,
-                GuildDiscordId = guildDiscordId,
-                CreatorDiscordId = creatorDiscordId,
-                EventType = AutoModRuleEventType.Created,
-                Name = e.Rule.Name ?? string.Empty,
-                TriggerType = (int)e.Rule.TriggerType,
-                IsEnabled = e.Rule.IsEnabled,
-                EventTimestampUtc = now,
-                ReceivedAtUtc = now,
-                RawEventJson = rawJson
-            });
-
-            await db.SaveChangesAsync();
-        }
-        catch (Exception ex)
-        {
-            logger.LogError(ex, "Error handling automod rule created");
-            using var failureScope = scopeFactory.CreateScope();
-            var failedEventService = failureScope.ServiceProvider.GetRequiredService<FailedEventService>();
-            await failedEventService.RecordFailureAsync(
-                "AutoModRuleCreated", nameof(AutoModRuleEventHandler), ex,
-                e.Rule.Guild?.Id, null, e.Rule.Creator?.Id);
+                logger.LogError(ex, "Error handling automod rule created");
+                using var failureScope = scopeFactory.CreateScope();
+                var failedEventService = failureScope.ServiceProvider.GetRequiredService<FailedEventService>();
+                await failedEventService.RecordFailureAsync(
+                    "AutoModRuleCreated", nameof(AutoModRuleEventHandler), ex,
+                    e.Rule.Guild?.Id, null, e.Rule.Creator?.Id, correlationId: correlationId);
+            }
         }
     }
 
     public async Task HandleEventAsync(DiscordClient sender, AutoModerationRuleUpdatedEventArgs e)
     {
-        try
+        var correlationId = Guid.NewGuid();
+        using (logger.BeginScope(new Dictionary<string, object> { ["CorrelationId"] = correlationId }))
         {
-            var now = DateTime.UtcNow;
-            using var scope = scopeFactory.CreateScope();
-            var db = scope.ServiceProvider.GetRequiredService<DiscordDbContext>();
-            var rawEventService = scope.ServiceProvider.GetRequiredService<RawEventLogService>();
-
-            var guildDiscordId = e.Rule.Guild?.Id ?? 0UL;
-
-            var rawJson = await rawEventService.SerializeAndLogAsync(
-                e, "AutoModRuleUpdatedRule", guildDiscordId, null, e.Rule.Creator?.Id);
-
-            await db.AutoModRules
-                .Where(r => r.DiscordId == e.Rule.Id)
-                .ExecuteUpdateAsync(s => s
-                    .SetProperty(r => r.Name, e.Rule.Name ?? string.Empty)
-                    .SetProperty(r => r.IsEnabled, e.Rule.IsEnabled)
-                    .SetProperty(r => r.ActionsJson, e.Rule.Actions != null ? JsonSerializer.Serialize(e.Rule.Actions) : null));
-
-            db.AutoModRuleEvents.Add(new AutoModRuleEventEntity
+            try
             {
-                RuleDiscordId = e.Rule.Id,
-                GuildDiscordId = guildDiscordId,
-                CreatorDiscordId = e.Rule.Creator?.Id ?? 0,
-                EventType = AutoModRuleEventType.Updated,
-                Name = e.Rule.Name ?? string.Empty,
-                TriggerType = (int)e.Rule.TriggerType,
-                IsEnabled = e.Rule.IsEnabled,
-                EventTimestampUtc = now,
-                ReceivedAtUtc = now,
-                RawEventJson = rawJson
-            });
+                var now = DateTime.UtcNow;
+                using var scope = scopeFactory.CreateScope();
+                var db = scope.ServiceProvider.GetRequiredService<DiscordDbContext>();
+                var rawEventService = scope.ServiceProvider.GetRequiredService<RawEventLogService>();
 
-            await db.SaveChangesAsync();
-        }
-        catch (Exception ex)
-        {
-            logger.LogError(ex, "Error handling automod rule updated");
-            using var failureScope = scopeFactory.CreateScope();
-            var failedEventService = failureScope.ServiceProvider.GetRequiredService<FailedEventService>();
-            await failedEventService.RecordFailureAsync(
-                "AutoModRuleUpdated", nameof(AutoModRuleEventHandler), ex,
-                e.Rule.Guild?.Id, null, e.Rule.Creator?.Id);
+                var guildDiscordId = e.Rule.Guild?.Id ?? 0UL;
+
+                var rawJson = await rawEventService.SerializeAndLogAsync(
+                    e, "AutoModRuleUpdatedRule", guildDiscordId, null, e.Rule.Creator?.Id, correlationId: correlationId);
+
+                await db.AutoModRules
+                    .Where(r => r.DiscordId == e.Rule.Id)
+                    .ExecuteUpdateAsync(s => s
+                        .SetProperty(r => r.Name, e.Rule.Name ?? string.Empty)
+                        .SetProperty(r => r.IsEnabled, e.Rule.IsEnabled)
+                        .SetProperty(r => r.ActionsJson, e.Rule.Actions != null ? JsonSerializer.Serialize(e.Rule.Actions) : null));
+
+                db.AutoModRuleEvents.Add(new AutoModRuleEventEntity
+                {
+                    RuleDiscordId = e.Rule.Id,
+                    GuildDiscordId = guildDiscordId,
+                    CreatorDiscordId = e.Rule.Creator?.Id ?? 0,
+                    EventType = AutoModRuleEventType.Updated,
+                    Name = e.Rule.Name ?? string.Empty,
+                    TriggerType = (int)e.Rule.TriggerType,
+                    IsEnabled = e.Rule.IsEnabled,
+                    EventTimestampUtc = now,
+                    ReceivedAtUtc = now,
+                    RawEventJson = rawJson
+                });
+
+                await db.SaveChangesAsync();
+            }
+            catch (Exception ex)
+            {
+                logger.LogError(ex, "Error handling automod rule updated");
+                using var failureScope = scopeFactory.CreateScope();
+                var failedEventService = failureScope.ServiceProvider.GetRequiredService<FailedEventService>();
+                await failedEventService.RecordFailureAsync(
+                    "AutoModRuleUpdated", nameof(AutoModRuleEventHandler), ex,
+                    e.Rule.Guild?.Id, null, e.Rule.Creator?.Id, correlationId: correlationId);
+            }
         }
     }
 
     public async Task HandleEventAsync(DiscordClient sender, AutoModerationRuleDeletedEventArgs e)
     {
-        try
+        var correlationId = Guid.NewGuid();
+        using (logger.BeginScope(new Dictionary<string, object> { ["CorrelationId"] = correlationId }))
         {
-            var now = DateTime.UtcNow;
-            using var scope = scopeFactory.CreateScope();
-            var db = scope.ServiceProvider.GetRequiredService<DiscordDbContext>();
-            var rawEventService = scope.ServiceProvider.GetRequiredService<RawEventLogService>();
-
-            var guildDiscordId = e.Rule.Guild?.Id ?? 0;
-
-            var rawJson = await rawEventService.SerializeAndLogAsync(
-                e, "AutoModRuleDeletedRule", guildDiscordId, null, e.Rule.Creator?.Id);
-
-            await db.AutoModRules
-                .Where(r => r.DiscordId == e.Rule.Id)
-                .ExecuteUpdateAsync(s => s
-                    .SetProperty(r => r.IsDeleted, true)
-                    .SetProperty(r => r.DeletedAtUtc, (DateTime?)now));
-
-            db.AutoModRuleEvents.Add(new AutoModRuleEventEntity
+            try
             {
-                RuleDiscordId = e.Rule.Id,
-                GuildDiscordId = guildDiscordId,
-                CreatorDiscordId = e.Rule.Creator?.Id ?? 0,
-                EventType = AutoModRuleEventType.Deleted,
-                Name = e.Rule.Name ?? string.Empty,
-                EventTimestampUtc = now,
-                ReceivedAtUtc = now,
-                RawEventJson = rawJson
-            });
+                var now = DateTime.UtcNow;
+                using var scope = scopeFactory.CreateScope();
+                var db = scope.ServiceProvider.GetRequiredService<DiscordDbContext>();
+                var rawEventService = scope.ServiceProvider.GetRequiredService<RawEventLogService>();
 
-            await db.SaveChangesAsync();
-        }
-        catch (Exception ex)
-        {
-            logger.LogError(ex, "Error handling automod rule deleted");
-            using var failureScope = scopeFactory.CreateScope();
-            var failedEventService = failureScope.ServiceProvider.GetRequiredService<FailedEventService>();
-            await failedEventService.RecordFailureAsync(
-                "AutoModRuleDeleted", nameof(AutoModRuleEventHandler), ex,
-                e.Rule.Guild?.Id, null, e.Rule.Creator?.Id);
+                var guildDiscordId = e.Rule.Guild?.Id ?? 0;
+
+                var rawJson = await rawEventService.SerializeAndLogAsync(
+                    e, "AutoModRuleDeletedRule", guildDiscordId, null, e.Rule.Creator?.Id, correlationId: correlationId);
+
+                await db.AutoModRules
+                    .Where(r => r.DiscordId == e.Rule.Id)
+                    .ExecuteUpdateAsync(s => s
+                        .SetProperty(r => r.IsDeleted, true)
+                        .SetProperty(r => r.DeletedAtUtc, (DateTime?)now));
+
+                db.AutoModRuleEvents.Add(new AutoModRuleEventEntity
+                {
+                    RuleDiscordId = e.Rule.Id,
+                    GuildDiscordId = guildDiscordId,
+                    CreatorDiscordId = e.Rule.Creator?.Id ?? 0,
+                    EventType = AutoModRuleEventType.Deleted,
+                    Name = e.Rule.Name ?? string.Empty,
+                    EventTimestampUtc = now,
+                    ReceivedAtUtc = now,
+                    RawEventJson = rawJson
+                });
+
+                await db.SaveChangesAsync();
+            }
+            catch (Exception ex)
+            {
+                logger.LogError(ex, "Error handling automod rule deleted");
+                using var failureScope = scopeFactory.CreateScope();
+                var failedEventService = failureScope.ServiceProvider.GetRequiredService<FailedEventService>();
+                await failedEventService.RecordFailureAsync(
+                    "AutoModRuleDeleted", nameof(AutoModRuleEventHandler), ex,
+                    e.Rule.Guild?.Id, null, e.Rule.Creator?.Id, correlationId: correlationId);
+            }
         }
     }
 }

--- a/src/DiscordEventService/Services/EventHandlers/BanEventHandler.cs
+++ b/src/DiscordEventService/Services/EventHandlers/BanEventHandler.cs
@@ -13,112 +13,120 @@ public class BanEventHandler(IServiceScopeFactory scopeFactory, ILogger<BanEvent
 {
     public async Task HandleEventAsync(DiscordClient sender, GuildBanAddedEventArgs e)
     {
-        string? rawJson = null;
-        try
+        var correlationId = Guid.NewGuid();
+        using (logger.BeginScope(new Dictionary<string, object> { ["CorrelationId"] = correlationId }))
         {
-            var now = DateTime.UtcNow;
-            using var scope = scopeFactory.CreateScope();
-            var db = scope.ServiceProvider.GetRequiredService<DiscordDbContext>();
-            var userService = scope.ServiceProvider.GetRequiredService<UserService>();
-            var rawEventService = scope.ServiceProvider.GetRequiredService<RawEventLogService>();
-
-            rawJson = await rawEventService.SerializeAndLogAsync(
-                e, "GuildBanAdded", e.Guild.Id, null, e.Member.Id);
-
-            await userService.UpsertUserAsync(e.Member);
-
-            // Look up Guid FKs
-            var guild = await db.Guilds.FirstOrDefaultAsync(g => g.DiscordId == e.Guild.Id);
-            var user = await db.Users.FirstOrDefaultAsync(u => u.DiscordId == e.Member.Id);
-
-            if (guild != null && user != null)
+            string? rawJson = null;
+            try
             {
-                // Add or update ban entity
-                var existingBan = await db.Bans
-                    .FirstOrDefaultAsync(b => b.GuildId == guild.Id && b.UserId == user.Id && b.IsActive);
+                var now = DateTime.UtcNow;
+                using var scope = scopeFactory.CreateScope();
+                var db = scope.ServiceProvider.GetRequiredService<DiscordDbContext>();
+                var userService = scope.ServiceProvider.GetRequiredService<UserService>();
+                var rawEventService = scope.ServiceProvider.GetRequiredService<RawEventLogService>();
 
-                if (existingBan == null)
+                rawJson = await rawEventService.SerializeAndLogAsync(
+                    e, "GuildBanAdded", e.Guild.Id, null, e.Member.Id, correlationId: correlationId);
+
+                await userService.UpsertUserAsync(e.Member);
+
+                // Look up Guid FKs
+                var guild = await db.Guilds.FirstOrDefaultAsync(g => g.DiscordId == e.Guild.Id);
+                var user = await db.Users.FirstOrDefaultAsync(u => u.DiscordId == e.Member.Id);
+
+                if (guild != null && user != null)
                 {
-                    db.Bans.Add(new BanEntity
+                    // Add or update ban entity
+                    var existingBan = await db.Bans
+                        .FirstOrDefaultAsync(b => b.GuildId == guild.Id && b.UserId == user.Id && b.IsActive);
+
+                    if (existingBan == null)
                     {
-                        GuildId = guild.Id,
-                        UserId = user.Id,
-                        IsActive = true,
-                        BannedAtUtc = now
-                    });
+                        db.Bans.Add(new BanEntity
+                        {
+                            GuildId = guild.Id,
+                            UserId = user.Id,
+                            IsActive = true,
+                            BannedAtUtc = now
+                        });
+                    }
                 }
+
+                db.BanEvents.Add(new BanEventEntity
+                {
+                    GuildDiscordId = e.Guild.Id,
+                    UserDiscordId = e.Member.Id,
+                    EventType = BanEventType.Added,
+                    EventTimestampUtc = now,
+                    ReceivedAtUtc = now,
+                    RawEventJson = rawJson
+                });
+
+                await db.SaveChangesAsync();
             }
-
-            db.BanEvents.Add(new BanEventEntity
+            catch (Exception ex)
             {
-                GuildDiscordId = e.Guild.Id,
-                UserDiscordId = e.Member.Id,
-                EventType = BanEventType.Added,
-                EventTimestampUtc = now,
-                ReceivedAtUtc = now,
-                RawEventJson = rawJson
-            });
-
-            await db.SaveChangesAsync();
-        }
-        catch (Exception ex)
-        {
-            logger.LogError(ex, "Error handling ban added for UserId={UserId}", e.Member.Id);
-            using var failureScope = scopeFactory.CreateScope();
-            var failedEventService = failureScope.ServiceProvider.GetRequiredService<FailedEventService>();
-            await failedEventService.RecordFailureAsync(
-                "GuildBanAdded", nameof(BanEventHandler), ex,
-                e.Guild?.Id, null, e.Member?.Id, rawJson);
+                logger.LogError(ex, "Error handling ban added for UserId={UserId}", e.Member.Id);
+                using var failureScope = scopeFactory.CreateScope();
+                var failedEventService = failureScope.ServiceProvider.GetRequiredService<FailedEventService>();
+                await failedEventService.RecordFailureAsync(
+                    "GuildBanAdded", nameof(BanEventHandler), ex,
+                    e.Guild?.Id, null, e.Member?.Id, rawJson, correlationId: correlationId);
+            }
         }
     }
 
     public async Task HandleEventAsync(DiscordClient sender, GuildBanRemovedEventArgs e)
     {
-        string? rawJson = null;
-        try
+        var correlationId = Guid.NewGuid();
+        using (logger.BeginScope(new Dictionary<string, object> { ["CorrelationId"] = correlationId }))
         {
-            var now = DateTime.UtcNow;
-            using var scope = scopeFactory.CreateScope();
-            var db = scope.ServiceProvider.GetRequiredService<DiscordDbContext>();
-            var rawEventService = scope.ServiceProvider.GetRequiredService<RawEventLogService>();
-
-            rawJson = await rawEventService.SerializeAndLogAsync(
-                e, "GuildBanRemoved", e.Guild.Id, null, e.Member.Id);
-
-            // Look up Guid FKs
-            var guild = await db.Guilds.FirstOrDefaultAsync(g => g.DiscordId == e.Guild.Id);
-            var user = await db.Users.FirstOrDefaultAsync(u => u.DiscordId == e.Member.Id);
-
-            if (guild != null && user != null)
+            string? rawJson = null;
+            try
             {
-                // Mark ban as inactive
-                await db.Bans
-                    .Where(b => b.GuildId == guild.Id && b.UserId == user.Id && b.IsActive)
-                    .ExecuteUpdateAsync(s => s
-                        .SetProperty(b => b.IsActive, false)
-                        .SetProperty(b => b.UnbannedAtUtc, now));
+                var now = DateTime.UtcNow;
+                using var scope = scopeFactory.CreateScope();
+                var db = scope.ServiceProvider.GetRequiredService<DiscordDbContext>();
+                var rawEventService = scope.ServiceProvider.GetRequiredService<RawEventLogService>();
+
+                rawJson = await rawEventService.SerializeAndLogAsync(
+                    e, "GuildBanRemoved", e.Guild.Id, null, e.Member.Id, correlationId: correlationId);
+
+                // Look up Guid FKs
+                var guild = await db.Guilds.FirstOrDefaultAsync(g => g.DiscordId == e.Guild.Id);
+                var user = await db.Users.FirstOrDefaultAsync(u => u.DiscordId == e.Member.Id);
+
+                if (guild != null && user != null)
+                {
+                    // Mark ban as inactive
+                    await db.Bans
+                        .Where(b => b.GuildId == guild.Id && b.UserId == user.Id && b.IsActive)
+                        .ExecuteUpdateAsync(s => s
+                            .SetProperty(b => b.IsActive, false)
+                            .SetProperty(b => b.UnbannedAtUtc, now));
+                }
+
+                db.BanEvents.Add(new BanEventEntity
+                {
+                    GuildDiscordId = e.Guild.Id,
+                    UserDiscordId = e.Member.Id,
+                    EventType = BanEventType.Removed,
+                    EventTimestampUtc = now,
+                    ReceivedAtUtc = now,
+                    RawEventJson = rawJson
+                });
+
+                await db.SaveChangesAsync();
             }
-
-            db.BanEvents.Add(new BanEventEntity
+            catch (Exception ex)
             {
-                GuildDiscordId = e.Guild.Id,
-                UserDiscordId = e.Member.Id,
-                EventType = BanEventType.Removed,
-                EventTimestampUtc = now,
-                ReceivedAtUtc = now,
-                RawEventJson = rawJson
-            });
-
-            await db.SaveChangesAsync();
-        }
-        catch (Exception ex)
-        {
-            logger.LogError(ex, "Error handling ban removed for UserId={UserId}", e.Member.Id);
-            using var failureScope = scopeFactory.CreateScope();
-            var failedEventService = failureScope.ServiceProvider.GetRequiredService<FailedEventService>();
-            await failedEventService.RecordFailureAsync(
-                "GuildBanRemoved", nameof(BanEventHandler), ex,
-                e.Guild?.Id, null, e.Member?.Id, rawJson);
+                logger.LogError(ex, "Error handling ban removed for UserId={UserId}", e.Member.Id);
+                using var failureScope = scopeFactory.CreateScope();
+                var failedEventService = failureScope.ServiceProvider.GetRequiredService<FailedEventService>();
+                await failedEventService.RecordFailureAsync(
+                    "GuildBanRemoved", nameof(BanEventHandler), ex,
+                    e.Guild?.Id, null, e.Member?.Id, rawJson, correlationId: correlationId);
+            }
         }
     }
 }

--- a/src/DiscordEventService/Services/EventHandlers/ChannelEventHandler.cs
+++ b/src/DiscordEventService/Services/EventHandlers/ChannelEventHandler.cs
@@ -16,224 +16,240 @@ public class ChannelEventHandler(IServiceScopeFactory scopeFactory, ILogger<Chan
 {
     public async Task HandleEventAsync(DiscordClient sender, ChannelCreatedEventArgs e)
     {
-        string? rawJson = null;
-        try
+        var correlationId = Guid.NewGuid();
+        using (logger.BeginScope(new Dictionary<string, object> { ["CorrelationId"] = correlationId }))
         {
-            var receivedAt = DateTime.UtcNow;
-            using var scope = scopeFactory.CreateScope();
-            var db = scope.ServiceProvider.GetRequiredService<DiscordDbContext>();
-            var rawEventService = scope.ServiceProvider.GetRequiredService<RawEventLogService>();
-
-            rawJson = await rawEventService.SerializeAndLogAsync(
-                e, "ChannelCreated", e.Guild.Id, e.Channel.Id, null);
-
-            // Look up Guild Guid
-            var guild = await db.Guilds.FirstOrDefaultAsync(g => g.DiscordId == e.Guild.Id);
-
-            ChannelEventEntity NewChannelEvent() => new()
-            {
-                ChannelDiscordId = e.Channel.Id,
-                GuildDiscordId = e.Guild.Id,
-                ChannelType = (int)e.Channel.Type,
-                EventType = ChannelEventType.Created,
-                NameAfter = e.Channel.Name,
-                TopicAfter = e.Channel.Topic,
-                PositionAfter = e.Channel.Position,
-                EventTimestampUtc = receivedAt,
-                ReceivedAtUtc = receivedAt,
-                RawEventJson = rawJson
-            };
-
-            var channelEntity = await db.Channels
-                .FirstOrDefaultAsync(c => c.DiscordId == e.Channel.Id);
-
-            if (channelEntity == null)
-            {
-                channelEntity = new ChannelEntity
-                {
-                    DiscordId = e.Channel.Id,
-                    GuildId = guild?.Id ?? Guid.Empty
-                };
-                db.Channels.Add(channelEntity);
-            }
-
-            UpdateChannelEntity(channelEntity, e.Channel);
-            db.ChannelEvents.Add(NewChannelEvent());
-
+            string? rawJson = null;
             try
             {
-                await db.SaveChangesAsync();
-            }
-            catch (DbUpdateException dbEx) when (dbEx.InnerException is Npgsql.PostgresException { SqlState: "23505" })
-            {
-                // Concurrent insert won the race. Re-fetch the now-existing row, update it, re-add the event.
-                db.ChangeTracker.Clear();
-                var existing = await db.Channels.FirstOrDefaultAsync(c => c.DiscordId == e.Channel.Id);
-                if (existing != null)
+                var receivedAt = DateTime.UtcNow;
+                using var scope = scopeFactory.CreateScope();
+                var db = scope.ServiceProvider.GetRequiredService<DiscordDbContext>();
+                var rawEventService = scope.ServiceProvider.GetRequiredService<RawEventLogService>();
+
+                rawJson = await rawEventService.SerializeAndLogAsync(
+                    e, "ChannelCreated", e.Guild.Id, e.Channel.Id, null, correlationId: correlationId);
+
+                // Look up Guild Guid
+                var guild = await db.Guilds.FirstOrDefaultAsync(g => g.DiscordId == e.Guild.Id);
+
+                ChannelEventEntity NewChannelEvent() => new()
                 {
-                    UpdateChannelEntity(existing, e.Channel);
+                    ChannelDiscordId = e.Channel.Id,
+                    GuildDiscordId = e.Guild.Id,
+                    ChannelType = (int)e.Channel.Type,
+                    EventType = ChannelEventType.Created,
+                    NameAfter = e.Channel.Name,
+                    TopicAfter = e.Channel.Topic,
+                    PositionAfter = e.Channel.Position,
+                    EventTimestampUtc = receivedAt,
+                    ReceivedAtUtc = receivedAt,
+                    RawEventJson = rawJson
+                };
+
+                var channelEntity = await db.Channels
+                    .FirstOrDefaultAsync(c => c.DiscordId == e.Channel.Id);
+
+                if (channelEntity == null)
+                {
+                    channelEntity = new ChannelEntity
+                    {
+                        DiscordId = e.Channel.Id,
+                        GuildId = guild?.Id ?? Guid.Empty
+                    };
+                    db.Channels.Add(channelEntity);
                 }
+
+                UpdateChannelEntity(channelEntity, e.Channel);
                 db.ChannelEvents.Add(NewChannelEvent());
-                await db.SaveChangesAsync();
+
+                try
+                {
+                    await db.SaveChangesAsync();
+                }
+                catch (DbUpdateException dbEx) when (dbEx.InnerException is Npgsql.PostgresException { SqlState: "23505" })
+                {
+                    // Concurrent insert won the race. Re-fetch the now-existing row, update it, re-add the event.
+                    db.ChangeTracker.Clear();
+                    var existing = await db.Channels.FirstOrDefaultAsync(c => c.DiscordId == e.Channel.Id);
+                    if (existing != null)
+                    {
+                        UpdateChannelEntity(existing, e.Channel);
+                    }
+                    db.ChannelEvents.Add(NewChannelEvent());
+                    await db.SaveChangesAsync();
+                }
             }
-        }
-        catch (Exception ex)
-        {
-            logger.LogError(ex, "Error handling channel created for ChannelId={ChannelId}", e.Channel.Id);
-            using var failureScope = scopeFactory.CreateScope();
-            var failedEventService = failureScope.ServiceProvider.GetRequiredService<FailedEventService>();
-            await failedEventService.RecordFailureAsync(
-                "ChannelCreated", nameof(ChannelEventHandler), ex,
-                e.Guild?.Id, e.Channel.Id, null, rawJson);
+            catch (Exception ex)
+            {
+                logger.LogError(ex, "Error handling channel created for ChannelId={ChannelId}", e.Channel.Id);
+                using var failureScope = scopeFactory.CreateScope();
+                var failedEventService = failureScope.ServiceProvider.GetRequiredService<FailedEventService>();
+                await failedEventService.RecordFailureAsync(
+                    "ChannelCreated", nameof(ChannelEventHandler), ex,
+                    e.Guild?.Id, e.Channel.Id, null, rawJson, correlationId: correlationId);
+            }
         }
     }
 
     public async Task HandleEventAsync(DiscordClient sender, ChannelUpdatedEventArgs e)
     {
-        string? rawJson = null;
-        try
+        var correlationId = Guid.NewGuid();
+        using (logger.BeginScope(new Dictionary<string, object> { ["CorrelationId"] = correlationId }))
         {
-            using var scope = scopeFactory.CreateScope();
-            var db = scope.ServiceProvider.GetRequiredService<DiscordDbContext>();
-            var rawEventService = scope.ServiceProvider.GetRequiredService<RawEventLogService>();
-
-            rawJson = await rawEventService.SerializeAndLogAsync(
-                e, "ChannelUpdated", e.ChannelAfter.Guild.Id, e.ChannelAfter.Id, null);
-
-            var channelEntity = await db.Channels
-                .FirstOrDefaultAsync(c => c.DiscordId == e.ChannelAfter.Id);
-
-            if (channelEntity != null)
+            string? rawJson = null;
+            try
             {
-                UpdateChannelEntity(channelEntity, e.ChannelAfter);
+                using var scope = scopeFactory.CreateScope();
+                var db = scope.ServiceProvider.GetRequiredService<DiscordDbContext>();
+                var rawEventService = scope.ServiceProvider.GetRequiredService<RawEventLogService>();
+
+                rawJson = await rawEventService.SerializeAndLogAsync(
+                    e, "ChannelUpdated", e.ChannelAfter.Guild.Id, e.ChannelAfter.Id, null, correlationId: correlationId);
+
+                var channelEntity = await db.Channels
+                    .FirstOrDefaultAsync(c => c.DiscordId == e.ChannelAfter.Id);
+
+                if (channelEntity != null)
+                {
+                    UpdateChannelEntity(channelEntity, e.ChannelAfter);
+                }
+
+                var channelEvent = new ChannelEventEntity
+                {
+                    ChannelDiscordId = e.ChannelAfter.Id,
+                    GuildDiscordId = e.ChannelAfter.Guild.Id,
+                    ChannelType = (int)e.ChannelAfter.Type,
+                    EventType = ChannelEventType.Updated,
+                    EventTimestampUtc = DateTime.UtcNow,
+                    ReceivedAtUtc = DateTime.UtcNow,
+                    RawEventJson = rawJson
+                };
+
+                if (e.ChannelBefore.Name != e.ChannelAfter.Name)
+                {
+                    channelEvent.NameBefore = e.ChannelBefore.Name;
+                    channelEvent.NameAfter = e.ChannelAfter.Name;
+                }
+
+                if (e.ChannelBefore.Topic != e.ChannelAfter.Topic)
+                {
+                    channelEvent.TopicBefore = e.ChannelBefore.Topic;
+                    channelEvent.TopicAfter = e.ChannelAfter.Topic;
+                }
+
+                if (e.ChannelBefore.Position != e.ChannelAfter.Position)
+                {
+                    channelEvent.PositionBefore = e.ChannelBefore.Position;
+                    channelEvent.PositionAfter = e.ChannelAfter.Position;
+                }
+
+                db.ChannelEvents.Add(channelEvent);
+                await db.SaveChangesAsync();
             }
-
-            var channelEvent = new ChannelEventEntity
+            catch (Exception ex)
             {
-                ChannelDiscordId = e.ChannelAfter.Id,
-                GuildDiscordId = e.ChannelAfter.Guild.Id,
-                ChannelType = (int)e.ChannelAfter.Type,
-                EventType = ChannelEventType.Updated,
-                EventTimestampUtc = DateTime.UtcNow,
-                ReceivedAtUtc = DateTime.UtcNow,
-                RawEventJson = rawJson
-            };
-
-            if (e.ChannelBefore.Name != e.ChannelAfter.Name)
-            {
-                channelEvent.NameBefore = e.ChannelBefore.Name;
-                channelEvent.NameAfter = e.ChannelAfter.Name;
+                logger.LogError(ex, "Error handling channel updated for ChannelId={ChannelId}", e.ChannelAfter.Id);
+                using var failureScope = scopeFactory.CreateScope();
+                var failedEventService = failureScope.ServiceProvider.GetRequiredService<FailedEventService>();
+                await failedEventService.RecordFailureAsync(
+                    "ChannelUpdated", nameof(ChannelEventHandler), ex,
+                    e.ChannelAfter.Guild?.Id, e.ChannelAfter.Id, null, rawJson, correlationId: correlationId);
             }
-
-            if (e.ChannelBefore.Topic != e.ChannelAfter.Topic)
-            {
-                channelEvent.TopicBefore = e.ChannelBefore.Topic;
-                channelEvent.TopicAfter = e.ChannelAfter.Topic;
-            }
-
-            if (e.ChannelBefore.Position != e.ChannelAfter.Position)
-            {
-                channelEvent.PositionBefore = e.ChannelBefore.Position;
-                channelEvent.PositionAfter = e.ChannelAfter.Position;
-            }
-
-            db.ChannelEvents.Add(channelEvent);
-            await db.SaveChangesAsync();
-        }
-        catch (Exception ex)
-        {
-            logger.LogError(ex, "Error handling channel updated for ChannelId={ChannelId}", e.ChannelAfter.Id);
-            using var failureScope = scopeFactory.CreateScope();
-            var failedEventService = failureScope.ServiceProvider.GetRequiredService<FailedEventService>();
-            await failedEventService.RecordFailureAsync(
-                "ChannelUpdated", nameof(ChannelEventHandler), ex,
-                e.ChannelAfter.Guild?.Id, e.ChannelAfter.Id, null, rawJson);
         }
     }
 
     public async Task HandleEventAsync(DiscordClient sender, ChannelDeletedEventArgs e)
     {
-        string? rawJson = null;
-        try
+        var correlationId = Guid.NewGuid();
+        using (logger.BeginScope(new Dictionary<string, object> { ["CorrelationId"] = correlationId }))
         {
-            using var scope = scopeFactory.CreateScope();
-            var db = scope.ServiceProvider.GetRequiredService<DiscordDbContext>();
-            var rawEventService = scope.ServiceProvider.GetRequiredService<RawEventLogService>();
-
-            rawJson = await rawEventService.SerializeAndLogAsync(
-                e, "ChannelDeleted", e.Guild.Id, e.Channel.Id, null);
-
-            var channelEntity = await db.Channels
-                .FirstOrDefaultAsync(c => c.DiscordId == e.Channel.Id);
-
-            if (channelEntity != null)
+            string? rawJson = null;
+            try
             {
-                channelEntity.IsDeleted = true;
-                channelEntity.DeletedAtUtc = DateTime.UtcNow;
+                using var scope = scopeFactory.CreateScope();
+                var db = scope.ServiceProvider.GetRequiredService<DiscordDbContext>();
+                var rawEventService = scope.ServiceProvider.GetRequiredService<RawEventLogService>();
+
+                rawJson = await rawEventService.SerializeAndLogAsync(
+                    e, "ChannelDeleted", e.Guild.Id, e.Channel.Id, null, correlationId: correlationId);
+
+                var channelEntity = await db.Channels
+                    .FirstOrDefaultAsync(c => c.DiscordId == e.Channel.Id);
+
+                if (channelEntity != null)
+                {
+                    channelEntity.IsDeleted = true;
+                    channelEntity.DeletedAtUtc = DateTime.UtcNow;
+                }
+
+                var channelEvent = new ChannelEventEntity
+                {
+                    ChannelDiscordId = e.Channel.Id,
+                    GuildDiscordId = e.Guild.Id,
+                    ChannelType = (int)e.Channel.Type,
+                    EventType = ChannelEventType.Deleted,
+                    NameBefore = e.Channel.Name,
+                    TopicBefore = e.Channel.Topic,
+                    PositionBefore = e.Channel.Position,
+                    EventTimestampUtc = DateTime.UtcNow,
+                    ReceivedAtUtc = DateTime.UtcNow,
+                    RawEventJson = rawJson
+                };
+
+                db.ChannelEvents.Add(channelEvent);
+                await db.SaveChangesAsync();
             }
-
-            var channelEvent = new ChannelEventEntity
+            catch (Exception ex)
             {
-                ChannelDiscordId = e.Channel.Id,
-                GuildDiscordId = e.Guild.Id,
-                ChannelType = (int)e.Channel.Type,
-                EventType = ChannelEventType.Deleted,
-                NameBefore = e.Channel.Name,
-                TopicBefore = e.Channel.Topic,
-                PositionBefore = e.Channel.Position,
-                EventTimestampUtc = DateTime.UtcNow,
-                ReceivedAtUtc = DateTime.UtcNow,
-                RawEventJson = rawJson
-            };
-
-            db.ChannelEvents.Add(channelEvent);
-            await db.SaveChangesAsync();
-        }
-        catch (Exception ex)
-        {
-            logger.LogError(ex, "Error handling channel deleted for ChannelId={ChannelId}", e.Channel.Id);
-            using var failureScope = scopeFactory.CreateScope();
-            var failedEventService = failureScope.ServiceProvider.GetRequiredService<FailedEventService>();
-            await failedEventService.RecordFailureAsync(
-                "ChannelDeleted", nameof(ChannelEventHandler), ex,
-                e.Guild?.Id, e.Channel.Id, null, rawJson);
+                logger.LogError(ex, "Error handling channel deleted for ChannelId={ChannelId}", e.Channel.Id);
+                using var failureScope = scopeFactory.CreateScope();
+                var failedEventService = failureScope.ServiceProvider.GetRequiredService<FailedEventService>();
+                await failedEventService.RecordFailureAsync(
+                    "ChannelDeleted", nameof(ChannelEventHandler), ex,
+                    e.Guild?.Id, e.Channel.Id, null, rawJson, correlationId: correlationId);
+            }
         }
     }
 
     public async Task HandleEventAsync(DiscordClient sender, ChannelPinsUpdatedEventArgs e)
     {
-        string? rawJson = null;
-        try
+        var correlationId = Guid.NewGuid();
+        using (logger.BeginScope(new Dictionary<string, object> { ["CorrelationId"] = correlationId }))
         {
-            using var scope = scopeFactory.CreateScope();
-            var db = scope.ServiceProvider.GetRequiredService<DiscordDbContext>();
-            var rawEventService = scope.ServiceProvider.GetRequiredService<RawEventLogService>();
-
-            rawJson = await rawEventService.SerializeAndLogAsync(
-                e, "ChannelPinsUpdatedChannel", e.Guild?.Id ?? 0, e.Channel.Id, null);
-
-            var channelEvent = new ChannelEventEntity
+            string? rawJson = null;
+            try
             {
-                ChannelDiscordId = e.Channel.Id,
-                GuildDiscordId = e.Guild?.Id ?? 0,
-                ChannelType = (int)e.Channel.Type,
-                EventType = ChannelEventType.PinsUpdated,
-                EventTimestampUtc = e.LastPinTimestamp?.UtcDateTime ?? DateTime.UtcNow,
-                ReceivedAtUtc = DateTime.UtcNow,
-                RawEventJson = rawJson
-            };
+                using var scope = scopeFactory.CreateScope();
+                var db = scope.ServiceProvider.GetRequiredService<DiscordDbContext>();
+                var rawEventService = scope.ServiceProvider.GetRequiredService<RawEventLogService>();
 
-            db.ChannelEvents.Add(channelEvent);
-            await db.SaveChangesAsync();
-        }
-        catch (Exception ex)
-        {
-            logger.LogError(ex, "Error handling channel pins updated for ChannelId={ChannelId}", e.Channel.Id);
-            using var failureScope = scopeFactory.CreateScope();
-            var failedEventService = failureScope.ServiceProvider.GetRequiredService<FailedEventService>();
-            await failedEventService.RecordFailureAsync(
-                "ChannelPinsUpdatedChannel", nameof(ChannelEventHandler), ex,
-                e.Guild?.Id, e.Channel.Id, null, rawJson);
+                rawJson = await rawEventService.SerializeAndLogAsync(
+                    e, "ChannelPinsUpdatedChannel", e.Guild?.Id ?? 0, e.Channel.Id, null, correlationId: correlationId);
+
+                var channelEvent = new ChannelEventEntity
+                {
+                    ChannelDiscordId = e.Channel.Id,
+                    GuildDiscordId = e.Guild?.Id ?? 0,
+                    ChannelType = (int)e.Channel.Type,
+                    EventType = ChannelEventType.PinsUpdated,
+                    EventTimestampUtc = e.LastPinTimestamp?.UtcDateTime ?? DateTime.UtcNow,
+                    ReceivedAtUtc = DateTime.UtcNow,
+                    RawEventJson = rawJson
+                };
+
+                db.ChannelEvents.Add(channelEvent);
+                await db.SaveChangesAsync();
+            }
+            catch (Exception ex)
+            {
+                logger.LogError(ex, "Error handling channel pins updated for ChannelId={ChannelId}", e.Channel.Id);
+                using var failureScope = scopeFactory.CreateScope();
+                var failedEventService = failureScope.ServiceProvider.GetRequiredService<FailedEventService>();
+                await failedEventService.RecordFailureAsync(
+                    "ChannelPinsUpdatedChannel", nameof(ChannelEventHandler), ex,
+                    e.Guild?.Id, e.Channel.Id, null, rawJson, correlationId: correlationId);
+            }
         }
     }
 

--- a/src/DiscordEventService/Services/EventHandlers/EmojiEventHandler.cs
+++ b/src/DiscordEventService/Services/EventHandlers/EmojiEventHandler.cs
@@ -13,93 +13,97 @@ public class EmojiEventHandler(IServiceScopeFactory scopeFactory, ILogger<EmojiE
 {
     public async Task HandleEventAsync(DiscordClient sender, GuildEmojisUpdatedEventArgs e)
     {
-        string? rawJson = null;
-        try
+        var correlationId = Guid.NewGuid();
+        using (logger.BeginScope(new Dictionary<string, object> { ["CorrelationId"] = correlationId }))
         {
-            var now = DateTime.UtcNow;
-            using var scope = scopeFactory.CreateScope();
-            var db = scope.ServiceProvider.GetRequiredService<DiscordDbContext>();
-            var rawEventService = scope.ServiceProvider.GetRequiredService<RawEventLogService>();
-
-            rawJson = await rawEventService.SerializeAndLogAsync(
-                e, "GuildEmojisUpdated", e.Guild.Id, null, null);
-
-            // Look up Guild Guid
-            var guild = await db.Guilds.FirstOrDefaultAsync(g => g.DiscordId == e.Guild.Id);
-
-            var beforeIds = e.EmojisBefore.Keys.ToHashSet();
-            var afterIds = e.EmojisAfter.Keys.ToHashSet();
-
-            var addedIds = afterIds.Except(beforeIds).ToList();
-            var removedIds = beforeIds.Except(afterIds).ToList();
-            var updatedIds = beforeIds.Intersect(afterIds)
-                .Where(id => e.EmojisBefore[id].Name != e.EmojisAfter[id].Name)
-                .ToList();
-
-            // Upsert emotes
-            foreach (var emoji in e.EmojisAfter.Values)
+            string? rawJson = null;
+            try
             {
-                var existing = await db.Emotes
-                    .Where(em => em.DiscordId == emoji.Id)
-                    .FirstOrDefaultAsync();
-                if (existing == null)
+                var now = DateTime.UtcNow;
+                using var scope = scopeFactory.CreateScope();
+                var db = scope.ServiceProvider.GetRequiredService<DiscordDbContext>();
+                var rawEventService = scope.ServiceProvider.GetRequiredService<RawEventLogService>();
+
+                rawJson = await rawEventService.SerializeAndLogAsync(
+                    e, "GuildEmojisUpdated", e.Guild.Id, null, null, correlationId: correlationId);
+
+                // Look up Guild Guid
+                var guild = await db.Guilds.FirstOrDefaultAsync(g => g.DiscordId == e.Guild.Id);
+
+                var beforeIds = e.EmojisBefore.Keys.ToHashSet();
+                var afterIds = e.EmojisAfter.Keys.ToHashSet();
+
+                var addedIds = afterIds.Except(beforeIds).ToList();
+                var removedIds = beforeIds.Except(afterIds).ToList();
+                var updatedIds = beforeIds.Intersect(afterIds)
+                    .Where(id => e.EmojisBefore[id].Name != e.EmojisAfter[id].Name)
+                    .ToList();
+
+                // Upsert emotes
+                foreach (var emoji in e.EmojisAfter.Values)
                 {
-                    db.Emotes.Add(new EmoteEntity
+                    var existing = await db.Emotes
+                        .Where(em => em.DiscordId == emoji.Id)
+                        .FirstOrDefaultAsync();
+                    if (existing == null)
                     {
-                        DiscordId = emoji.Id,
-                        GuildId = guild?.Id,
-                        Name = emoji.Name,
-                        IsAnimated = emoji.IsAnimated,
-                        IsAvailable = emoji.IsAvailable
-                    });
+                        db.Emotes.Add(new EmoteEntity
+                        {
+                            DiscordId = emoji.Id,
+                            GuildId = guild?.Id,
+                            Name = emoji.Name,
+                            IsAnimated = emoji.IsAnimated,
+                            IsAvailable = emoji.IsAvailable
+                        });
+                    }
+                    else
+                    {
+                        existing.Name = emoji.Name;
+                        existing.IsAnimated = emoji.IsAnimated;
+                        existing.IsAvailable = emoji.IsAvailable;
+                        existing.IsDeleted = false;
+                        existing.DeletedAtUtc = null;
+                    }
                 }
-                else
+
+                // Mark removed as deleted
+                foreach (var id in removedIds)
                 {
-                    existing.Name = emoji.Name;
-                    existing.IsAnimated = emoji.IsAnimated;
-                    existing.IsAvailable = emoji.IsAvailable;
-                    existing.IsDeleted = false;
-                    existing.DeletedAtUtc = null;
+                    await db.Emotes.Where(em => em.DiscordId == id)
+                        .ExecuteUpdateAsync(s => s
+                            .SetProperty(em => em.IsDeleted, true)
+                            .SetProperty(em => em.DeletedAtUtc, (DateTime?)now));
                 }
+
+                var emojiEvent = new EmojiEventEntity
+                {
+                    GuildDiscordId = e.Guild.Id,
+                    EmojisAddedJson = addedIds.Count > 0
+                        ? JsonSerializer.Serialize(addedIds.Select(id => new { Id = id, e.EmojisAfter[id].Name }))
+                        : null,
+                    EmojisRemovedJson = removedIds.Count > 0
+                        ? JsonSerializer.Serialize(removedIds.Select(id => new { Id = id, e.EmojisBefore[id].Name }))
+                        : null,
+                    EmojisUpdatedJson = updatedIds.Count > 0
+                        ? JsonSerializer.Serialize(updatedIds.Select(id => new { Id = id, NameBefore = e.EmojisBefore[id].Name, NameAfter = e.EmojisAfter[id].Name }))
+                        : null,
+                    EventTimestampUtc = now,
+                    ReceivedAtUtc = now,
+                    RawEventJson = rawJson
+                };
+
+                db.EmojiEvents.Add(emojiEvent);
+                await db.SaveChangesAsync();
             }
-
-            // Mark removed as deleted
-            foreach (var id in removedIds)
+            catch (Exception ex)
             {
-                await db.Emotes.Where(em => em.DiscordId == id)
-                    .ExecuteUpdateAsync(s => s
-                        .SetProperty(em => em.IsDeleted, true)
-                        .SetProperty(em => em.DeletedAtUtc, (DateTime?)now));
+                logger.LogError(ex, "Error handling emojis updated for GuildId={GuildId}", e.Guild.Id);
+                using var failureScope = scopeFactory.CreateScope();
+                var failedEventService = failureScope.ServiceProvider.GetRequiredService<FailedEventService>();
+                await failedEventService.RecordFailureAsync(
+                    "GuildEmojisUpdated", nameof(EmojiEventHandler), ex,
+                    e.Guild?.Id, null, null, rawJson, correlationId: correlationId);
             }
-
-            var emojiEvent = new EmojiEventEntity
-            {
-                GuildDiscordId = e.Guild.Id,
-                EmojisAddedJson = addedIds.Count > 0
-                    ? JsonSerializer.Serialize(addedIds.Select(id => new { Id = id, e.EmojisAfter[id].Name }))
-                    : null,
-                EmojisRemovedJson = removedIds.Count > 0
-                    ? JsonSerializer.Serialize(removedIds.Select(id => new { Id = id, e.EmojisBefore[id].Name }))
-                    : null,
-                EmojisUpdatedJson = updatedIds.Count > 0
-                    ? JsonSerializer.Serialize(updatedIds.Select(id => new { Id = id, NameBefore = e.EmojisBefore[id].Name, NameAfter = e.EmojisAfter[id].Name }))
-                    : null,
-                EventTimestampUtc = now,
-                ReceivedAtUtc = now,
-                RawEventJson = rawJson
-            };
-
-            db.EmojiEvents.Add(emojiEvent);
-            await db.SaveChangesAsync();
-        }
-        catch (Exception ex)
-        {
-            logger.LogError(ex, "Error handling emojis updated for GuildId={GuildId}", e.Guild.Id);
-            using var failureScope = scopeFactory.CreateScope();
-            var failedEventService = failureScope.ServiceProvider.GetRequiredService<FailedEventService>();
-            await failedEventService.RecordFailureAsync(
-                "GuildEmojisUpdated", nameof(EmojiEventHandler), ex,
-                e.Guild?.Id, null, null, rawJson);
         }
     }
 }

--- a/src/DiscordEventService/Services/EventHandlers/GuildEventHandler.cs
+++ b/src/DiscordEventService/Services/EventHandlers/GuildEventHandler.cs
@@ -16,99 +16,103 @@ public class GuildEventHandler(IServiceScopeFactory scopeFactory, ILogger<GuildE
 {
     public async Task HandleEventAsync(DiscordClient sender, GuildCreatedEventArgs e)
     {
-        logger.LogInformation("GuildCreated event received for GuildId={GuildId} Name={GuildName}", e.Guild.Id, e.Guild.Name);
-        try
+        var correlationId = Guid.NewGuid();
+        using (logger.BeginScope(new Dictionary<string, object> { ["CorrelationId"] = correlationId }))
         {
-            using var scope = scopeFactory.CreateScope();
-            var db = scope.ServiceProvider.GetRequiredService<DiscordDbContext>();
-
-            void ApplyGuildFields(GuildEntity g)
+            logger.LogInformation("GuildCreated event received for GuildId={GuildId} Name={GuildName}", e.Guild.Id, e.Guild.Name);
+            try
             {
-                g.Name = e.Guild.Name;
-                g.IconHash = e.Guild.IconHash;
-                g.OwnerId = e.Guild.OwnerId;
-                g.LeftAtUtc = null;
-            }
+                using var scope = scopeFactory.CreateScope();
+                var db = scope.ServiceProvider.GetRequiredService<DiscordDbContext>();
 
-            // Wrap the two-stage upsert (Guild flush for Guid, then channels/roles) in
-            // one transaction so a partial failure (e.g. FK error on roles after Guild
-            // already flushed) rolls back atomically. ExecutionStrategy is required
-            // because EnableRetryOnFailure is configured on the DbContext.
-            var strategy = db.Database.CreateExecutionStrategy();
-            await strategy.ExecuteAsync(async () =>
-            {
-                db.ChangeTracker.Clear();
-                await using var tx = await db.Database.BeginTransactionAsync();
-
-                // Upsert guild
-                var existingGuild = await db.Guilds
-                    .Where(g => g.DiscordId == e.Guild.Id)
-                    .FirstOrDefaultAsync();
-                if (existingGuild == null)
+                void ApplyGuildFields(GuildEntity g)
                 {
-                    existingGuild = new GuildEntity
+                    g.Name = e.Guild.Name;
+                    g.IconHash = e.Guild.IconHash;
+                    g.OwnerId = e.Guild.OwnerId;
+                    g.LeftAtUtc = null;
+                }
+
+                // Wrap the two-stage upsert (Guild flush for Guid, then channels/roles) in
+                // one transaction so a partial failure (e.g. FK error on roles after Guild
+                // already flushed) rolls back atomically. ExecutionStrategy is required
+                // because EnableRetryOnFailure is configured on the DbContext.
+                var strategy = db.Database.CreateExecutionStrategy();
+                await strategy.ExecuteAsync(async () =>
+                {
+                    db.ChangeTracker.Clear();
+                    await using var tx = await db.Database.BeginTransactionAsync();
+
+                    // Upsert guild
+                    var existingGuild = await db.Guilds
+                        .Where(g => g.DiscordId == e.Guild.Id)
+                        .FirstOrDefaultAsync();
+                    if (existingGuild == null)
                     {
-                        DiscordId = e.Guild.Id,
-                        Name = e.Guild.Name,
-                        IconHash = e.Guild.IconHash,
-                        OwnerId = e.Guild.OwnerId,
-                        LeftAtUtc = null
-                    };
-                    db.Guilds.Add(existingGuild);
+                        existingGuild = new GuildEntity
+                        {
+                            DiscordId = e.Guild.Id,
+                            Name = e.Guild.Name,
+                            IconHash = e.Guild.IconHash,
+                            OwnerId = e.Guild.OwnerId,
+                            LeftAtUtc = null
+                        };
+                        db.Guilds.Add(existingGuild);
+                        try
+                        {
+                            await db.SaveChangesAsync(); // Flush to get the Guid Id (committed atomically with the rest at tx.CommitAsync).
+                        }
+                        catch (DbUpdateException dbEx) when (dbEx.InnerException is Npgsql.PostgresException { SqlState: "23505" })
+                        {
+                            // Concurrent insert won the race. Re-fetch and update.
+                            db.ChangeTracker.Clear();
+                            existingGuild = await db.Guilds
+                                .Where(g => g.DiscordId == e.Guild.Id)
+                                .FirstOrDefaultAsync()
+                                ?? throw new InvalidOperationException($"Guild {e.Guild.Id} disappeared after 23505 conflict");
+                            ApplyGuildFields(existingGuild);
+                        }
+                    }
+                    else
+                    {
+                        ApplyGuildFields(existingGuild);
+                    }
+
+                    var guildGuid = existingGuild.Id;
+
+                    await UpsertChannelsAndRolesAsync(db, e.Guild, guildGuid);
+
                     try
                     {
-                        await db.SaveChangesAsync(); // Flush to get the Guid Id (committed atomically with the rest at tx.CommitAsync).
+                        await db.SaveChangesAsync();
                     }
                     catch (DbUpdateException dbEx) when (dbEx.InnerException is Npgsql.PostgresException { SqlState: "23505" })
                     {
-                        // Concurrent insert won the race. Re-fetch and update.
+                        // Concurrent GuildCreated inserted a channel/role that wasn't in our batch lookup.
+                        // Clear drops the Guild field updates set above, so re-fetch and re-apply them
+                        // alongside the channel/role re-batch-load before saving.
                         db.ChangeTracker.Clear();
-                        existingGuild = await db.Guilds
-                            .Where(g => g.DiscordId == e.Guild.Id)
-                            .FirstOrDefaultAsync()
-                            ?? throw new InvalidOperationException($"Guild {e.Guild.Id} disappeared after 23505 conflict");
-                        ApplyGuildFields(existingGuild);
+                        var refreshedGuild = await db.Guilds.FirstOrDefaultAsync(g => g.DiscordId == e.Guild.Id);
+                        if (refreshedGuild != null)
+                        {
+                            ApplyGuildFields(refreshedGuild);
+                        }
+                        await UpsertChannelsAndRolesAsync(db, e.Guild, guildGuid);
+                        await db.SaveChangesAsync();
                     }
-                }
-                else
-                {
-                    ApplyGuildFields(existingGuild);
-                }
 
-                var guildGuid = existingGuild.Id;
-
-                await UpsertChannelsAndRolesAsync(db, e.Guild, guildGuid);
-
-                try
-                {
-                    await db.SaveChangesAsync();
-                }
-                catch (DbUpdateException dbEx) when (dbEx.InnerException is Npgsql.PostgresException { SqlState: "23505" })
-                {
-                    // Concurrent GuildCreated inserted a channel/role that wasn't in our batch lookup.
-                    // Clear drops the Guild field updates set above, so re-fetch and re-apply them
-                    // alongside the channel/role re-batch-load before saving.
-                    db.ChangeTracker.Clear();
-                    var refreshedGuild = await db.Guilds.FirstOrDefaultAsync(g => g.DiscordId == e.Guild.Id);
-                    if (refreshedGuild != null)
-                    {
-                        ApplyGuildFields(refreshedGuild);
-                    }
-                    await UpsertChannelsAndRolesAsync(db, e.Guild, guildGuid);
-                    await db.SaveChangesAsync();
-                }
-
-                await tx.CommitAsync();
-            });
-        }
-        catch (Exception ex)
-        {
-            logger.LogError(ex, "Error handling guild created for GuildId={GuildId}", e.Guild.Id);
-            using var failureScope = scopeFactory.CreateScope();
-            var failedEventService = failureScope.ServiceProvider.GetRequiredService<FailedEventService>();
-            await failedEventService.RecordFailureAsync(
-                "GuildCreated", nameof(GuildEventHandler), ex,
-                e.Guild?.Id, null, null);
+                    await tx.CommitAsync();
+                });
+            }
+            catch (Exception ex)
+            {
+                logger.LogError(ex, "Error handling guild created for GuildId={GuildId}", e.Guild.Id);
+                using var failureScope = scopeFactory.CreateScope();
+                var failedEventService = failureScope.ServiceProvider.GetRequiredService<FailedEventService>();
+                await failedEventService.RecordFailureAsync(
+                    "GuildCreated", nameof(GuildEventHandler), ex,
+                    e.Guild?.Id, null, null, correlationId: correlationId);
+            }
         }
     }
 
@@ -120,125 +124,137 @@ public class GuildEventHandler(IServiceScopeFactory scopeFactory, ILogger<GuildE
 
     public async Task HandleEventAsync(DiscordClient sender, GuildUpdatedEventArgs e)
     {
-        try
+        var correlationId = Guid.NewGuid();
+        using (logger.BeginScope(new Dictionary<string, object> { ["CorrelationId"] = correlationId }))
         {
-            using var scope = scopeFactory.CreateScope();
-            var db = scope.ServiceProvider.GetRequiredService<DiscordDbContext>();
-
-            var existingGuild = await db.Guilds
-                .Where(g => g.DiscordId == e.GuildAfter.Id)
-                .FirstOrDefaultAsync();
-            if (existingGuild != null)
+            try
             {
-                existingGuild.Name = e.GuildAfter.Name;
-                existingGuild.IconHash = e.GuildAfter.IconHash;
-                existingGuild.OwnerId = e.GuildAfter.OwnerId;
+                using var scope = scopeFactory.CreateScope();
+                var db = scope.ServiceProvider.GetRequiredService<DiscordDbContext>();
 
-                await db.SaveChangesAsync();
+                var existingGuild = await db.Guilds
+                    .Where(g => g.DiscordId == e.GuildAfter.Id)
+                    .FirstOrDefaultAsync();
+                if (existingGuild != null)
+                {
+                    existingGuild.Name = e.GuildAfter.Name;
+                    existingGuild.IconHash = e.GuildAfter.IconHash;
+                    existingGuild.OwnerId = e.GuildAfter.OwnerId;
+
+                    await db.SaveChangesAsync();
+                }
             }
-        }
-        catch (Exception ex)
-        {
-            logger.LogError(ex, "Error handling guild updated for GuildId={GuildId}", e.GuildAfter.Id);
-            using var failureScope = scopeFactory.CreateScope();
-            var failedEventService = failureScope.ServiceProvider.GetRequiredService<FailedEventService>();
-            await failedEventService.RecordFailureAsync(
-                "GuildUpdated", nameof(GuildEventHandler), ex,
-                e.GuildAfter?.Id, null, null);
+            catch (Exception ex)
+            {
+                logger.LogError(ex, "Error handling guild updated for GuildId={GuildId}", e.GuildAfter.Id);
+                using var failureScope = scopeFactory.CreateScope();
+                var failedEventService = failureScope.ServiceProvider.GetRequiredService<FailedEventService>();
+                await failedEventService.RecordFailureAsync(
+                    "GuildUpdated", nameof(GuildEventHandler), ex,
+                    e.GuildAfter?.Id, null, null, correlationId: correlationId);
+            }
         }
     }
 
     public async Task HandleEventAsync(DiscordClient sender, GuildDeletedEventArgs e)
     {
-        try
+        var correlationId = Guid.NewGuid();
+        using (logger.BeginScope(new Dictionary<string, object> { ["CorrelationId"] = correlationId }))
         {
-            using var scope = scopeFactory.CreateScope();
-            var db = scope.ServiceProvider.GetRequiredService<DiscordDbContext>();
-
-            var existingGuild = await db.Guilds
-                .Where(g => g.DiscordId == e.Guild.Id)
-                .FirstOrDefaultAsync();
-            if (existingGuild != null)
+            try
             {
-                existingGuild.LeftAtUtc = DateTime.UtcNow;
-                await db.SaveChangesAsync();
+                using var scope = scopeFactory.CreateScope();
+                var db = scope.ServiceProvider.GetRequiredService<DiscordDbContext>();
+
+                var existingGuild = await db.Guilds
+                    .Where(g => g.DiscordId == e.Guild.Id)
+                    .FirstOrDefaultAsync();
+                if (existingGuild != null)
+                {
+                    existingGuild.LeftAtUtc = DateTime.UtcNow;
+                    await db.SaveChangesAsync();
+                }
             }
-        }
-        catch (Exception ex)
-        {
-            logger.LogError(ex, "Error handling guild deleted for GuildId={GuildId}", e.Guild.Id);
-            using var failureScope = scopeFactory.CreateScope();
-            var failedEventService = failureScope.ServiceProvider.GetRequiredService<FailedEventService>();
-            await failedEventService.RecordFailureAsync(
-                "GuildDeleted", nameof(GuildEventHandler), ex,
-                e.Guild?.Id, null, null);
+            catch (Exception ex)
+            {
+                logger.LogError(ex, "Error handling guild deleted for GuildId={GuildId}", e.Guild.Id);
+                using var failureScope = scopeFactory.CreateScope();
+                var failedEventService = failureScope.ServiceProvider.GetRequiredService<FailedEventService>();
+                await failedEventService.RecordFailureAsync(
+                    "GuildDeleted", nameof(GuildEventHandler), ex,
+                    e.Guild?.Id, null, null, correlationId: correlationId);
+            }
         }
     }
 
     public async Task HandleEventAsync(DiscordClient sender, GuildEmojisUpdatedEventArgs e)
     {
-        try
+        var correlationId = Guid.NewGuid();
+        using (logger.BeginScope(new Dictionary<string, object> { ["CorrelationId"] = correlationId }))
         {
-            using var scope = scopeFactory.CreateScope();
-            var db = scope.ServiceProvider.GetRequiredService<DiscordDbContext>();
-
-            // Look up Guild Guid
-            var guild = await db.Guilds.FirstOrDefaultAsync(g => g.DiscordId == e.Guild.Id);
-            var guildGuid = guild?.Id;
-
-            // Batch load existing emotes for this guild
-            var existingEmotes = await db.Emotes
-                .Where(em => em.GuildId == guildGuid)
-                .ToDictionaryAsync(em => em.DiscordId);
-
-            var currentEmoteIds = e.EmojisAfter.Select(em => em.Key).ToHashSet();
-
-            // Mark deleted emotes
-            foreach (var existingEmote in existingEmotes.Values)
+            try
             {
-                if (!currentEmoteIds.Contains(existingEmote.DiscordId))
-                {
-                    existingEmote.IsDeleted = true;
-                    existingEmote.DeletedAtUtc ??= DateTime.UtcNow;
-                }
-            }
+                using var scope = scopeFactory.CreateScope();
+                var db = scope.ServiceProvider.GetRequiredService<DiscordDbContext>();
 
-            // Upsert current emotes (use dictionary lookup instead of FindAsync)
-            foreach (var emoteKvp in e.EmojisAfter)
-            {
-                var emote = emoteKvp.Value;
-                if (!existingEmotes.TryGetValue(emote.Id, out var existingEmote))
+                // Look up Guild Guid
+                var guild = await db.Guilds.FirstOrDefaultAsync(g => g.DiscordId == e.Guild.Id);
+                var guildGuid = guild?.Id;
+
+                // Batch load existing emotes for this guild
+                var existingEmotes = await db.Emotes
+                    .Where(em => em.GuildId == guildGuid)
+                    .ToDictionaryAsync(em => em.DiscordId);
+
+                var currentEmoteIds = e.EmojisAfter.Select(em => em.Key).ToHashSet();
+
+                // Mark deleted emotes
+                foreach (var existingEmote in existingEmotes.Values)
                 {
-                    db.Emotes.Add(new EmoteEntity
+                    if (!currentEmoteIds.Contains(existingEmote.DiscordId))
                     {
-                        DiscordId = emote.Id,
-                        GuildId = guildGuid,
-                        Name = emote.Name,
-                        IsAnimated = emote.IsAnimated,
-                        IsAvailable = emote.IsAvailable,
-                        IsDeleted = false
-                    });
+                        existingEmote.IsDeleted = true;
+                        existingEmote.DeletedAtUtc ??= DateTime.UtcNow;
+                    }
                 }
-                else
-                {
-                    existingEmote.Name = emote.Name;
-                    existingEmote.IsAnimated = emote.IsAnimated;
-                    existingEmote.IsAvailable = emote.IsAvailable;
-                    existingEmote.IsDeleted = false;
-                    existingEmote.DeletedAtUtc = null;
-                }
-            }
 
-            await db.SaveChangesAsync();
-        }
-        catch (Exception ex)
-        {
-            logger.LogError(ex, "Error handling guild emojis updated for GuildId={GuildId}", e.Guild.Id);
-            using var failureScope = scopeFactory.CreateScope();
-            var failedEventService = failureScope.ServiceProvider.GetRequiredService<FailedEventService>();
-            await failedEventService.RecordFailureAsync(
-                "GuildEmojisUpdated", nameof(GuildEventHandler), ex,
-                e.Guild?.Id, null, null);
+                // Upsert current emotes (use dictionary lookup instead of FindAsync)
+                foreach (var emoteKvp in e.EmojisAfter)
+                {
+                    var emote = emoteKvp.Value;
+                    if (!existingEmotes.TryGetValue(emote.Id, out var existingEmote))
+                    {
+                        db.Emotes.Add(new EmoteEntity
+                        {
+                            DiscordId = emote.Id,
+                            GuildId = guildGuid,
+                            Name = emote.Name,
+                            IsAnimated = emote.IsAnimated,
+                            IsAvailable = emote.IsAvailable,
+                            IsDeleted = false
+                        });
+                    }
+                    else
+                    {
+                        existingEmote.Name = emote.Name;
+                        existingEmote.IsAnimated = emote.IsAnimated;
+                        existingEmote.IsAvailable = emote.IsAvailable;
+                        existingEmote.IsDeleted = false;
+                        existingEmote.DeletedAtUtc = null;
+                    }
+                }
+
+                await db.SaveChangesAsync();
+            }
+            catch (Exception ex)
+            {
+                logger.LogError(ex, "Error handling guild emojis updated for GuildId={GuildId}", e.Guild.Id);
+                using var failureScope = scopeFactory.CreateScope();
+                var failedEventService = failureScope.ServiceProvider.GetRequiredService<FailedEventService>();
+                await failedEventService.RecordFailureAsync(
+                    "GuildEmojisUpdated", nameof(GuildEventHandler), ex,
+                    e.Guild?.Id, null, null, correlationId: correlationId);
+            }
         }
     }
 

--- a/src/DiscordEventService/Services/EventHandlers/GuildMembersChunkHandler.cs
+++ b/src/DiscordEventService/Services/EventHandlers/GuildMembersChunkHandler.cs
@@ -17,63 +17,67 @@ public class GuildMembersChunkHandler(IServiceScopeFactory scopeFactory, ILogger
 
     public async Task HandleEventAsync(DiscordClient sender, GuildMembersChunkedEventArgs args)
     {
-        string? rawJson = null;
-        try
+        var correlationId = Guid.NewGuid();
+        using (logger.BeginScope(new Dictionary<string, object> { ["CorrelationId"] = correlationId }))
         {
-            var now = DateTime.UtcNow;
-
-            using var scope = scopeFactory.CreateScope();
-            var db = scope.ServiceProvider.GetRequiredService<DiscordDbContext>();
-            var userService = scope.ServiceProvider.GetRequiredService<UserService>();
-            var rawEventService = scope.ServiceProvider.GetRequiredService<RawEventLogService>();
-
-            rawJson = await rawEventService.SerializeAndLogAsync(
-                args, "GuildMembersChunked", args.Guild.Id, null, null);
-
-            // Upsert all members received in this chunk
-            foreach (var member in args.Members)
+            string? rawJson = null;
+            try
             {
-                await userService.UpsertUserAsync(member);
+                var now = DateTime.UtcNow;
+
+                using var scope = scopeFactory.CreateScope();
+                var db = scope.ServiceProvider.GetRequiredService<DiscordDbContext>();
+                var userService = scope.ServiceProvider.GetRequiredService<UserService>();
+                var rawEventService = scope.ServiceProvider.GetRequiredService<RawEventLogService>();
+
+                rawJson = await rawEventService.SerializeAndLogAsync(
+                    args, "GuildMembersChunked", args.Guild.Id, null, null, correlationId: correlationId);
+
+                // Upsert all members received in this chunk
+                foreach (var member in args.Members)
+                {
+                    await userService.UpsertUserAsync(member);
+                }
+
+                var chunkEvent = new GuildMembersChunkEventEntity
+                {
+                    GuildDiscordId = args.Guild.Id,
+                    ChunkIndex = args.ChunkIndex,
+                    ChunkCount = args.ChunkCount,
+                    MemberCount = args.Members.Count,
+                    MemberIdsJson = JsonSerializer.Serialize(args.Members.Select(m => m.Id.ToString()), JsonOptions),
+                    PresencesJson = args.Presences?.Count > 0
+                        ? JsonSerializer.Serialize(args.Presences.Select(p => new
+                        {
+                            UserId = p.User.Id.ToString(),
+                            Status = p.Status.ToString(),
+                            Activities = p.Activities?.Select(a => new { a.Name, Type = (int)a.ActivityType })
+                        }), JsonOptions)
+                        : null,
+                    Nonce = args.Nonce,
+                    NotFoundIdsJson = args.NotFound?.Count > 0
+                        ? JsonSerializer.Serialize(args.NotFound.Select(id => id.ToString()), JsonOptions)
+                        : null,
+                    EventTimestampUtc = now,
+                    ReceivedAtUtc = now,
+                    RawEventJson = rawJson
+                };
+
+                await db.GuildMembersChunkEvents.AddAsync(chunkEvent);
+                await db.SaveChangesAsync();
+
+                logger.LogDebug("Recorded guild members chunk {ChunkIndex}/{ChunkCount} for guild {GuildId} with {MemberCount} members",
+                    args.ChunkIndex, args.ChunkCount, args.Guild.Id, args.Members.Count);
             }
-
-            var chunkEvent = new GuildMembersChunkEventEntity
+            catch (Exception ex)
             {
-                GuildDiscordId = args.Guild.Id,
-                ChunkIndex = args.ChunkIndex,
-                ChunkCount = args.ChunkCount,
-                MemberCount = args.Members.Count,
-                MemberIdsJson = JsonSerializer.Serialize(args.Members.Select(m => m.Id.ToString()), JsonOptions),
-                PresencesJson = args.Presences?.Count > 0
-                    ? JsonSerializer.Serialize(args.Presences.Select(p => new
-                    {
-                        UserId = p.User.Id.ToString(),
-                        Status = p.Status.ToString(),
-                        Activities = p.Activities?.Select(a => new { a.Name, Type = (int)a.ActivityType })
-                    }), JsonOptions)
-                    : null,
-                Nonce = args.Nonce,
-                NotFoundIdsJson = args.NotFound?.Count > 0
-                    ? JsonSerializer.Serialize(args.NotFound.Select(id => id.ToString()), JsonOptions)
-                    : null,
-                EventTimestampUtc = now,
-                ReceivedAtUtc = now,
-                RawEventJson = rawJson
-            };
-
-            await db.GuildMembersChunkEvents.AddAsync(chunkEvent);
-            await db.SaveChangesAsync();
-
-            logger.LogDebug("Recorded guild members chunk {ChunkIndex}/{ChunkCount} for guild {GuildId} with {MemberCount} members",
-                args.ChunkIndex, args.ChunkCount, args.Guild.Id, args.Members.Count);
-        }
-        catch (Exception ex)
-        {
-            logger.LogError(ex, "Error handling guild members chunk for guild {GuildId}", args.Guild.Id);
-            using var failureScope = scopeFactory.CreateScope();
-            var failedEventService = failureScope.ServiceProvider.GetRequiredService<FailedEventService>();
-            await failedEventService.RecordFailureAsync(
-                "GuildMembersChunked", nameof(GuildMembersChunkHandler), ex,
-                args.Guild?.Id, null, null, rawJson);
+                logger.LogError(ex, "Error handling guild members chunk for guild {GuildId}", args.Guild.Id);
+                using var failureScope = scopeFactory.CreateScope();
+                var failedEventService = failureScope.ServiceProvider.GetRequiredService<FailedEventService>();
+                await failedEventService.RecordFailureAsync(
+                    "GuildMembersChunked", nameof(GuildMembersChunkHandler), ex,
+                    args.Guild?.Id, null, null, rawJson, correlationId: correlationId);
+            }
         }
     }
 }

--- a/src/DiscordEventService/Services/EventHandlers/GuildUpdateEventHandler.cs
+++ b/src/DiscordEventService/Services/EventHandlers/GuildUpdateEventHandler.cs
@@ -10,55 +10,59 @@ public class GuildUpdateEventHandler(IServiceScopeFactory scopeFactory, ILogger<
 {
     public async Task HandleEventAsync(DiscordClient sender, GuildUpdatedEventArgs e)
     {
-        string? rawJson = null;
-        try
+        var correlationId = Guid.NewGuid();
+        using (logger.BeginScope(new Dictionary<string, object> { ["CorrelationId"] = correlationId }))
         {
-            var now = DateTime.UtcNow;
-            using var scope = scopeFactory.CreateScope();
-            var db = scope.ServiceProvider.GetRequiredService<DiscordDbContext>();
-            var rawEventService = scope.ServiceProvider.GetRequiredService<RawEventLogService>();
-
-            rawJson = await rawEventService.SerializeAndLogAsync(
-                e, "GuildUpdatedEvent", e.GuildAfter.Id, null, null);
-
-            var guildEvent = new GuildEventEntity
+            string? rawJson = null;
+            try
             {
-                GuildDiscordId = e.GuildAfter.Id,
-                EventType = GuildEventType.Updated,
-                EventTimestampUtc = now,
-                ReceivedAtUtc = now,
-                RawEventJson = rawJson
-            };
+                var now = DateTime.UtcNow;
+                using var scope = scopeFactory.CreateScope();
+                var db = scope.ServiceProvider.GetRequiredService<DiscordDbContext>();
+                var rawEventService = scope.ServiceProvider.GetRequiredService<RawEventLogService>();
 
-            if (e.GuildBefore.Name != e.GuildAfter.Name)
-            {
-                guildEvent.NameBefore = e.GuildBefore.Name;
-                guildEvent.NameAfter = e.GuildAfter.Name;
+                rawJson = await rawEventService.SerializeAndLogAsync(
+                    e, "GuildUpdatedEvent", e.GuildAfter.Id, null, null, correlationId: correlationId);
+
+                var guildEvent = new GuildEventEntity
+                {
+                    GuildDiscordId = e.GuildAfter.Id,
+                    EventType = GuildEventType.Updated,
+                    EventTimestampUtc = now,
+                    ReceivedAtUtc = now,
+                    RawEventJson = rawJson
+                };
+
+                if (e.GuildBefore.Name != e.GuildAfter.Name)
+                {
+                    guildEvent.NameBefore = e.GuildBefore.Name;
+                    guildEvent.NameAfter = e.GuildAfter.Name;
+                }
+
+                if (e.GuildBefore.IconHash != e.GuildAfter.IconHash)
+                {
+                    guildEvent.IconHashBefore = e.GuildBefore.IconHash;
+                    guildEvent.IconHashAfter = e.GuildAfter.IconHash;
+                }
+
+                if (e.GuildBefore.OwnerId != e.GuildAfter.OwnerId)
+                {
+                    guildEvent.OwnerDiscordIdBefore = e.GuildBefore.OwnerId;
+                    guildEvent.OwnerDiscordIdAfter = e.GuildAfter.OwnerId;
+                }
+
+                db.GuildEvents.Add(guildEvent);
+                await db.SaveChangesAsync();
             }
-
-            if (e.GuildBefore.IconHash != e.GuildAfter.IconHash)
+            catch (Exception ex)
             {
-                guildEvent.IconHashBefore = e.GuildBefore.IconHash;
-                guildEvent.IconHashAfter = e.GuildAfter.IconHash;
+                logger.LogError(ex, "Error handling guild updated for GuildId={GuildId}", e.GuildAfter.Id);
+                using var failureScope = scopeFactory.CreateScope();
+                var failedEventService = failureScope.ServiceProvider.GetRequiredService<FailedEventService>();
+                await failedEventService.RecordFailureAsync(
+                    "GuildUpdatedEvent", nameof(GuildUpdateEventHandler), ex,
+                    e.GuildAfter?.Id, null, null, rawJson, correlationId: correlationId);
             }
-
-            if (e.GuildBefore.OwnerId != e.GuildAfter.OwnerId)
-            {
-                guildEvent.OwnerDiscordIdBefore = e.GuildBefore.OwnerId;
-                guildEvent.OwnerDiscordIdAfter = e.GuildAfter.OwnerId;
-            }
-
-            db.GuildEvents.Add(guildEvent);
-            await db.SaveChangesAsync();
-        }
-        catch (Exception ex)
-        {
-            logger.LogError(ex, "Error handling guild updated for GuildId={GuildId}", e.GuildAfter.Id);
-            using var failureScope = scopeFactory.CreateScope();
-            var failedEventService = failureScope.ServiceProvider.GetRequiredService<FailedEventService>();
-            await failedEventService.RecordFailureAsync(
-                "GuildUpdatedEvent", nameof(GuildUpdateEventHandler), ex,
-                e.GuildAfter?.Id, null, null, rawJson);
         }
     }
 }

--- a/src/DiscordEventService/Services/EventHandlers/IntegrationEventHandler.cs
+++ b/src/DiscordEventService/Services/EventHandlers/IntegrationEventHandler.cs
@@ -14,139 +14,151 @@ public class IntegrationEventHandler(IServiceScopeFactory scopeFactory, ILogger<
 {
     public async Task HandleEventAsync(DiscordClient sender, IntegrationCreatedEventArgs e)
     {
-        string? rawJson = null;
-        try
+        var correlationId = Guid.NewGuid();
+        using (logger.BeginScope(new Dictionary<string, object> { ["CorrelationId"] = correlationId }))
         {
-            var now = DateTime.UtcNow;
-            using var scope = scopeFactory.CreateScope();
-            var db = scope.ServiceProvider.GetRequiredService<DiscordDbContext>();
-            var rawEventService = scope.ServiceProvider.GetRequiredService<RawEventLogService>();
-
-            rawJson = await rawEventService.SerializeAndLogAsync(
-                e, "IntegrationCreated", e.Guild.Id, null, null);
-
-            // Look up Guid FK
-            var guild = await db.Guilds.FirstOrDefaultAsync(g => g.DiscordId == e.Guild.Id);
-
-            db.Integrations.Add(new IntegrationEntity
+            string? rawJson = null;
+            try
             {
-                DiscordId = e.Integration.Id,
-                GuildId = guild?.Id ?? Guid.Empty,
-                Name = e.Integration.Name,
-                Type = e.Integration.Type,
-                IsEnabled = e.Integration.IsEnabled
-            });
+                var now = DateTime.UtcNow;
+                using var scope = scopeFactory.CreateScope();
+                var db = scope.ServiceProvider.GetRequiredService<DiscordDbContext>();
+                var rawEventService = scope.ServiceProvider.GetRequiredService<RawEventLogService>();
 
-            db.IntegrationEvents.Add(new IntegrationEventEntity
+                rawJson = await rawEventService.SerializeAndLogAsync(
+                    e, "IntegrationCreated", e.Guild.Id, null, null, correlationId: correlationId);
+
+                // Look up Guid FK
+                var guild = await db.Guilds.FirstOrDefaultAsync(g => g.DiscordId == e.Guild.Id);
+
+                db.Integrations.Add(new IntegrationEntity
+                {
+                    DiscordId = e.Integration.Id,
+                    GuildId = guild?.Id ?? Guid.Empty,
+                    Name = e.Integration.Name,
+                    Type = e.Integration.Type,
+                    IsEnabled = e.Integration.IsEnabled
+                });
+
+                db.IntegrationEvents.Add(new IntegrationEventEntity
+                {
+                    IntegrationDiscordId = e.Integration.Id,
+                    GuildDiscordId = e.Guild.Id,
+                    EventType = IntegrationEventType.Created,
+                    Name = e.Integration.Name,
+                    Type = e.Integration.Type,
+                    IsEnabled = e.Integration.IsEnabled,
+                    EventTimestampUtc = now,
+                    ReceivedAtUtc = now,
+                    RawEventJson = rawJson
+                });
+
+                await db.SaveChangesAsync();
+            }
+            catch (Exception ex)
             {
-                IntegrationDiscordId = e.Integration.Id,
-                GuildDiscordId = e.Guild.Id,
-                EventType = IntegrationEventType.Created,
-                Name = e.Integration.Name,
-                Type = e.Integration.Type,
-                IsEnabled = e.Integration.IsEnabled,
-                EventTimestampUtc = now,
-                ReceivedAtUtc = now,
-                RawEventJson = rawJson
-            });
-
-            await db.SaveChangesAsync();
-        }
-        catch (Exception ex)
-        {
-            logger.LogError(ex, "Error handling integration created");
-            using var failureScope = scopeFactory.CreateScope();
-            var failedEventService = failureScope.ServiceProvider.GetRequiredService<FailedEventService>();
-            await failedEventService.RecordFailureAsync(
-                "IntegrationCreated", nameof(IntegrationEventHandler), ex,
-                e.Guild?.Id, null, null, rawJson);
+                logger.LogError(ex, "Error handling integration created");
+                using var failureScope = scopeFactory.CreateScope();
+                var failedEventService = failureScope.ServiceProvider.GetRequiredService<FailedEventService>();
+                await failedEventService.RecordFailureAsync(
+                    "IntegrationCreated", nameof(IntegrationEventHandler), ex,
+                    e.Guild?.Id, null, null, rawJson, correlationId: correlationId);
+            }
         }
     }
 
     public async Task HandleEventAsync(DiscordClient sender, IntegrationUpdatedEventArgs e)
     {
-        string? rawJson = null;
-        try
+        var correlationId = Guid.NewGuid();
+        using (logger.BeginScope(new Dictionary<string, object> { ["CorrelationId"] = correlationId }))
         {
-            var now = DateTime.UtcNow;
-            using var scope = scopeFactory.CreateScope();
-            var db = scope.ServiceProvider.GetRequiredService<DiscordDbContext>();
-            var rawEventService = scope.ServiceProvider.GetRequiredService<RawEventLogService>();
-
-            rawJson = await rawEventService.SerializeAndLogAsync(
-                e, "IntegrationUpdated", e.Guild.Id, null, null);
-
-            await db.Integrations
-                .Where(i => i.DiscordId == e.Integration.Id)
-                .ExecuteUpdateAsync(s => s
-                    .SetProperty(i => i.Name, e.Integration.Name)
-                    .SetProperty(i => i.IsEnabled, e.Integration.IsEnabled));
-
-            db.IntegrationEvents.Add(new IntegrationEventEntity
+            string? rawJson = null;
+            try
             {
-                IntegrationDiscordId = e.Integration.Id,
-                GuildDiscordId = e.Guild.Id,
-                EventType = IntegrationEventType.Updated,
-                Name = e.Integration.Name,
-                Type = e.Integration.Type,
-                IsEnabled = e.Integration.IsEnabled,
-                EventTimestampUtc = now,
-                ReceivedAtUtc = now,
-                RawEventJson = rawJson
-            });
+                var now = DateTime.UtcNow;
+                using var scope = scopeFactory.CreateScope();
+                var db = scope.ServiceProvider.GetRequiredService<DiscordDbContext>();
+                var rawEventService = scope.ServiceProvider.GetRequiredService<RawEventLogService>();
 
-            await db.SaveChangesAsync();
-        }
-        catch (Exception ex)
-        {
-            logger.LogError(ex, "Error handling integration updated");
-            using var failureScope = scopeFactory.CreateScope();
-            var failedEventService = failureScope.ServiceProvider.GetRequiredService<FailedEventService>();
-            await failedEventService.RecordFailureAsync(
-                "IntegrationUpdated", nameof(IntegrationEventHandler), ex,
-                e.Guild?.Id, null, null, rawJson);
+                rawJson = await rawEventService.SerializeAndLogAsync(
+                    e, "IntegrationUpdated", e.Guild.Id, null, null, correlationId: correlationId);
+
+                await db.Integrations
+                    .Where(i => i.DiscordId == e.Integration.Id)
+                    .ExecuteUpdateAsync(s => s
+                        .SetProperty(i => i.Name, e.Integration.Name)
+                        .SetProperty(i => i.IsEnabled, e.Integration.IsEnabled));
+
+                db.IntegrationEvents.Add(new IntegrationEventEntity
+                {
+                    IntegrationDiscordId = e.Integration.Id,
+                    GuildDiscordId = e.Guild.Id,
+                    EventType = IntegrationEventType.Updated,
+                    Name = e.Integration.Name,
+                    Type = e.Integration.Type,
+                    IsEnabled = e.Integration.IsEnabled,
+                    EventTimestampUtc = now,
+                    ReceivedAtUtc = now,
+                    RawEventJson = rawJson
+                });
+
+                await db.SaveChangesAsync();
+            }
+            catch (Exception ex)
+            {
+                logger.LogError(ex, "Error handling integration updated");
+                using var failureScope = scopeFactory.CreateScope();
+                var failedEventService = failureScope.ServiceProvider.GetRequiredService<FailedEventService>();
+                await failedEventService.RecordFailureAsync(
+                    "IntegrationUpdated", nameof(IntegrationEventHandler), ex,
+                    e.Guild?.Id, null, null, rawJson, correlationId: correlationId);
+            }
         }
     }
 
     public async Task HandleEventAsync(DiscordClient sender, IntegrationDeletedEventArgs e)
     {
-        string? rawJson = null;
-        try
+        var correlationId = Guid.NewGuid();
+        using (logger.BeginScope(new Dictionary<string, object> { ["CorrelationId"] = correlationId }))
         {
-            var now = DateTime.UtcNow;
-            using var scope = scopeFactory.CreateScope();
-            var db = scope.ServiceProvider.GetRequiredService<DiscordDbContext>();
-            var rawEventService = scope.ServiceProvider.GetRequiredService<RawEventLogService>();
-
-            rawJson = await rawEventService.SerializeAndLogAsync(
-                e, "IntegrationDeleted", e.Guild.Id, null, null);
-
-            await db.Integrations
-                .Where(i => i.DiscordId == e.IntegrationId)
-                .ExecuteUpdateAsync(s => s
-                    .SetProperty(i => i.IsDeleted, true)
-                    .SetProperty(i => i.DeletedAtUtc, (DateTime?)now));
-
-            db.IntegrationEvents.Add(new IntegrationEventEntity
+            string? rawJson = null;
+            try
             {
-                IntegrationDiscordId = e.IntegrationId,
-                GuildDiscordId = e.Guild.Id,
-                EventType = IntegrationEventType.Deleted,
-                EventTimestampUtc = now,
-                ReceivedAtUtc = now,
-                RawEventJson = rawJson
-            });
+                var now = DateTime.UtcNow;
+                using var scope = scopeFactory.CreateScope();
+                var db = scope.ServiceProvider.GetRequiredService<DiscordDbContext>();
+                var rawEventService = scope.ServiceProvider.GetRequiredService<RawEventLogService>();
 
-            await db.SaveChangesAsync();
-        }
-        catch (Exception ex)
-        {
-            logger.LogError(ex, "Error handling integration deleted");
-            using var failureScope = scopeFactory.CreateScope();
-            var failedEventService = failureScope.ServiceProvider.GetRequiredService<FailedEventService>();
-            await failedEventService.RecordFailureAsync(
-                "IntegrationDeleted", nameof(IntegrationEventHandler), ex,
-                e.Guild?.Id, null, null, rawJson);
+                rawJson = await rawEventService.SerializeAndLogAsync(
+                    e, "IntegrationDeleted", e.Guild.Id, null, null, correlationId: correlationId);
+
+                await db.Integrations
+                    .Where(i => i.DiscordId == e.IntegrationId)
+                    .ExecuteUpdateAsync(s => s
+                        .SetProperty(i => i.IsDeleted, true)
+                        .SetProperty(i => i.DeletedAtUtc, (DateTime?)now));
+
+                db.IntegrationEvents.Add(new IntegrationEventEntity
+                {
+                    IntegrationDiscordId = e.IntegrationId,
+                    GuildDiscordId = e.Guild.Id,
+                    EventType = IntegrationEventType.Deleted,
+                    EventTimestampUtc = now,
+                    ReceivedAtUtc = now,
+                    RawEventJson = rawJson
+                });
+
+                await db.SaveChangesAsync();
+            }
+            catch (Exception ex)
+            {
+                logger.LogError(ex, "Error handling integration deleted");
+                using var failureScope = scopeFactory.CreateScope();
+                var failedEventService = failureScope.ServiceProvider.GetRequiredService<FailedEventService>();
+                await failedEventService.RecordFailureAsync(
+                    "IntegrationDeleted", nameof(IntegrationEventHandler), ex,
+                    e.Guild?.Id, null, null, rawJson, correlationId: correlationId);
+            }
         }
     }
 }

--- a/src/DiscordEventService/Services/EventHandlers/InviteEventHandler.cs
+++ b/src/DiscordEventService/Services/EventHandlers/InviteEventHandler.cs
@@ -13,117 +13,125 @@ public class InviteEventHandler(IServiceScopeFactory scopeFactory, ILogger<Invit
 {
     public async Task HandleEventAsync(DiscordClient sender, InviteCreatedEventArgs e)
     {
-        string? rawJson = null;
-        try
+        var correlationId = Guid.NewGuid();
+        using (logger.BeginScope(new Dictionary<string, object> { ["CorrelationId"] = correlationId }))
         {
-            var now = DateTime.UtcNow;
-            using var scope = scopeFactory.CreateScope();
-            var db = scope.ServiceProvider.GetRequiredService<DiscordDbContext>();
-            var rawEventService = scope.ServiceProvider.GetRequiredService<RawEventLogService>();
-
-            rawJson = await rawEventService.SerializeAndLogAsync(
-                e, "InviteCreated", e.Guild.Id, e.Channel.Id, e.Invite.Inviter?.Id);
-
-            // Look up Guid FKs
-            var guild = await db.Guilds.FirstOrDefaultAsync(g => g.DiscordId == e.Guild.Id);
-            var channel = await db.Channels.FirstOrDefaultAsync(c => c.DiscordId == e.Channel.Id);
-            var inviter = e.Invite.Inviter != null
-                ? await db.Users.FirstOrDefaultAsync(u => u.DiscordId == e.Invite.Inviter.Id)
-                : null;
-
-            // Upsert InviteEntity
-            var invite = e.Invite;
-            var inviteEntity = await db.Invites.FirstOrDefaultAsync(i => i.Code == invite.Code);
-            if (inviteEntity == null)
+            string? rawJson = null;
+            try
             {
-                inviteEntity = new InviteEntity { Code = invite.Code };
-                db.Invites.Add(inviteEntity);
+                var now = DateTime.UtcNow;
+                using var scope = scopeFactory.CreateScope();
+                var db = scope.ServiceProvider.GetRequiredService<DiscordDbContext>();
+                var rawEventService = scope.ServiceProvider.GetRequiredService<RawEventLogService>();
+
+                rawJson = await rawEventService.SerializeAndLogAsync(
+                    e, "InviteCreated", e.Guild.Id, e.Channel.Id, e.Invite.Inviter?.Id, correlationId: correlationId);
+
+                // Look up Guid FKs
+                var guild = await db.Guilds.FirstOrDefaultAsync(g => g.DiscordId == e.Guild.Id);
+                var channel = await db.Channels.FirstOrDefaultAsync(c => c.DiscordId == e.Channel.Id);
+                var inviter = e.Invite.Inviter != null
+                    ? await db.Users.FirstOrDefaultAsync(u => u.DiscordId == e.Invite.Inviter.Id)
+                    : null;
+
+                // Upsert InviteEntity
+                var invite = e.Invite;
+                var inviteEntity = await db.Invites.FirstOrDefaultAsync(i => i.Code == invite.Code);
+                if (inviteEntity == null)
+                {
+                    inviteEntity = new InviteEntity { Code = invite.Code };
+                    db.Invites.Add(inviteEntity);
+                }
+
+                if (guild != null) inviteEntity.GuildId = guild.Id;
+                if (channel != null) inviteEntity.ChannelId = channel.Id;
+                inviteEntity.InviterId = inviter?.Id;
+                inviteEntity.MaxAge = invite.MaxAge;
+                inviteEntity.MaxUses = invite.MaxUses;
+                inviteEntity.Uses = invite.Uses;
+                inviteEntity.IsTemporary = invite.IsTemporary;
+                inviteEntity.CreatedAtUtc = invite.CreatedAt.UtcDateTime;
+                inviteEntity.ExpiresAtUtc = invite.MaxAge > 0 ? invite.CreatedAt.AddSeconds(invite.MaxAge).UtcDateTime : null;
+                inviteEntity.IsDeleted = false;
+                inviteEntity.DeletedAtUtc = null;
+
+                var eventEntity = new InviteEventEntity
+                {
+                    GuildDiscordId = e.Guild.Id,
+                    ChannelDiscordId = e.Channel.Id,
+                    InviterDiscordId = invite.Inviter?.Id,
+                    EventType = InviteEventType.Created,
+                    Code = invite.Code,
+                    MaxAge = invite.MaxAge,
+                    MaxUses = invite.MaxUses,
+                    IsTemporary = invite.IsTemporary,
+                    Uses = invite.Uses,
+                    EventTimestampUtc = now,
+                    ReceivedAtUtc = now,
+                    RawEventJson = rawJson
+                };
+
+                db.InviteEvents.Add(eventEntity);
+                await db.SaveChangesAsync();
             }
-
-            if (guild != null) inviteEntity.GuildId = guild.Id;
-            if (channel != null) inviteEntity.ChannelId = channel.Id;
-            inviteEntity.InviterId = inviter?.Id;
-            inviteEntity.MaxAge = invite.MaxAge;
-            inviteEntity.MaxUses = invite.MaxUses;
-            inviteEntity.Uses = invite.Uses;
-            inviteEntity.IsTemporary = invite.IsTemporary;
-            inviteEntity.CreatedAtUtc = invite.CreatedAt.UtcDateTime;
-            inviteEntity.ExpiresAtUtc = invite.MaxAge > 0 ? invite.CreatedAt.AddSeconds(invite.MaxAge).UtcDateTime : null;
-            inviteEntity.IsDeleted = false;
-            inviteEntity.DeletedAtUtc = null;
-
-            var eventEntity = new InviteEventEntity
+            catch (Exception ex)
             {
-                GuildDiscordId = e.Guild.Id,
-                ChannelDiscordId = e.Channel.Id,
-                InviterDiscordId = invite.Inviter?.Id,
-                EventType = InviteEventType.Created,
-                Code = invite.Code,
-                MaxAge = invite.MaxAge,
-                MaxUses = invite.MaxUses,
-                IsTemporary = invite.IsTemporary,
-                Uses = invite.Uses,
-                EventTimestampUtc = now,
-                ReceivedAtUtc = now,
-                RawEventJson = rawJson
-            };
-
-            db.InviteEvents.Add(eventEntity);
-            await db.SaveChangesAsync();
-        }
-        catch (Exception ex)
-        {
-            logger.LogError(ex, "Error handling invite created");
-            using var failureScope = scopeFactory.CreateScope();
-            var failedEventService = failureScope.ServiceProvider.GetRequiredService<FailedEventService>();
-            await failedEventService.RecordFailureAsync(
-                "InviteCreated", nameof(InviteEventHandler), ex,
-                e.Guild?.Id, e.Channel?.Id, e.Invite?.Inviter?.Id, rawJson);
+                logger.LogError(ex, "Error handling invite created");
+                using var failureScope = scopeFactory.CreateScope();
+                var failedEventService = failureScope.ServiceProvider.GetRequiredService<FailedEventService>();
+                await failedEventService.RecordFailureAsync(
+                    "InviteCreated", nameof(InviteEventHandler), ex,
+                    e.Guild?.Id, e.Channel?.Id, e.Invite?.Inviter?.Id, rawJson, correlationId: correlationId);
+            }
         }
     }
 
     public async Task HandleEventAsync(DiscordClient sender, InviteDeletedEventArgs e)
     {
-        string? rawJson = null;
-        try
+        var correlationId = Guid.NewGuid();
+        using (logger.BeginScope(new Dictionary<string, object> { ["CorrelationId"] = correlationId }))
         {
-            var now = DateTime.UtcNow;
-            using var scope = scopeFactory.CreateScope();
-            var db = scope.ServiceProvider.GetRequiredService<DiscordDbContext>();
-            var rawEventService = scope.ServiceProvider.GetRequiredService<RawEventLogService>();
-
-            rawJson = await rawEventService.SerializeAndLogAsync(
-                e, "InviteDeleted", e.Guild.Id, e.Channel.Id, null);
-
-            // Mark invite as deleted
-            await db.Invites
-                .Where(i => i.Code == e.Invite.Code)
-                .ExecuteUpdateAsync(s => s
-                    .SetProperty(i => i.IsDeleted, true)
-                    .SetProperty(i => i.DeletedAtUtc, (DateTime?)now));
-
-            var eventEntity = new InviteEventEntity
+            string? rawJson = null;
+            try
             {
-                GuildDiscordId = e.Guild.Id,
-                ChannelDiscordId = e.Channel.Id,
-                EventType = InviteEventType.Deleted,
-                Code = e.Invite.Code,
-                EventTimestampUtc = now,
-                ReceivedAtUtc = now,
-                RawEventJson = rawJson
-            };
+                var now = DateTime.UtcNow;
+                using var scope = scopeFactory.CreateScope();
+                var db = scope.ServiceProvider.GetRequiredService<DiscordDbContext>();
+                var rawEventService = scope.ServiceProvider.GetRequiredService<RawEventLogService>();
 
-            db.InviteEvents.Add(eventEntity);
-            await db.SaveChangesAsync();
-        }
-        catch (Exception ex)
-        {
-            logger.LogError(ex, "Error handling invite deleted");
-            using var failureScope = scopeFactory.CreateScope();
-            var failedEventService = failureScope.ServiceProvider.GetRequiredService<FailedEventService>();
-            await failedEventService.RecordFailureAsync(
-                "InviteDeleted", nameof(InviteEventHandler), ex,
-                e.Guild?.Id, e.Channel?.Id, null, rawJson);
+                rawJson = await rawEventService.SerializeAndLogAsync(
+                    e, "InviteDeleted", e.Guild.Id, e.Channel.Id, null, correlationId: correlationId);
+
+                // Mark invite as deleted
+                await db.Invites
+                    .Where(i => i.Code == e.Invite.Code)
+                    .ExecuteUpdateAsync(s => s
+                        .SetProperty(i => i.IsDeleted, true)
+                        .SetProperty(i => i.DeletedAtUtc, (DateTime?)now));
+
+                var eventEntity = new InviteEventEntity
+                {
+                    GuildDiscordId = e.Guild.Id,
+                    ChannelDiscordId = e.Channel.Id,
+                    EventType = InviteEventType.Deleted,
+                    Code = e.Invite.Code,
+                    EventTimestampUtc = now,
+                    ReceivedAtUtc = now,
+                    RawEventJson = rawJson
+                };
+
+                db.InviteEvents.Add(eventEntity);
+                await db.SaveChangesAsync();
+            }
+            catch (Exception ex)
+            {
+                logger.LogError(ex, "Error handling invite deleted");
+                using var failureScope = scopeFactory.CreateScope();
+                var failedEventService = failureScope.ServiceProvider.GetRequiredService<FailedEventService>();
+                await failedEventService.RecordFailureAsync(
+                    "InviteDeleted", nameof(InviteEventHandler), ex,
+                    e.Guild?.Id, e.Channel?.Id, null, rawJson, correlationId: correlationId);
+            }
         }
     }
 }

--- a/src/DiscordEventService/Services/EventHandlers/MemberEventHandler.cs
+++ b/src/DiscordEventService/Services/EventHandlers/MemberEventHandler.cs
@@ -17,194 +17,206 @@ public class MemberEventHandler(IServiceScopeFactory scopeFactory, ILogger<Membe
 {
     public async Task HandleEventAsync(DiscordClient sender, GuildMemberAddedEventArgs e)
     {
-        string? rawJson = null;
-        try
+        var correlationId = Guid.NewGuid();
+        using (logger.BeginScope(new Dictionary<string, object> { ["CorrelationId"] = correlationId }))
         {
-            using var scope = scopeFactory.CreateScope();
-            var db = scope.ServiceProvider.GetRequiredService<DiscordDbContext>();
-            var userService = scope.ServiceProvider.GetRequiredService<UserService>();
-            var rawEventService = scope.ServiceProvider.GetRequiredService<RawEventLogService>();
-
-            rawJson = await rawEventService.SerializeAndLogAsync(
-                e, "GuildMemberAdded", e.Guild.Id, null, e.Member.Id);
-
-            await userService.UpsertMemberAsync(e.Member);
-
-            var memberEvent = new MemberEventEntity
+            string? rawJson = null;
+            try
             {
-                UserDiscordId = e.Member.Id,
-                GuildDiscordId = e.Guild.Id,
-                EventType = MemberEventType.Joined,
-                NicknameAfter = e.Member.Nickname,
-                RolesAddedJson = e.Member.Roles.Any()
-                    ? JsonSerializer.Serialize(e.Member.Roles.Select(r => r.Id))
-                    : null,
-                EventTimestampUtc = e.Member.JoinedAt.UtcDateTime,
-                ReceivedAtUtc = DateTime.UtcNow,
-                RawEventJson = rawJson
-            };
+                using var scope = scopeFactory.CreateScope();
+                var db = scope.ServiceProvider.GetRequiredService<DiscordDbContext>();
+                var userService = scope.ServiceProvider.GetRequiredService<UserService>();
+                var rawEventService = scope.ServiceProvider.GetRequiredService<RawEventLogService>();
 
-            db.MemberEvents.Add(memberEvent);
-            await db.SaveChangesAsync();
-        }
-        catch (Exception ex)
-        {
-            logger.LogError(ex, "Error handling member added for UserId={UserId} GuildId={GuildId}", e.Member.Id, e.Guild.Id);
-            using var failureScope = scopeFactory.CreateScope();
-            var failedEventService = failureScope.ServiceProvider.GetRequiredService<FailedEventService>();
-            await failedEventService.RecordFailureAsync(
-                "GuildMemberAdded", nameof(MemberEventHandler), ex,
-                e.Guild?.Id, null, e.Member.Id, rawJson);
+                rawJson = await rawEventService.SerializeAndLogAsync(
+                    e, "GuildMemberAdded", e.Guild.Id, null, e.Member.Id, correlationId: correlationId);
+
+                await userService.UpsertMemberAsync(e.Member);
+
+                var memberEvent = new MemberEventEntity
+                {
+                    UserDiscordId = e.Member.Id,
+                    GuildDiscordId = e.Guild.Id,
+                    EventType = MemberEventType.Joined,
+                    NicknameAfter = e.Member.Nickname,
+                    RolesAddedJson = e.Member.Roles.Any()
+                        ? JsonSerializer.Serialize(e.Member.Roles.Select(r => r.Id))
+                        : null,
+                    EventTimestampUtc = e.Member.JoinedAt.UtcDateTime,
+                    ReceivedAtUtc = DateTime.UtcNow,
+                    RawEventJson = rawJson
+                };
+
+                db.MemberEvents.Add(memberEvent);
+                await db.SaveChangesAsync();
+            }
+            catch (Exception ex)
+            {
+                logger.LogError(ex, "Error handling member added for UserId={UserId} GuildId={GuildId}", e.Member.Id, e.Guild.Id);
+                using var failureScope = scopeFactory.CreateScope();
+                var failedEventService = failureScope.ServiceProvider.GetRequiredService<FailedEventService>();
+                await failedEventService.RecordFailureAsync(
+                    "GuildMemberAdded", nameof(MemberEventHandler), ex,
+                    e.Guild?.Id, null, e.Member.Id, rawJson, correlationId: correlationId);
+            }
         }
     }
 
     public async Task HandleEventAsync(DiscordClient sender, GuildMemberRemovedEventArgs e)
     {
-        string? rawJson = null;
-        try
+        var correlationId = Guid.NewGuid();
+        using (logger.BeginScope(new Dictionary<string, object> { ["CorrelationId"] = correlationId }))
         {
-            var receivedAt = DateTime.UtcNow;
-            using var scope = scopeFactory.CreateScope();
-            var db = scope.ServiceProvider.GetRequiredService<DiscordDbContext>();
-            var rawEventService = scope.ServiceProvider.GetRequiredService<RawEventLogService>();
-
-            rawJson = await rawEventService.SerializeAndLogAsync(
-                e, "GuildMemberRemoved", e.Guild.Id, null, e.Member.Id);
-
-            var memberEvent = new MemberEventEntity
+            string? rawJson = null;
+            try
             {
-                UserDiscordId = e.Member.Id,
-                GuildDiscordId = e.Guild.Id,
-                EventType = MemberEventType.Left,
-                NicknameBefore = e.Member.Nickname,
-                RolesRemovedJson = e.Member.Roles.Any()
-                    ? JsonSerializer.Serialize(e.Member.Roles.Select(r => r.Id))
-                    : null,
-                EventTimestampUtc = receivedAt,
-                ReceivedAtUtc = receivedAt,
-                RawEventJson = rawJson
-            };
+                var receivedAt = DateTime.UtcNow;
+                using var scope = scopeFactory.CreateScope();
+                var db = scope.ServiceProvider.GetRequiredService<DiscordDbContext>();
+                var rawEventService = scope.ServiceProvider.GetRequiredService<RawEventLogService>();
 
-            db.MemberEvents.Add(memberEvent);
-            await db.SaveChangesAsync();
-        }
-        catch (Exception ex)
-        {
-            logger.LogError(ex, "Error handling member removed for UserId={UserId} GuildId={GuildId}", e.Member.Id, e.Guild.Id);
-            using var failureScope = scopeFactory.CreateScope();
-            var failedEventService = failureScope.ServiceProvider.GetRequiredService<FailedEventService>();
-            await failedEventService.RecordFailureAsync(
-                "GuildMemberRemoved", nameof(MemberEventHandler), ex,
-                e.Guild?.Id, null, e.Member.Id, rawJson);
+                rawJson = await rawEventService.SerializeAndLogAsync(
+                    e, "GuildMemberRemoved", e.Guild.Id, null, e.Member.Id, correlationId: correlationId);
+
+                var memberEvent = new MemberEventEntity
+                {
+                    UserDiscordId = e.Member.Id,
+                    GuildDiscordId = e.Guild.Id,
+                    EventType = MemberEventType.Left,
+                    NicknameBefore = e.Member.Nickname,
+                    RolesRemovedJson = e.Member.Roles.Any()
+                        ? JsonSerializer.Serialize(e.Member.Roles.Select(r => r.Id))
+                        : null,
+                    EventTimestampUtc = receivedAt,
+                    ReceivedAtUtc = receivedAt,
+                    RawEventJson = rawJson
+                };
+
+                db.MemberEvents.Add(memberEvent);
+                await db.SaveChangesAsync();
+            }
+            catch (Exception ex)
+            {
+                logger.LogError(ex, "Error handling member removed for UserId={UserId} GuildId={GuildId}", e.Member.Id, e.Guild.Id);
+                using var failureScope = scopeFactory.CreateScope();
+                var failedEventService = failureScope.ServiceProvider.GetRequiredService<FailedEventService>();
+                await failedEventService.RecordFailureAsync(
+                    "GuildMemberRemoved", nameof(MemberEventHandler), ex,
+                    e.Guild?.Id, null, e.Member.Id, rawJson, correlationId: correlationId);
+            }
         }
     }
 
     public async Task HandleEventAsync(DiscordClient sender, GuildMemberUpdatedEventArgs e)
     {
-        string? rawJson = null;
-        try
+        var correlationId = Guid.NewGuid();
+        using (logger.BeginScope(new Dictionary<string, object> { ["CorrelationId"] = correlationId }))
         {
-            var receivedAt = DateTime.UtcNow;
-            using var scope = scopeFactory.CreateScope();
-            var db = scope.ServiceProvider.GetRequiredService<DiscordDbContext>();
-            var userService = scope.ServiceProvider.GetRequiredService<UserService>();
-            var rawEventService = scope.ServiceProvider.GetRequiredService<RawEventLogService>();
-
-            rawJson = await rawEventService.SerializeAndLogAsync(
-                e, "GuildMemberUpdated", e.Guild.Id, null, e.Member.Id);
-
-            await userService.UpsertMemberAsync(e.Member);
-
-            var oldRoleIds = e.RolesBefore?.Select(r => r.Id).ToHashSet() ?? new HashSet<ulong>();
-            var newRoleIds = e.RolesAfter?.Select(r => r.Id).ToHashSet() ?? new HashSet<ulong>();
-
-            var rolesAdded = newRoleIds.Except(oldRoleIds).ToList();
-            var rolesRemoved = oldRoleIds.Except(newRoleIds).ToList();
-
-            var nicknameChanged = e.NicknameBefore != e.NicknameAfter;
-            var avatarHashChanged = e.GuildAvatarHashBefore != e.GuildAvatarHashAfter;
-            var pendingChanged = e.PendingBefore != e.PendingAfter;
-            var timeoutChanged = e.CommunicationDisabledUntilBefore != e.CommunicationDisabledUntilAfter;
-
-            // Member-object deltas are only meaningful when MemberBefore is cached.
-            // Without it we can't distinguish "field changed" from "field newly known",
-            // so treat unknown-before as unchanged to avoid spurious filter triggers.
-            // (DSharpPlus annotates MemberBefore as non-nullable, but defensively check.)
-            var memberBefore = e.MemberBefore;
-            var hasBefore = memberBefore is not null;
-
-            var premiumBefore = memberBefore?.PremiumSince;
-            var premiumAfter = e.Member.PremiumSince;
-            var premiumChanged = hasBefore && premiumBefore != premiumAfter;
-
-            bool? mutedBefore = memberBefore?.IsMuted;
-            bool mutedAfter = e.Member.IsMuted;
-            var mutedChanged = mutedBefore.HasValue && mutedBefore.Value != mutedAfter;
-
-            bool? deafenedBefore = memberBefore?.IsDeafened;
-            bool deafenedAfter = e.Member.IsDeafened;
-            var deafenedChanged = deafenedBefore.HasValue && deafenedBefore.Value != deafenedAfter;
-
-            if (nicknameChanged || rolesAdded.Any() || rolesRemoved.Any() || timeoutChanged
-                || avatarHashChanged || pendingChanged || premiumChanged || mutedChanged || deafenedChanged)
+            string? rawJson = null;
+            try
             {
-                var strategy = db.Database.CreateExecutionStrategy();
-                await strategy.ExecuteAsync(async () =>
+                var receivedAt = DateTime.UtcNow;
+                using var scope = scopeFactory.CreateScope();
+                var db = scope.ServiceProvider.GetRequiredService<DiscordDbContext>();
+                var userService = scope.ServiceProvider.GetRequiredService<UserService>();
+                var rawEventService = scope.ServiceProvider.GetRequiredService<RawEventLogService>();
+
+                rawJson = await rawEventService.SerializeAndLogAsync(
+                    e, "GuildMemberUpdated", e.Guild.Id, null, e.Member.Id, correlationId: correlationId);
+
+                await userService.UpsertMemberAsync(e.Member);
+
+                var oldRoleIds = e.RolesBefore?.Select(r => r.Id).ToHashSet() ?? new HashSet<ulong>();
+                var newRoleIds = e.RolesAfter?.Select(r => r.Id).ToHashSet() ?? new HashSet<ulong>();
+
+                var rolesAdded = newRoleIds.Except(oldRoleIds).ToList();
+                var rolesRemoved = oldRoleIds.Except(newRoleIds).ToList();
+
+                var nicknameChanged = e.NicknameBefore != e.NicknameAfter;
+                var avatarHashChanged = e.GuildAvatarHashBefore != e.GuildAvatarHashAfter;
+                var pendingChanged = e.PendingBefore != e.PendingAfter;
+                var timeoutChanged = e.CommunicationDisabledUntilBefore != e.CommunicationDisabledUntilAfter;
+
+                // Member-object deltas are only meaningful when MemberBefore is cached.
+                // Without it we can't distinguish "field changed" from "field newly known",
+                // so treat unknown-before as unchanged to avoid spurious filter triggers.
+                // (DSharpPlus annotates MemberBefore as non-nullable, but defensively check.)
+                var memberBefore = e.MemberBefore;
+                var hasBefore = memberBefore is not null;
+
+                var premiumBefore = memberBefore?.PremiumSince;
+                var premiumAfter = e.Member.PremiumSince;
+                var premiumChanged = hasBefore && premiumBefore != premiumAfter;
+
+                bool? mutedBefore = memberBefore?.IsMuted;
+                bool mutedAfter = e.Member.IsMuted;
+                var mutedChanged = mutedBefore.HasValue && mutedBefore.Value != mutedAfter;
+
+                bool? deafenedBefore = memberBefore?.IsDeafened;
+                bool deafenedAfter = e.Member.IsDeafened;
+                var deafenedChanged = deafenedBefore.HasValue && deafenedBefore.Value != deafenedAfter;
+
+                if (nicknameChanged || rolesAdded.Any() || rolesRemoved.Any() || timeoutChanged
+                    || avatarHashChanged || pendingChanged || premiumChanged || mutedChanged || deafenedChanged)
                 {
-                    db.ChangeTracker.Clear();
-                    await using var tx = await db.Database.BeginTransactionAsync();
-
-                    var memberEvent = new MemberEventEntity
+                    var strategy = db.Database.CreateExecutionStrategy();
+                    await strategy.ExecuteAsync(async () =>
                     {
-                        UserDiscordId = e.Member.Id,
-                        GuildDiscordId = e.Guild.Id,
-                        EventType = MemberEventType.Updated,
-                        NicknameBefore = e.NicknameBefore,
-                        NicknameAfter = e.NicknameAfter,
-                        RolesAddedJson = rolesAdded.Any()
-                            ? JsonSerializer.Serialize(rolesAdded)
-                            : null,
-                        RolesRemovedJson = rolesRemoved.Any()
-                            ? JsonSerializer.Serialize(rolesRemoved)
-                            : null,
-                        TimeoutUntilUtc = e.CommunicationDisabledUntilAfter?.UtcDateTime,
-                        PremiumSinceBefore = premiumBefore?.UtcDateTime,
-                        PremiumSinceAfter = premiumAfter?.UtcDateTime,
-                        GuildAvatarHashBefore = e.GuildAvatarHashBefore,
-                        GuildAvatarHashAfter = e.GuildAvatarHashAfter,
-                        IsPendingBefore = e.PendingBefore,
-                        IsPendingAfter = e.PendingAfter,
-                        IsMutedBefore = mutedBefore,
-                        IsMutedAfter = mutedAfter,
-                        IsDeafenedBefore = deafenedBefore,
-                        IsDeafenedAfter = deafenedAfter,
-                        EventTimestampUtc = receivedAt,
-                        ReceivedAtUtc = receivedAt,
-                        RawEventJson = rawJson
-                    };
+                        db.ChangeTracker.Clear();
+                        await using var tx = await db.Database.BeginTransactionAsync();
 
-                    db.MemberEvents.Add(memberEvent);
-                    await db.SaveChangesAsync();
+                        var memberEvent = new MemberEventEntity
+                        {
+                            UserDiscordId = e.Member.Id,
+                            GuildDiscordId = e.Guild.Id,
+                            EventType = MemberEventType.Updated,
+                            NicknameBefore = e.NicknameBefore,
+                            NicknameAfter = e.NicknameAfter,
+                            RolesAddedJson = rolesAdded.Any()
+                                ? JsonSerializer.Serialize(rolesAdded)
+                                : null,
+                            RolesRemovedJson = rolesRemoved.Any()
+                                ? JsonSerializer.Serialize(rolesRemoved)
+                                : null,
+                            TimeoutUntilUtc = e.CommunicationDisabledUntilAfter?.UtcDateTime,
+                            PremiumSinceBefore = premiumBefore?.UtcDateTime,
+                            PremiumSinceAfter = premiumAfter?.UtcDateTime,
+                            GuildAvatarHashBefore = e.GuildAvatarHashBefore,
+                            GuildAvatarHashAfter = e.GuildAvatarHashAfter,
+                            IsPendingBefore = e.PendingBefore,
+                            IsPendingAfter = e.PendingAfter,
+                            IsMutedBefore = mutedBefore,
+                            IsMutedAfter = mutedAfter,
+                            IsDeafenedBefore = deafenedBefore,
+                            IsDeafenedAfter = deafenedAfter,
+                            EventTimestampUtc = receivedAt,
+                            ReceivedAtUtc = receivedAt,
+                            RawEventJson = rawJson
+                        };
 
-                    if ((rolesAdded.Any() || rolesRemoved.Any())
-                        && e.RolesBefore is not null && e.RolesAfter is not null)
-                    {
-                        await MaintainRoleSnapshotsAsync(db, e.Member.Id, e.Guild.Id,
-                            rolesAdded, rolesRemoved, receivedAt, memberEvent.Id);
-                    }
+                        db.MemberEvents.Add(memberEvent);
+                        await db.SaveChangesAsync();
 
-                    await tx.CommitAsync();
-                });
+                        if ((rolesAdded.Any() || rolesRemoved.Any())
+                            && e.RolesBefore is not null && e.RolesAfter is not null)
+                        {
+                            await MaintainRoleSnapshotsAsync(db, e.Member.Id, e.Guild.Id,
+                                rolesAdded, rolesRemoved, receivedAt, memberEvent.Id);
+                        }
+
+                        await tx.CommitAsync();
+                    });
+                }
             }
-        }
-        catch (Exception ex)
-        {
-            logger.LogError(ex, "Error handling member updated for UserId={UserId} GuildId={GuildId}", e.Member.Id, e.Guild.Id);
-            using var failureScope = scopeFactory.CreateScope();
-            var failedEventService = failureScope.ServiceProvider.GetRequiredService<FailedEventService>();
-            await failedEventService.RecordFailureAsync(
-                "GuildMemberUpdated", nameof(MemberEventHandler), ex,
-                e.Guild?.Id, null, e.Member.Id, rawJson);
+            catch (Exception ex)
+            {
+                logger.LogError(ex, "Error handling member updated for UserId={UserId} GuildId={GuildId}", e.Member.Id, e.Guild.Id);
+                using var failureScope = scopeFactory.CreateScope();
+                var failedEventService = failureScope.ServiceProvider.GetRequiredService<FailedEventService>();
+                await failedEventService.RecordFailureAsync(
+                    "GuildMemberUpdated", nameof(MemberEventHandler), ex,
+                    e.Guild?.Id, null, e.Member.Id, rawJson, correlationId: correlationId);
+            }
         }
     }
 
@@ -263,81 +275,89 @@ public class MemberEventHandler(IServiceScopeFactory scopeFactory, ILogger<Membe
 
     public async Task HandleEventAsync(DiscordClient sender, GuildBanAddedEventArgs e)
     {
-        string? rawJson = null;
-        try
+        var correlationId = Guid.NewGuid();
+        using (logger.BeginScope(new Dictionary<string, object> { ["CorrelationId"] = correlationId }))
         {
-            var receivedAt = DateTime.UtcNow;
-            using var scope = scopeFactory.CreateScope();
-            var db = scope.ServiceProvider.GetRequiredService<DiscordDbContext>();
-            var userService = scope.ServiceProvider.GetRequiredService<UserService>();
-            var rawEventService = scope.ServiceProvider.GetRequiredService<RawEventLogService>();
-
-            rawJson = await rawEventService.SerializeAndLogAsync(
-                e, "GuildBanAddedMember", e.Guild.Id, null, e.Member.Id);
-
-            await userService.UpsertUserAsync(e.Member);
-
-            var memberEvent = new MemberEventEntity
+            string? rawJson = null;
+            try
             {
-                UserDiscordId = e.Member.Id,
-                GuildDiscordId = e.Guild.Id,
-                EventType = MemberEventType.Banned,
-                EventTimestampUtc = receivedAt,
-                ReceivedAtUtc = receivedAt,
-                RawEventJson = rawJson
-            };
+                var receivedAt = DateTime.UtcNow;
+                using var scope = scopeFactory.CreateScope();
+                var db = scope.ServiceProvider.GetRequiredService<DiscordDbContext>();
+                var userService = scope.ServiceProvider.GetRequiredService<UserService>();
+                var rawEventService = scope.ServiceProvider.GetRequiredService<RawEventLogService>();
 
-            db.MemberEvents.Add(memberEvent);
-            await db.SaveChangesAsync();
-        }
-        catch (Exception ex)
-        {
-            logger.LogError(ex, "Error handling ban added for UserId={UserId} GuildId={GuildId}", e.Member.Id, e.Guild.Id);
-            using var failureScope = scopeFactory.CreateScope();
-            var failedEventService = failureScope.ServiceProvider.GetRequiredService<FailedEventService>();
-            await failedEventService.RecordFailureAsync(
-                "GuildBanAddedMember", nameof(MemberEventHandler), ex,
-                e.Guild?.Id, null, e.Member.Id, rawJson);
+                rawJson = await rawEventService.SerializeAndLogAsync(
+                    e, "GuildBanAddedMember", e.Guild.Id, null, e.Member.Id, correlationId: correlationId);
+
+                await userService.UpsertUserAsync(e.Member);
+
+                var memberEvent = new MemberEventEntity
+                {
+                    UserDiscordId = e.Member.Id,
+                    GuildDiscordId = e.Guild.Id,
+                    EventType = MemberEventType.Banned,
+                    EventTimestampUtc = receivedAt,
+                    ReceivedAtUtc = receivedAt,
+                    RawEventJson = rawJson
+                };
+
+                db.MemberEvents.Add(memberEvent);
+                await db.SaveChangesAsync();
+            }
+            catch (Exception ex)
+            {
+                logger.LogError(ex, "Error handling ban added for UserId={UserId} GuildId={GuildId}", e.Member.Id, e.Guild.Id);
+                using var failureScope = scopeFactory.CreateScope();
+                var failedEventService = failureScope.ServiceProvider.GetRequiredService<FailedEventService>();
+                await failedEventService.RecordFailureAsync(
+                    "GuildBanAddedMember", nameof(MemberEventHandler), ex,
+                    e.Guild?.Id, null, e.Member.Id, rawJson, correlationId: correlationId);
+            }
         }
     }
 
     public async Task HandleEventAsync(DiscordClient sender, GuildBanRemovedEventArgs e)
     {
-        string? rawJson = null;
-        try
+        var correlationId = Guid.NewGuid();
+        using (logger.BeginScope(new Dictionary<string, object> { ["CorrelationId"] = correlationId }))
         {
-            var receivedAt = DateTime.UtcNow;
-            using var scope = scopeFactory.CreateScope();
-            var db = scope.ServiceProvider.GetRequiredService<DiscordDbContext>();
-            var userService = scope.ServiceProvider.GetRequiredService<UserService>();
-            var rawEventService = scope.ServiceProvider.GetRequiredService<RawEventLogService>();
-
-            rawJson = await rawEventService.SerializeAndLogAsync(
-                e, "GuildBanRemovedMember", e.Guild.Id, null, e.Member.Id);
-
-            await userService.UpsertUserAsync(e.Member);
-
-            var memberEvent = new MemberEventEntity
+            string? rawJson = null;
+            try
             {
-                UserDiscordId = e.Member.Id,
-                GuildDiscordId = e.Guild.Id,
-                EventType = MemberEventType.Unbanned,
-                EventTimestampUtc = receivedAt,
-                ReceivedAtUtc = receivedAt,
-                RawEventJson = rawJson
-            };
+                var receivedAt = DateTime.UtcNow;
+                using var scope = scopeFactory.CreateScope();
+                var db = scope.ServiceProvider.GetRequiredService<DiscordDbContext>();
+                var userService = scope.ServiceProvider.GetRequiredService<UserService>();
+                var rawEventService = scope.ServiceProvider.GetRequiredService<RawEventLogService>();
 
-            db.MemberEvents.Add(memberEvent);
-            await db.SaveChangesAsync();
-        }
-        catch (Exception ex)
-        {
-            logger.LogError(ex, "Error handling ban removed for UserId={UserId} GuildId={GuildId}", e.Member.Id, e.Guild.Id);
-            using var failureScope = scopeFactory.CreateScope();
-            var failedEventService = failureScope.ServiceProvider.GetRequiredService<FailedEventService>();
-            await failedEventService.RecordFailureAsync(
-                "GuildBanRemovedMember", nameof(MemberEventHandler), ex,
-                e.Guild?.Id, null, e.Member.Id, rawJson);
+                rawJson = await rawEventService.SerializeAndLogAsync(
+                    e, "GuildBanRemovedMember", e.Guild.Id, null, e.Member.Id, correlationId: correlationId);
+
+                await userService.UpsertUserAsync(e.Member);
+
+                var memberEvent = new MemberEventEntity
+                {
+                    UserDiscordId = e.Member.Id,
+                    GuildDiscordId = e.Guild.Id,
+                    EventType = MemberEventType.Unbanned,
+                    EventTimestampUtc = receivedAt,
+                    ReceivedAtUtc = receivedAt,
+                    RawEventJson = rawJson
+                };
+
+                db.MemberEvents.Add(memberEvent);
+                await db.SaveChangesAsync();
+            }
+            catch (Exception ex)
+            {
+                logger.LogError(ex, "Error handling ban removed for UserId={UserId} GuildId={GuildId}", e.Member.Id, e.Guild.Id);
+                using var failureScope = scopeFactory.CreateScope();
+                var failedEventService = failureScope.ServiceProvider.GetRequiredService<FailedEventService>();
+                await failedEventService.RecordFailureAsync(
+                    "GuildBanRemovedMember", nameof(MemberEventHandler), ex,
+                    e.Guild?.Id, null, e.Member.Id, rawJson, correlationId: correlationId);
+            }
         }
     }
 }

--- a/src/DiscordEventService/Services/EventHandlers/MessageEventHandler.cs
+++ b/src/DiscordEventService/Services/EventHandlers/MessageEventHandler.cs
@@ -21,114 +21,211 @@ public class MessageEventHandler(IServiceScopeFactory scopeFactory, ILogger<Mess
     {
         if (e.Guild is null) return;
 
-        string? rawJson = null;
-        try
+        var correlationId = Guid.NewGuid();
+        using (logger.BeginScope(new Dictionary<string, object> { ["CorrelationId"] = correlationId }))
         {
-            using var scope = scopeFactory.CreateScope();
-            var db = scope.ServiceProvider.GetRequiredService<DiscordDbContext>();
-            var userService = scope.ServiceProvider.GetRequiredService<UserService>();
-            var guildUpsert = scope.ServiceProvider.GetRequiredService<GuildUpsertService>();
-            var channelUpsert = scope.ServiceProvider.GetRequiredService<ChannelUpsertService>();
-            var rawEventService = scope.ServiceProvider.GetRequiredService<RawEventLogService>();
-
-            rawJson = await rawEventService.SerializeAndLogAsync(
-                e, "MessageCreated", e.Guild.Id, e.Channel.Id, e.Author.Id);
-
-            // Persist the raw event row immediately. Otherwise any 23505 race inside one of the
-            // upsert services below clears the change tracker on its catch path and the staged
-            // raw_event_logs row is silently dropped along with the rolled-back insert.
-            await db.SaveChangesAsync();
-
-            await userService.UpsertUserAsync(e.Author);
-
-            var attachmentsJson = e.Message.Attachments.Count > 0
-                ? JsonSerializer.Serialize(e.Message.Attachments.Select(a => new { a.Id, a.Url, a.FileName, a.FileSize }))
-                : null;
-            var embedsJson = e.Message.Embeds.Count > 0
-                ? JsonSerializer.Serialize(e.Message.Embeds)
-                : null;
-
-            // Resolve FKs via upsert-if-missing. The 2026-05-03 incident left 69 messages with
-            // channel_id IS NULL because the prior FirstOrDefault path silently wrote null when
-            // the channel (a thread) wasn't yet in our DB. §P1.9 closes that hole; §P2.6 (#74)
-            // makes the FKs NOT NULL so any regression in the upsert services becomes a loud
-            // skip + FailedEvent instead of a silent NULL FK row.
-            var guildId = await guildUpsert.UpsertGuildAsync(e.Guild);
-            var channelId = await channelUpsert.UpsertChannelAsync(e.Channel, guildId);
-            var authorId = await db.Users
-                .Where(u => u.DiscordId == e.Author.Id)
-                .Select(u => u.Id)
-                .FirstOrDefaultAsync();
-
-            if (guildId == Guid.Empty || channelId == Guid.Empty || authorId == Guid.Empty)
+            string? rawJson = null;
+            try
             {
-                logger.LogError(
-                    "MessageCreated: could not resolve required FKs for MessageId={MessageId} (guildId={GuildId} channelId={ChannelId} authorId={AuthorId}); skipping insert",
-                    e.Message.Id, guildId, channelId, authorId);
-                using var fkFailScope = scopeFactory.CreateScope();
-                var failedEventService = fkFailScope.ServiceProvider.GetRequiredService<FailedEventService>();
-                await failedEventService.RecordFailureAsync(
-                    "MessageCreated", nameof(MessageEventHandler),
-                    new InvalidOperationException(
-                        $"Required FK not resolved: guild={guildId} channel={channelId} author={authorId}"),
-                    e.Guild?.Id, e.Channel.Id, e.Author.Id, rawJson);
-                return;
-            }
+                using var scope = scopeFactory.CreateScope();
+                var db = scope.ServiceProvider.GetRequiredService<DiscordDbContext>();
+                var userService = scope.ServiceProvider.GetRequiredService<UserService>();
+                var guildUpsert = scope.ServiceProvider.GetRequiredService<GuildUpsertService>();
+                var channelUpsert = scope.ServiceProvider.GetRequiredService<ChannelUpsertService>();
+                var rawEventService = scope.ServiceProvider.GetRequiredService<RawEventLogService>();
 
-            MessageEventEntity NewMessageEvent() => new()
-            {
-                MessageDiscordId = e.Message.Id,
-                ChannelDiscordId = e.Channel.Id,
-                AuthorDiscordId = e.Author.Id,
-                GuildDiscordId = e.Guild.Id,
-                EventType = MessageEventType.Created,
-                Content = e.Message.Content,
-                HasAttachments = e.Message.Attachments.Count > 0,
-                HasEmbeds = e.Message.Embeds.Count > 0,
-                ReplyToMessageDiscordId = e.Message.ReferencedMessage?.Id,
-                AttachmentsJson = attachmentsJson,
-                EmbedsJson = embedsJson,
-                EventTimestampUtc = e.Message.Timestamp.UtcDateTime,
-                ReceivedAtUtc = DateTime.UtcNow,
-                RawEventJson = rawJson
-            };
+                rawJson = await rawEventService.SerializeAndLogAsync(
+                    e, "MessageCreated", e.Guild.Id, e.Channel.Id, e.Author.Id, correlationId: correlationId);
 
-            // Wrap multi-row writes in a transaction so the 23505 retry path
-            // (ExecuteUpdate + insert) is atomic. ExecutionStrategy is required
-            // because EnableRetryOnFailure is configured on the DbContext.
-            var strategy = db.Database.CreateExecutionStrategy();
-            await strategy.ExecuteAsync(async () =>
-            {
-                db.ChangeTracker.Clear();
-                await using var tx = await db.Database.BeginTransactionAsync();
+                // Persist the raw event row immediately. Otherwise any 23505 race inside one of the
+                // upsert services below clears the change tracker on its catch path and the staged
+                // raw_event_logs row is silently dropped along with the rolled-back insert.
+                await db.SaveChangesAsync();
 
-                var messageEntity = new MessageEntity
+                await userService.UpsertUserAsync(e.Author);
+
+                var attachmentsJson = e.Message.Attachments.Count > 0
+                    ? JsonSerializer.Serialize(e.Message.Attachments.Select(a => new { a.Id, a.Url, a.FileName, a.FileSize }))
+                    : null;
+                var embedsJson = e.Message.Embeds.Count > 0
+                    ? JsonSerializer.Serialize(e.Message.Embeds)
+                    : null;
+
+                // Resolve FKs via upsert-if-missing. The 2026-05-03 incident left 69 messages with
+                // channel_id IS NULL because the prior FirstOrDefault path silently wrote null when
+                // the channel (a thread) wasn't yet in our DB. §P1.9 closes that hole; §P2.6 (#74)
+                // makes the FKs NOT NULL so any regression in the upsert services becomes a loud
+                // skip + FailedEvent instead of a silent NULL FK row.
+                var guildId = await guildUpsert.UpsertGuildAsync(e.Guild);
+                var channelId = await channelUpsert.UpsertChannelAsync(e.Channel, guildId);
+                var authorId = await db.Users
+                    .Where(u => u.DiscordId == e.Author.Id)
+                    .Select(u => u.Id)
+                    .FirstOrDefaultAsync();
+
+                if (guildId == Guid.Empty || channelId == Guid.Empty || authorId == Guid.Empty)
                 {
-                    DiscordId = e.Message.Id,
-                    ChannelId = channelId,
-                    GuildId = guildId,
-                    AuthorId = authorId,
+                    logger.LogError(
+                        "MessageCreated: could not resolve required FKs for MessageId={MessageId} (guildId={GuildId} channelId={ChannelId} authorId={AuthorId}); skipping insert",
+                        e.Message.Id, guildId, channelId, authorId);
+                    using var fkFailScope = scopeFactory.CreateScope();
+                    var failedEventService = fkFailScope.ServiceProvider.GetRequiredService<FailedEventService>();
+                    await failedEventService.RecordFailureAsync(
+                        "MessageCreated", nameof(MessageEventHandler),
+                        new InvalidOperationException(
+                            $"Required FK not resolved: guild={guildId} channel={channelId} author={authorId}"),
+                        e.Guild?.Id, e.Channel.Id, e.Author.Id, rawJson, correlationId: correlationId);
+                    return;
+                }
+
+                MessageEventEntity NewMessageEvent() => new()
+                {
+                    MessageDiscordId = e.Message.Id,
+                    ChannelDiscordId = e.Channel.Id,
+                    AuthorDiscordId = e.Author.Id,
+                    GuildDiscordId = e.Guild.Id,
+                    EventType = MessageEventType.Created,
                     Content = e.Message.Content,
-                    ReplyToDiscordId = e.Message.ReferencedMessage?.Id,
                     HasAttachments = e.Message.Attachments.Count > 0,
                     HasEmbeds = e.Message.Embeds.Count > 0,
+                    ReplyToMessageDiscordId = e.Message.ReferencedMessage?.Id,
                     AttachmentsJson = attachmentsJson,
                     EmbedsJson = embedsJson,
-                    Flags = (int)(e.Message.Flags ?? 0),
-                    CreatedAtUtc = e.Message.Timestamp.UtcDateTime
+                    EventTimestampUtc = e.Message.Timestamp.UtcDateTime,
+                    ReceivedAtUtc = DateTime.UtcNow,
+                    RawEventJson = rawJson
                 };
-                db.Messages.Add(messageEntity);
-                db.MessageEvents.Add(NewMessageEvent());
 
-                Guid messageId;
-                try
-                {
-                    await db.SaveChangesAsync();
-                    messageId = messageEntity.Id;
-                }
-                catch (DbUpdateException dbEx) when (dbEx.InnerException is Npgsql.PostgresException { SqlState: "23505" })
+                // Wrap multi-row writes in a transaction so the 23505 retry path
+                // (ExecuteUpdate + insert) is atomic. ExecutionStrategy is required
+                // because EnableRetryOnFailure is configured on the DbContext.
+                var strategy = db.Database.CreateExecutionStrategy();
+                await strategy.ExecuteAsync(async () =>
                 {
                     db.ChangeTracker.Clear();
+                    await using var tx = await db.Database.BeginTransactionAsync();
+
+                    var messageEntity = new MessageEntity
+                    {
+                        DiscordId = e.Message.Id,
+                        ChannelId = channelId,
+                        GuildId = guildId,
+                        AuthorId = authorId,
+                        Content = e.Message.Content,
+                        ReplyToDiscordId = e.Message.ReferencedMessage?.Id,
+                        HasAttachments = e.Message.Attachments.Count > 0,
+                        HasEmbeds = e.Message.Embeds.Count > 0,
+                        AttachmentsJson = attachmentsJson,
+                        EmbedsJson = embedsJson,
+                        Flags = (int)(e.Message.Flags ?? 0),
+                        CreatedAtUtc = e.Message.Timestamp.UtcDateTime
+                    };
+                    db.Messages.Add(messageEntity);
+                    db.MessageEvents.Add(NewMessageEvent());
+
+                    Guid messageId;
+                    try
+                    {
+                        await db.SaveChangesAsync();
+                        messageId = messageEntity.Id;
+                    }
+                    catch (DbUpdateException dbEx) when (dbEx.InnerException is Npgsql.PostgresException { SqlState: "23505" })
+                    {
+                        db.ChangeTracker.Clear();
+                        await db.Messages
+                            .Where(m => m.DiscordId == e.Message.Id)
+                            .ExecuteUpdateAsync(s => s
+                                .SetProperty(m => m.Content, e.Message.Content)
+                                .SetProperty(m => m.HasAttachments, e.Message.Attachments.Count > 0)
+                                .SetProperty(m => m.HasEmbeds, e.Message.Embeds.Count > 0)
+                                .SetProperty(m => m.AttachmentsJson, attachmentsJson)
+                                .SetProperty(m => m.EmbedsJson, embedsJson)
+                                .SetProperty(m => m.Flags, (int)(e.Message.Flags ?? 0))
+                                .SetProperty(m => m.ReplyToDiscordId, e.Message.ReferencedMessage?.Id));
+                        db.MessageEvents.Add(NewMessageEvent());
+                        await db.SaveChangesAsync();
+                        messageId = await db.Messages
+                            .Where(m => m.DiscordId == e.Message.Id)
+                            .Select(m => m.Id)
+                            .FirstAsync();
+                    }
+
+                    await ExtractAndSaveMentionsAsync(db, messageId, e.Message);
+                    await tx.CommitAsync();
+                });
+            }
+            catch (Exception ex)
+            {
+                logger.LogError(ex, "Error handling message created for MessageId={MessageId}", e.Message.Id);
+                using var failureScope = scopeFactory.CreateScope();
+                var failedEventService = failureScope.ServiceProvider.GetRequiredService<FailedEventService>();
+                await failedEventService.RecordFailureAsync(
+                    "MessageCreated", nameof(MessageEventHandler), ex,
+                    e.Guild?.Id, e.Channel.Id, e.Author.Id, rawJson, correlationId: correlationId);
+            }
+        }
+    }
+
+    public async Task HandleEventAsync(DiscordClient sender, MessageUpdatedEventArgs e)
+    {
+        if (e.Guild is null) return;
+
+        var correlationId = Guid.NewGuid();
+        using (logger.BeginScope(new Dictionary<string, object> { ["CorrelationId"] = correlationId }))
+        {
+            try
+            {
+                var receivedAt = DateTime.UtcNow;
+                using var scope = scopeFactory.CreateScope();
+                var db = scope.ServiceProvider.GetRequiredService<DiscordDbContext>();
+                var rawEventService = scope.ServiceProvider.GetRequiredService<RawEventLogService>();
+
+                var rawJson = await rawEventService.SerializeAndLogAsync(
+                    e, "MessageUpdated", e.Guild.Id, e.Channel.Id, e.Author?.Id, correlationId: correlationId);
+
+                var attachmentsJson = e.Message.Attachments.Count > 0
+                    ? JsonSerializer.Serialize(e.Message.Attachments.Select(a => new { a.Id, a.Url, a.FileName, a.FileSize }))
+                    : null;
+                var embedsJson = e.Message.Embeds.Count > 0
+                    ? JsonSerializer.Serialize(e.Message.Embeds)
+                    : null;
+                var editedAt = e.Message.EditedTimestamp?.UtcDateTime ?? receivedAt;
+                var flagsAfter = (int)(e.Message.Flags ?? 0);
+
+                // Get the message entity for FK reference + before-state fallback when DSharpPlus
+                // didn't deliver e.MessageBefore (uncached message edit).
+                var message = await db.Messages.FirstOrDefaultAsync(m => m.DiscordId == e.Message.Id);
+                var messageGuid = message?.Id;
+
+                var contentBefore = e.MessageBefore is { } beforeForContent
+                    ? beforeForContent.Content
+                    : message?.Content;
+                var attachmentsBeforeJson = e.MessageBefore is { } beforeForAttachments
+                    ? (beforeForAttachments.Attachments.Count > 0
+                        ? JsonSerializer.Serialize(beforeForAttachments.Attachments.Select(a => new { a.Id, a.Url, a.FileName, a.FileSize }))
+                        : null)
+                    : message?.AttachmentsJson;
+                var embedsBeforeJson = e.MessageBefore is { } beforeForEmbeds
+                    ? (beforeForEmbeds.Embeds.Count > 0
+                        ? JsonSerializer.Serialize(beforeForEmbeds.Embeds)
+                        : null)
+                    : message?.EmbedsJson;
+                int? flagsBefore = e.MessageBefore is { } before
+                    ? (int)(before.Flags ?? 0)
+                    : message?.Flags;
+
+                // SerializeAndLogAsync staged a RawEventLog row but did NOT save it; flush it
+                // before the strategy lambda's ChangeTracker.Clear() detaches it.
+                await db.SaveChangesAsync();
+
+                // Wrap the ExecuteUpdate (auto-commits without a tx) and the event-log inserts
+                // in one transaction so a failure between them rolls back atomically.
+                var strategy = db.Database.CreateExecutionStrategy();
+                await strategy.ExecuteAsync(async () =>
+                {
+                    db.ChangeTracker.Clear();
+                    await using var tx = await db.Database.BeginTransactionAsync();
+
                     await db.Messages
                         .Where(m => m.DiscordId == e.Message.Id)
                         .ExecuteUpdateAsync(s => s
@@ -137,164 +234,75 @@ public class MessageEventHandler(IServiceScopeFactory scopeFactory, ILogger<Mess
                             .SetProperty(m => m.HasEmbeds, e.Message.Embeds.Count > 0)
                             .SetProperty(m => m.AttachmentsJson, attachmentsJson)
                             .SetProperty(m => m.EmbedsJson, embedsJson)
-                            .SetProperty(m => m.Flags, (int)(e.Message.Flags ?? 0))
-                            .SetProperty(m => m.ReplyToDiscordId, e.Message.ReferencedMessage?.Id));
-                    db.MessageEvents.Add(NewMessageEvent());
-                    await db.SaveChangesAsync();
-                    messageId = await db.Messages
-                        .Where(m => m.DiscordId == e.Message.Id)
-                        .Select(m => m.Id)
-                        .FirstAsync();
-                }
+                            .SetProperty(m => m.Flags, flagsAfter)
+                            .SetProperty(m => m.EditedAtUtc, editedAt));
 
-                await ExtractAndSaveMentionsAsync(db, messageId, e.Message);
-                await tx.CommitAsync();
-            });
-        }
-        catch (Exception ex)
-        {
-            logger.LogError(ex, "Error handling message created for MessageId={MessageId}", e.Message.Id);
-            using var failureScope = scopeFactory.CreateScope();
-            var failedEventService = failureScope.ServiceProvider.GetRequiredService<FailedEventService>();
-            await failedEventService.RecordFailureAsync(
-                "MessageCreated", nameof(MessageEventHandler), ex,
-                e.Guild?.Id, e.Channel.Id, e.Author.Id, rawJson);
-        }
-    }
-
-    public async Task HandleEventAsync(DiscordClient sender, MessageUpdatedEventArgs e)
-    {
-        if (e.Guild is null) return;
-
-        try
-        {
-            var receivedAt = DateTime.UtcNow;
-            using var scope = scopeFactory.CreateScope();
-            var db = scope.ServiceProvider.GetRequiredService<DiscordDbContext>();
-            var rawEventService = scope.ServiceProvider.GetRequiredService<RawEventLogService>();
-
-            var rawJson = await rawEventService.SerializeAndLogAsync(
-                e, "MessageUpdated", e.Guild.Id, e.Channel.Id, e.Author?.Id);
-
-            var attachmentsJson = e.Message.Attachments.Count > 0
-                ? JsonSerializer.Serialize(e.Message.Attachments.Select(a => new { a.Id, a.Url, a.FileName, a.FileSize }))
-                : null;
-            var embedsJson = e.Message.Embeds.Count > 0
-                ? JsonSerializer.Serialize(e.Message.Embeds)
-                : null;
-            var editedAt = e.Message.EditedTimestamp?.UtcDateTime ?? receivedAt;
-            var flagsAfter = (int)(e.Message.Flags ?? 0);
-
-            // Get the message entity for FK reference + before-state fallback when DSharpPlus
-            // didn't deliver e.MessageBefore (uncached message edit).
-            var message = await db.Messages.FirstOrDefaultAsync(m => m.DiscordId == e.Message.Id);
-            var messageGuid = message?.Id;
-
-            var contentBefore = e.MessageBefore is { } beforeForContent
-                ? beforeForContent.Content
-                : message?.Content;
-            var attachmentsBeforeJson = e.MessageBefore is { } beforeForAttachments
-                ? (beforeForAttachments.Attachments.Count > 0
-                    ? JsonSerializer.Serialize(beforeForAttachments.Attachments.Select(a => new { a.Id, a.Url, a.FileName, a.FileSize }))
-                    : null)
-                : message?.AttachmentsJson;
-            var embedsBeforeJson = e.MessageBefore is { } beforeForEmbeds
-                ? (beforeForEmbeds.Embeds.Count > 0
-                    ? JsonSerializer.Serialize(beforeForEmbeds.Embeds)
-                    : null)
-                : message?.EmbedsJson;
-            int? flagsBefore = e.MessageBefore is { } before
-                ? (int)(before.Flags ?? 0)
-                : message?.Flags;
-
-            // SerializeAndLogAsync staged a RawEventLog row but did NOT save it; flush it
-            // before the strategy lambda's ChangeTracker.Clear() detaches it.
-            await db.SaveChangesAsync();
-
-            // Wrap the ExecuteUpdate (auto-commits without a tx) and the event-log inserts
-            // in one transaction so a failure between them rolls back atomically.
-            var strategy = db.Database.CreateExecutionStrategy();
-            await strategy.ExecuteAsync(async () =>
-            {
-                db.ChangeTracker.Clear();
-                await using var tx = await db.Database.BeginTransactionAsync();
-
-                await db.Messages
-                    .Where(m => m.DiscordId == e.Message.Id)
-                    .ExecuteUpdateAsync(s => s
-                        .SetProperty(m => m.Content, e.Message.Content)
-                        .SetProperty(m => m.HasAttachments, e.Message.Attachments.Count > 0)
-                        .SetProperty(m => m.HasEmbeds, e.Message.Embeds.Count > 0)
-                        .SetProperty(m => m.AttachmentsJson, attachmentsJson)
-                        .SetProperty(m => m.EmbedsJson, embedsJson)
-                        .SetProperty(m => m.Flags, flagsAfter)
-                        .SetProperty(m => m.EditedAtUtc, editedAt));
-
-                db.MessageEvents.Add(new MessageEventEntity
-                {
-                    MessageDiscordId = e.Message.Id,
-                    ChannelDiscordId = e.Channel.Id,
-                    AuthorDiscordId = e.Author?.Id,
-                    GuildDiscordId = e.Guild.Id,
-                    EventType = MessageEventType.Updated,
-                    Content = e.Message.Content,
-                    ContentBefore = e.MessageBefore?.Content,
-                    HasAttachments = e.Message.Attachments.Count > 0,
-                    HasEmbeds = e.Message.Embeds.Count > 0,
-                    ReplyToMessageDiscordId = e.Message.ReferencedMessage?.Id,
-                    AttachmentsJson = attachmentsJson,
-                    EmbedsJson = embedsJson,
-                    EventTimestampUtc = editedAt,
-                    ReceivedAtUtc = receivedAt,
-                    RawEventJson = rawJson
-                });
-
-                var contentChanged = contentBefore != e.Message.Content;
-                // jsonb columns get PG-normalized on storage; freshly-serialized strings
-                // (from e.Message or e.MessageBefore) won't byte-match the DB-loaded value
-                // even when the underlying data is identical. Structural compare.
-                var attachmentsChanged = !JsonEquals(attachmentsBeforeJson, attachmentsJson);
-                var embedsChanged = !JsonEquals(embedsBeforeJson, embedsJson);
-                var flagsChanged = flagsBefore != flagsAfter;
-
-                if (messageGuid is Guid mid &&
-                    (contentChanged || attachmentsChanged || embedsChanged || flagsChanged))
-                {
-                    db.MessageEditHistory.Add(new MessageEditHistoryEntity
+                    db.MessageEvents.Add(new MessageEventEntity
                     {
-                        MessageId = mid,
                         MessageDiscordId = e.Message.Id,
-                        ContentBefore = contentBefore,
-                        ContentAfter = e.Message.Content,
-                        AttachmentsBeforeJson = attachmentsBeforeJson,
-                        AttachmentsAfterJson = attachmentsJson,
-                        EmbedsBeforeJson = embedsBeforeJson,
-                        EmbedsAfterJson = embedsJson,
-                        FlagsBefore = flagsBefore,
-                        FlagsAfter = flagsAfter,
-                        EditedAtUtc = editedAt,
-                        RecordedAtUtc = receivedAt
+                        ChannelDiscordId = e.Channel.Id,
+                        AuthorDiscordId = e.Author?.Id,
+                        GuildDiscordId = e.Guild.Id,
+                        EventType = MessageEventType.Updated,
+                        Content = e.Message.Content,
+                        ContentBefore = e.MessageBefore?.Content,
+                        HasAttachments = e.Message.Attachments.Count > 0,
+                        HasEmbeds = e.Message.Embeds.Count > 0,
+                        ReplyToMessageDiscordId = e.Message.ReferencedMessage?.Id,
+                        AttachmentsJson = attachmentsJson,
+                        EmbedsJson = embedsJson,
+                        EventTimestampUtc = editedAt,
+                        ReceivedAtUtc = receivedAt,
+                        RawEventJson = rawJson
                     });
-                }
 
-                await db.SaveChangesAsync();
+                    var contentChanged = contentBefore != e.Message.Content;
+                    // jsonb columns get PG-normalized on storage; freshly-serialized strings
+                    // (from e.Message or e.MessageBefore) won't byte-match the DB-loaded value
+                    // even when the underlying data is identical. Structural compare.
+                    var attachmentsChanged = !JsonEquals(attachmentsBeforeJson, attachmentsJson);
+                    var embedsChanged = !JsonEquals(embedsBeforeJson, embedsJson);
+                    var flagsChanged = flagsBefore != flagsAfter;
 
-                if (messageGuid is Guid mentionMid)
-                {
-                    await ExtractAndSaveMentionsAsync(db, mentionMid, e.Message);
-                }
+                    if (messageGuid is Guid mid &&
+                        (contentChanged || attachmentsChanged || embedsChanged || flagsChanged))
+                    {
+                        db.MessageEditHistory.Add(new MessageEditHistoryEntity
+                        {
+                            MessageId = mid,
+                            MessageDiscordId = e.Message.Id,
+                            ContentBefore = contentBefore,
+                            ContentAfter = e.Message.Content,
+                            AttachmentsBeforeJson = attachmentsBeforeJson,
+                            AttachmentsAfterJson = attachmentsJson,
+                            EmbedsBeforeJson = embedsBeforeJson,
+                            EmbedsAfterJson = embedsJson,
+                            FlagsBefore = flagsBefore,
+                            FlagsAfter = flagsAfter,
+                            EditedAtUtc = editedAt,
+                            RecordedAtUtc = receivedAt
+                        });
+                    }
 
-                await tx.CommitAsync();
-            });
-        }
-        catch (Exception ex)
-        {
-            logger.LogError(ex, "Error handling message updated for MessageId={MessageId}", e.Message.Id);
-            using var failureScope = scopeFactory.CreateScope();
-            var failedEventService = failureScope.ServiceProvider.GetRequiredService<FailedEventService>();
-            await failedEventService.RecordFailureAsync(
-                "MessageUpdated", nameof(MessageEventHandler), ex,
-                e.Guild?.Id, e.Channel.Id, e.Author?.Id);
+                    await db.SaveChangesAsync();
+
+                    if (messageGuid is Guid mentionMid)
+                    {
+                        await ExtractAndSaveMentionsAsync(db, mentionMid, e.Message);
+                    }
+
+                    await tx.CommitAsync();
+                });
+            }
+            catch (Exception ex)
+            {
+                logger.LogError(ex, "Error handling message updated for MessageId={MessageId}", e.Message.Id);
+                using var failureScope = scopeFactory.CreateScope();
+                var failedEventService = failureScope.ServiceProvider.GetRequiredService<FailedEventService>();
+                await failedEventService.RecordFailureAsync(
+                    "MessageUpdated", nameof(MessageEventHandler), ex,
+                    e.Guild?.Id, e.Channel.Id, e.Author?.Id, correlationId: correlationId);
+            }
         }
     }
 
@@ -302,46 +310,50 @@ public class MessageEventHandler(IServiceScopeFactory scopeFactory, ILogger<Mess
     {
         if (e.Guild is null) return;
 
-        try
+        var correlationId = Guid.NewGuid();
+        using (logger.BeginScope(new Dictionary<string, object> { ["CorrelationId"] = correlationId }))
         {
-            var receivedAt = DateTime.UtcNow;
-            using var scope = scopeFactory.CreateScope();
-            var db = scope.ServiceProvider.GetRequiredService<DiscordDbContext>();
-            var rawEventService = scope.ServiceProvider.GetRequiredService<RawEventLogService>();
-
-            var rawJson = await rawEventService.SerializeAndLogAsync(
-                e, "MessageDeleted", e.Guild.Id, e.Channel.Id, e.Message.Author?.Id);
-
-            // Mark message as deleted
-            await db.Messages
-                .Where(m => m.DiscordId == e.Message.Id)
-                .ExecuteUpdateAsync(s => s
-                    .SetProperty(m => m.IsDeleted, true)
-                    .SetProperty(m => m.DeletedAtUtc, receivedAt));
-
-            db.MessageEvents.Add(new MessageEventEntity
+            try
             {
-                MessageDiscordId = e.Message.Id,
-                ChannelDiscordId = e.Channel.Id,
-                AuthorDiscordId = e.Message.Author?.Id,
-                GuildDiscordId = e.Guild.Id,
-                EventType = MessageEventType.Deleted,
-                Content = e.Message.Content,
-                EventTimestampUtc = receivedAt,
-                ReceivedAtUtc = receivedAt,
-                RawEventJson = rawJson
-            });
+                var receivedAt = DateTime.UtcNow;
+                using var scope = scopeFactory.CreateScope();
+                var db = scope.ServiceProvider.GetRequiredService<DiscordDbContext>();
+                var rawEventService = scope.ServiceProvider.GetRequiredService<RawEventLogService>();
 
-            await db.SaveChangesAsync();
-        }
-        catch (Exception ex)
-        {
-            logger.LogError(ex, "Error handling message deleted for MessageId={MessageId}", e.Message.Id);
-            using var failureScope = scopeFactory.CreateScope();
-            var failedEventService = failureScope.ServiceProvider.GetRequiredService<FailedEventService>();
-            await failedEventService.RecordFailureAsync(
-                "MessageDeleted", nameof(MessageEventHandler), ex,
-                e.Guild?.Id, e.Channel.Id, e.Message.Author?.Id);
+                var rawJson = await rawEventService.SerializeAndLogAsync(
+                    e, "MessageDeleted", e.Guild.Id, e.Channel.Id, e.Message.Author?.Id, correlationId: correlationId);
+
+                // Mark message as deleted
+                await db.Messages
+                    .Where(m => m.DiscordId == e.Message.Id)
+                    .ExecuteUpdateAsync(s => s
+                        .SetProperty(m => m.IsDeleted, true)
+                        .SetProperty(m => m.DeletedAtUtc, receivedAt));
+
+                db.MessageEvents.Add(new MessageEventEntity
+                {
+                    MessageDiscordId = e.Message.Id,
+                    ChannelDiscordId = e.Channel.Id,
+                    AuthorDiscordId = e.Message.Author?.Id,
+                    GuildDiscordId = e.Guild.Id,
+                    EventType = MessageEventType.Deleted,
+                    Content = e.Message.Content,
+                    EventTimestampUtc = receivedAt,
+                    ReceivedAtUtc = receivedAt,
+                    RawEventJson = rawJson
+                });
+
+                await db.SaveChangesAsync();
+            }
+            catch (Exception ex)
+            {
+                logger.LogError(ex, "Error handling message deleted for MessageId={MessageId}", e.Message.Id);
+                using var failureScope = scopeFactory.CreateScope();
+                var failedEventService = failureScope.ServiceProvider.GetRequiredService<FailedEventService>();
+                await failedEventService.RecordFailureAsync(
+                    "MessageDeleted", nameof(MessageEventHandler), ex,
+                    e.Guild?.Id, e.Channel.Id, e.Message.Author?.Id, correlationId: correlationId);
+            }
         }
     }
 
@@ -419,48 +431,52 @@ public class MessageEventHandler(IServiceScopeFactory scopeFactory, ILogger<Mess
     {
         if (e.Guild is null) return;
 
-        try
+        var correlationId = Guid.NewGuid();
+        using (logger.BeginScope(new Dictionary<string, object> { ["CorrelationId"] = correlationId }))
         {
-            var receivedAt = DateTime.UtcNow;
-            using var scope = scopeFactory.CreateScope();
-            var db = scope.ServiceProvider.GetRequiredService<DiscordDbContext>();
-            var rawEventService = scope.ServiceProvider.GetRequiredService<RawEventLogService>();
-
-            var rawJson = await rawEventService.SerializeAndLogAsync(
-                e, "MessagesBulkDeleted", e.Guild.Id, e.Channel.Id, null);
-
-            // Mark all messages as deleted
-            var messageIds = e.Messages.Select(m => m.Id).ToList();
-            await db.Messages
-                .Where(m => messageIds.Contains(m.DiscordId))
-                .ExecuteUpdateAsync(s => s
-                    .SetProperty(m => m.IsDeleted, true)
-                    .SetProperty(m => m.DeletedAtUtc, receivedAt));
-
-            var events = e.Messages.Select(msg => new MessageEventEntity
+            try
             {
-                MessageDiscordId = msg.Id,
-                ChannelDiscordId = e.Channel.Id,
-                AuthorDiscordId = msg.Author?.Id,
-                GuildDiscordId = e.Guild.Id,
-                EventType = MessageEventType.BulkDeleted,
-                Content = msg.Content,
-                EventTimestampUtc = receivedAt,
-                ReceivedAtUtc = receivedAt,
-                RawEventJson = rawJson
-            });
+                var receivedAt = DateTime.UtcNow;
+                using var scope = scopeFactory.CreateScope();
+                var db = scope.ServiceProvider.GetRequiredService<DiscordDbContext>();
+                var rawEventService = scope.ServiceProvider.GetRequiredService<RawEventLogService>();
 
-            db.MessageEvents.AddRange(events);
-            await db.SaveChangesAsync();
-        }
-        catch (Exception ex)
-        {
-            logger.LogError(ex, "Error handling bulk message delete in ChannelId={ChannelId}", e.Channel.Id);
-            using var failureScope = scopeFactory.CreateScope();
-            var failedEventService = failureScope.ServiceProvider.GetRequiredService<FailedEventService>();
-            await failedEventService.RecordFailureAsync(
-                "MessagesBulkDeleted", nameof(MessageEventHandler), ex,
-                e.Guild?.Id, e.Channel.Id, null);
+                var rawJson = await rawEventService.SerializeAndLogAsync(
+                    e, "MessagesBulkDeleted", e.Guild.Id, e.Channel.Id, null, correlationId: correlationId);
+
+                // Mark all messages as deleted
+                var messageIds = e.Messages.Select(m => m.Id).ToList();
+                await db.Messages
+                    .Where(m => messageIds.Contains(m.DiscordId))
+                    .ExecuteUpdateAsync(s => s
+                        .SetProperty(m => m.IsDeleted, true)
+                        .SetProperty(m => m.DeletedAtUtc, receivedAt));
+
+                var events = e.Messages.Select(msg => new MessageEventEntity
+                {
+                    MessageDiscordId = msg.Id,
+                    ChannelDiscordId = e.Channel.Id,
+                    AuthorDiscordId = msg.Author?.Id,
+                    GuildDiscordId = e.Guild.Id,
+                    EventType = MessageEventType.BulkDeleted,
+                    Content = msg.Content,
+                    EventTimestampUtc = receivedAt,
+                    ReceivedAtUtc = receivedAt,
+                    RawEventJson = rawJson
+                });
+
+                db.MessageEvents.AddRange(events);
+                await db.SaveChangesAsync();
+            }
+            catch (Exception ex)
+            {
+                logger.LogError(ex, "Error handling bulk message delete in ChannelId={ChannelId}", e.Channel.Id);
+                using var failureScope = scopeFactory.CreateScope();
+                var failedEventService = failureScope.ServiceProvider.GetRequiredService<FailedEventService>();
+                await failedEventService.RecordFailureAsync(
+                    "MessagesBulkDeleted", nameof(MessageEventHandler), ex,
+                    e.Guild?.Id, e.Channel.Id, null, correlationId: correlationId);
+            }
         }
     }
 }

--- a/src/DiscordEventService/Services/EventHandlers/PinEventHandler.cs
+++ b/src/DiscordEventService/Services/EventHandlers/PinEventHandler.cs
@@ -12,37 +12,41 @@ public class PinEventHandler(IServiceScopeFactory scopeFactory, ILogger<PinEvent
     {
         if (e.Guild is null) return;
 
-        string? rawJson = null;
-        try
+        var correlationId = Guid.NewGuid();
+        using (logger.BeginScope(new Dictionary<string, object> { ["CorrelationId"] = correlationId }))
         {
-            var now = DateTime.UtcNow;
-            using var scope = scopeFactory.CreateScope();
-            var db = scope.ServiceProvider.GetRequiredService<DiscordDbContext>();
-            var rawEventService = scope.ServiceProvider.GetRequiredService<RawEventLogService>();
-
-            rawJson = await rawEventService.SerializeAndLogAsync(
-                e, "ChannelPinsUpdated", e.Guild.Id, e.Channel.Id, null);
-
-            db.PinEvents.Add(new PinEventEntity
+            string? rawJson = null;
+            try
             {
-                ChannelDiscordId = e.Channel.Id,
-                GuildDiscordId = e.Guild.Id,
-                LastPinTimestampUtc = e.LastPinTimestamp?.UtcDateTime,
-                EventTimestampUtc = now,
-                ReceivedAtUtc = now,
-                RawEventJson = rawJson
-            });
+                var now = DateTime.UtcNow;
+                using var scope = scopeFactory.CreateScope();
+                var db = scope.ServiceProvider.GetRequiredService<DiscordDbContext>();
+                var rawEventService = scope.ServiceProvider.GetRequiredService<RawEventLogService>();
 
-            await db.SaveChangesAsync();
-        }
-        catch (Exception ex)
-        {
-            logger.LogError(ex, "Error handling pins updated for ChannelId={ChannelId}", e.Channel.Id);
-            using var failureScope = scopeFactory.CreateScope();
-            var failedEventService = failureScope.ServiceProvider.GetRequiredService<FailedEventService>();
-            await failedEventService.RecordFailureAsync(
-                "ChannelPinsUpdated", nameof(PinEventHandler), ex,
-                e.Guild?.Id, e.Channel?.Id, null, rawJson);
+                rawJson = await rawEventService.SerializeAndLogAsync(
+                    e, "ChannelPinsUpdated", e.Guild.Id, e.Channel.Id, null, correlationId: correlationId);
+
+                db.PinEvents.Add(new PinEventEntity
+                {
+                    ChannelDiscordId = e.Channel.Id,
+                    GuildDiscordId = e.Guild.Id,
+                    LastPinTimestampUtc = e.LastPinTimestamp?.UtcDateTime,
+                    EventTimestampUtc = now,
+                    ReceivedAtUtc = now,
+                    RawEventJson = rawJson
+                });
+
+                await db.SaveChangesAsync();
+            }
+            catch (Exception ex)
+            {
+                logger.LogError(ex, "Error handling pins updated for ChannelId={ChannelId}", e.Channel.Id);
+                using var failureScope = scopeFactory.CreateScope();
+                var failedEventService = failureScope.ServiceProvider.GetRequiredService<FailedEventService>();
+                await failedEventService.RecordFailureAsync(
+                    "ChannelPinsUpdated", nameof(PinEventHandler), ex,
+                    e.Guild?.Id, e.Channel?.Id, null, rawJson, correlationId: correlationId);
+            }
         }
     }
 }

--- a/src/DiscordEventService/Services/EventHandlers/PollEventHandler.cs
+++ b/src/DiscordEventService/Services/EventHandlers/PollEventHandler.cs
@@ -13,40 +13,44 @@ public class PollEventHandler(IServiceScopeFactory scopeFactory, ILogger<PollEve
         var update = e.PollVoteUpdate;
         if (update.Guild is null) return;
 
-        string? rawJson = null;
-        try
+        var correlationId = Guid.NewGuid();
+        using (logger.BeginScope(new Dictionary<string, object> { ["CorrelationId"] = correlationId }))
         {
-            var now = DateTime.UtcNow;
-            using var scope = scopeFactory.CreateScope();
-            var db = scope.ServiceProvider.GetRequiredService<DiscordDbContext>();
-            var rawEventService = scope.ServiceProvider.GetRequiredService<RawEventLogService>();
-
-            rawJson = await rawEventService.SerializeAndLogAsync(
-                e, "MessagePollVoted", update.Guild.Id, update.Message?.ChannelId, update.User?.Id);
-
-            db.PollEvents.Add(new PollEventEntity
+            string? rawJson = null;
+            try
             {
-                MessageDiscordId = update.Message?.Id ?? 0,
-                ChannelDiscordId = update.Message?.ChannelId ?? 0,
-                GuildDiscordId = update.Guild.Id,
-                UserDiscordId = update.User?.Id ?? 0,
-                AnswerId = 0, // AnswerId not exposed in this event
-                EventType = update.WasAdded ? PollEventType.VoteAdded : PollEventType.VoteRemoved,
-                EventTimestampUtc = now,
-                ReceivedAtUtc = now,
-                RawEventJson = rawJson
-            });
+                var now = DateTime.UtcNow;
+                using var scope = scopeFactory.CreateScope();
+                var db = scope.ServiceProvider.GetRequiredService<DiscordDbContext>();
+                var rawEventService = scope.ServiceProvider.GetRequiredService<RawEventLogService>();
 
-            await db.SaveChangesAsync();
-        }
-        catch (Exception ex)
-        {
-            logger.LogError(ex, "Error handling poll vote");
-            using var failureScope = scopeFactory.CreateScope();
-            var failedEventService = failureScope.ServiceProvider.GetRequiredService<FailedEventService>();
-            await failedEventService.RecordFailureAsync(
-                "MessagePollVoted", nameof(PollEventHandler), ex,
-                update.Guild?.Id, update.Message?.ChannelId, update.User?.Id, rawJson);
+                rawJson = await rawEventService.SerializeAndLogAsync(
+                    e, "MessagePollVoted", update.Guild.Id, update.Message?.ChannelId, update.User?.Id, correlationId: correlationId);
+
+                db.PollEvents.Add(new PollEventEntity
+                {
+                    MessageDiscordId = update.Message?.Id ?? 0,
+                    ChannelDiscordId = update.Message?.ChannelId ?? 0,
+                    GuildDiscordId = update.Guild.Id,
+                    UserDiscordId = update.User?.Id ?? 0,
+                    AnswerId = 0, // AnswerId not exposed in this event
+                    EventType = update.WasAdded ? PollEventType.VoteAdded : PollEventType.VoteRemoved,
+                    EventTimestampUtc = now,
+                    ReceivedAtUtc = now,
+                    RawEventJson = rawJson
+                });
+
+                await db.SaveChangesAsync();
+            }
+            catch (Exception ex)
+            {
+                logger.LogError(ex, "Error handling poll vote");
+                using var failureScope = scopeFactory.CreateScope();
+                var failedEventService = failureScope.ServiceProvider.GetRequiredService<FailedEventService>();
+                await failedEventService.RecordFailureAsync(
+                    "MessagePollVoted", nameof(PollEventHandler), ex,
+                    update.Guild?.Id, update.Message?.ChannelId, update.User?.Id, rawJson, correlationId: correlationId);
+            }
         }
     }
 }

--- a/src/DiscordEventService/Services/EventHandlers/PresenceEventHandler.cs
+++ b/src/DiscordEventService/Services/EventHandlers/PresenceEventHandler.cs
@@ -22,97 +22,101 @@ public class PresenceEventHandler(IServiceScopeFactory scopeFactory, ILogger<Pre
 
     public async Task HandleEventAsync(DiscordClient sender, PresenceUpdatedEventArgs args)
     {
-        try
+        var correlationId = Guid.NewGuid();
+        using (logger.BeginScope(new Dictionary<string, object> { ["CorrelationId"] = correlationId }))
         {
-            var now = DateTime.UtcNow;
-
-            using var scope = scopeFactory.CreateScope();
-            var dbContext = scope.ServiceProvider.GetRequiredService<DiscordDbContext>();
-            var rawEventService = scope.ServiceProvider.GetRequiredService<RawEventLogService>();
-            var userService = scope.ServiceProvider.GetRequiredService<UserService>();
-
-            var guildId = args.PresenceAfter?.Guild?.Id ?? args.PresenceBefore?.Guild?.Id ?? 0;
-
-            // Create DTO to avoid serialization issues with DSharpPlus internals
-            var eventDto = new
+            try
             {
-                UserId = args.User.Id,
-                GuildId = guildId,
-                Before = args.PresenceBefore == null ? null : new
+                var now = DateTime.UtcNow;
+
+                using var scope = scopeFactory.CreateScope();
+                var dbContext = scope.ServiceProvider.GetRequiredService<DiscordDbContext>();
+                var rawEventService = scope.ServiceProvider.GetRequiredService<RawEventLogService>();
+                var userService = scope.ServiceProvider.GetRequiredService<UserService>();
+
+                var guildId = args.PresenceAfter?.Guild?.Id ?? args.PresenceBefore?.Guild?.Id ?? 0;
+
+                // Create DTO to avoid serialization issues with DSharpPlus internals
+                var eventDto = new
                 {
-                    Desktop = GetStatusValue(args.PresenceBefore.ClientStatus?.Desktop),
-                    Mobile = GetStatusValue(args.PresenceBefore.ClientStatus?.Mobile),
-                    Web = GetStatusValue(args.PresenceBefore.ClientStatus?.Web),
-                    Activities = args.PresenceBefore.Activities?.Select(a => new { a.Name, Type = (int)a.ActivityType, a.StreamUrl })
-                },
-                After = args.PresenceAfter == null ? null : new
+                    UserId = args.User.Id,
+                    GuildId = guildId,
+                    Before = args.PresenceBefore == null ? null : new
+                    {
+                        Desktop = GetStatusValue(args.PresenceBefore.ClientStatus?.Desktop),
+                        Mobile = GetStatusValue(args.PresenceBefore.ClientStatus?.Mobile),
+                        Web = GetStatusValue(args.PresenceBefore.ClientStatus?.Web),
+                        Activities = args.PresenceBefore.Activities?.Select(a => new { a.Name, Type = (int)a.ActivityType, a.StreamUrl })
+                    },
+                    After = args.PresenceAfter == null ? null : new
+                    {
+                        Desktop = GetStatusValue(args.PresenceAfter.ClientStatus?.Desktop),
+                        Mobile = GetStatusValue(args.PresenceAfter.ClientStatus?.Mobile),
+                        Web = GetStatusValue(args.PresenceAfter.ClientStatus?.Web),
+                        Activities = args.PresenceAfter.Activities?.Select(a => new { a.Name, Type = (int)a.ActivityType, a.StreamUrl })
+                    }
+                };
+
+                var rawJson = await rawEventService.SerializeAndLogAsync(
+                    eventDto, "PresenceUpdated", guildId, null, args.User.Id, correlationId: correlationId);
+
+                // Record the presence event
+                var presenceEvent = new PresenceEventEntity
                 {
-                    Desktop = GetStatusValue(args.PresenceAfter.ClientStatus?.Desktop),
-                    Mobile = GetStatusValue(args.PresenceAfter.ClientStatus?.Mobile),
-                    Web = GetStatusValue(args.PresenceAfter.ClientStatus?.Web),
-                    Activities = args.PresenceAfter.Activities?.Select(a => new { a.Name, Type = (int)a.ActivityType, a.StreamUrl })
-                }
-            };
+                    UserDiscordId = args.User.Id,
+                    GuildDiscordId = guildId,
 
-            var rawJson = await rawEventService.SerializeAndLogAsync(
-                eventDto, "PresenceUpdated", guildId, null, args.User.Id);
+                    DesktopStatusBefore = GetStatusValue(args.PresenceBefore?.ClientStatus?.Desktop),
+                    MobileStatusBefore = GetStatusValue(args.PresenceBefore?.ClientStatus?.Mobile),
+                    WebStatusBefore = GetStatusValue(args.PresenceBefore?.ClientStatus?.Web),
 
-            // Record the presence event
-            var presenceEvent = new PresenceEventEntity
-            {
-                UserDiscordId = args.User.Id,
-                GuildDiscordId = guildId,
+                    DesktopStatusAfter = GetStatusValue(args.PresenceAfter?.ClientStatus?.Desktop),
+                    MobileStatusAfter = GetStatusValue(args.PresenceAfter?.ClientStatus?.Mobile),
+                    WebStatusAfter = GetStatusValue(args.PresenceAfter?.ClientStatus?.Web),
 
-                DesktopStatusBefore = GetStatusValue(args.PresenceBefore?.ClientStatus?.Desktop),
-                MobileStatusBefore = GetStatusValue(args.PresenceBefore?.ClientStatus?.Mobile),
-                WebStatusBefore = GetStatusValue(args.PresenceBefore?.ClientStatus?.Web),
+                    ActivitiesBeforeJson = SerializeActivities(args.PresenceBefore?.Activities),
+                    ActivitiesAfterJson = SerializeActivities(args.PresenceAfter?.Activities),
 
-                DesktopStatusAfter = GetStatusValue(args.PresenceAfter?.ClientStatus?.Desktop),
-                MobileStatusAfter = GetStatusValue(args.PresenceAfter?.ClientStatus?.Mobile),
-                WebStatusAfter = GetStatusValue(args.PresenceAfter?.ClientStatus?.Web),
+                    EventTimestampUtc = now,
+                    ReceivedAtUtc = now,
+                    RawEventJson = rawJson
+                };
 
-                ActivitiesBeforeJson = SerializeActivities(args.PresenceBefore?.Activities),
-                ActivitiesAfterJson = SerializeActivities(args.PresenceAfter?.Activities),
+                await dbContext.PresenceEvents.AddAsync(presenceEvent);
 
-                EventTimestampUtc = now,
-                ReceivedAtUtc = now,
-                RawEventJson = rawJson
-            };
-
-            await dbContext.PresenceEvents.AddAsync(presenceEvent);
-
-            // Flush before the user upsert so its 23505 catch path (ChangeTracker.Clear)
-            // can't discard the staged raw_event_logs + presence_events rows.
-            await dbContext.SaveChangesAsync();
-
-            // Track activities in ActivityEntity — upsert the user first so we never silently
-            // skip activity tracking for unknown users (87k presence events historically).
-            await userService.UpsertUserAsync(args.User);
-            var userGuid = await dbContext.Users
-                .Where(u => u.DiscordId == args.User.Id)
-                .Select(u => u.Id)
-                .FirstOrDefaultAsync();
-
-            if (userGuid != Guid.Empty)
-            {
-                await UpdateActivityTracking(dbContext, userGuid, args.PresenceBefore?.Activities, args.PresenceAfter?.Activities, now);
+                // Flush before the user upsert so its 23505 catch path (ChangeTracker.Clear)
+                // can't discard the staged raw_event_logs + presence_events rows.
                 await dbContext.SaveChangesAsync();
-            }
-            else
-            {
-                logger.LogWarning("Skipping activity tracking: UpsertUserAsync did not produce a User row for {UserId}", args.User.Id);
-            }
 
-            logger.LogDebug("Recorded presence event for user {UserId}", args.User.Id);
-        }
-        catch (Exception ex)
-        {
-            logger.LogError(ex, "Error handling presence update for user {UserId}", args.User.Id);
-            using var failureScope = scopeFactory.CreateScope();
-            var failedEventService = failureScope.ServiceProvider.GetRequiredService<FailedEventService>();
-            await failedEventService.RecordFailureAsync(
-                "PresenceUpdated", nameof(PresenceEventHandler), ex,
-                null, null, args.User.Id);
+                // Track activities in ActivityEntity — upsert the user first so we never silently
+                // skip activity tracking for unknown users (87k presence events historically).
+                await userService.UpsertUserAsync(args.User);
+                var userGuid = await dbContext.Users
+                    .Where(u => u.DiscordId == args.User.Id)
+                    .Select(u => u.Id)
+                    .FirstOrDefaultAsync();
+
+                if (userGuid != Guid.Empty)
+                {
+                    await UpdateActivityTracking(dbContext, userGuid, args.PresenceBefore?.Activities, args.PresenceAfter?.Activities, now);
+                    await dbContext.SaveChangesAsync();
+                }
+                else
+                {
+                    logger.LogWarning("Skipping activity tracking: UpsertUserAsync did not produce a User row for {UserId}", args.User.Id);
+                }
+
+                logger.LogDebug("Recorded presence event for user {UserId}", args.User.Id);
+            }
+            catch (Exception ex)
+            {
+                logger.LogError(ex, "Error handling presence update for user {UserId}", args.User.Id);
+                using var failureScope = scopeFactory.CreateScope();
+                var failedEventService = failureScope.ServiceProvider.GetRequiredService<FailedEventService>();
+                await failedEventService.RecordFailureAsync(
+                    "PresenceUpdated", nameof(PresenceEventHandler), ex,
+                    null, null, args.User.Id, correlationId: correlationId);
+            }
         }
     }
 

--- a/src/DiscordEventService/Services/EventHandlers/ReactionEventHandler.cs
+++ b/src/DiscordEventService/Services/EventHandlers/ReactionEventHandler.cs
@@ -15,44 +15,48 @@ public class ReactionEventHandler(IServiceScopeFactory scopeFactory, ILogger<Rea
     {
         if (e.Guild is null) return;
 
-        string? rawJson = null;
-        try
+        var correlationId = Guid.NewGuid();
+        using (logger.BeginScope(new Dictionary<string, object> { ["CorrelationId"] = correlationId }))
         {
-            var receivedAt = DateTime.UtcNow;
-            using var scope = scopeFactory.CreateScope();
-            var db = scope.ServiceProvider.GetRequiredService<DiscordDbContext>();
-            var rawEventService = scope.ServiceProvider.GetRequiredService<RawEventLogService>();
-
-            rawJson = await rawEventService.SerializeAndLogAsync(
-                e, "MessageReactionAdded", e.Guild.Id, e.Channel.Id, e.User.Id);
-
-            var reactionEvent = new ReactionEventEntity
+            string? rawJson = null;
+            try
             {
-                MessageDiscordId = e.Message.Id,
-                ChannelDiscordId = e.Channel.Id,
-                UserDiscordId = e.User.Id,
-                GuildDiscordId = e.Guild.Id,
-                EmoteDiscordId = e.Emoji.Id,
-                EmoteName = e.Emoji.Name ?? string.Empty,
-                IsAnimated = e.Emoji.IsAnimated,
-                IsBurst = false,
-                EventType = ReactionEventType.Added,
-                EventTimestampUtc = receivedAt,
-                ReceivedAtUtc = receivedAt,
-                RawEventJson = rawJson
-            };
+                var receivedAt = DateTime.UtcNow;
+                using var scope = scopeFactory.CreateScope();
+                var db = scope.ServiceProvider.GetRequiredService<DiscordDbContext>();
+                var rawEventService = scope.ServiceProvider.GetRequiredService<RawEventLogService>();
 
-            db.ReactionEvents.Add(reactionEvent);
-            await db.SaveChangesAsync();
-        }
-        catch (Exception ex)
-        {
-            logger.LogError(ex, "Error handling reaction added for MessageId={MessageId}", e.Message.Id);
-            using var failureScope = scopeFactory.CreateScope();
-            var failedEventService = failureScope.ServiceProvider.GetRequiredService<FailedEventService>();
-            await failedEventService.RecordFailureAsync(
-                "MessageReactionAdded", nameof(ReactionEventHandler), ex,
-                e.Guild?.Id, e.Channel.Id, e.User.Id, rawJson);
+                rawJson = await rawEventService.SerializeAndLogAsync(
+                    e, "MessageReactionAdded", e.Guild.Id, e.Channel.Id, e.User.Id, correlationId: correlationId);
+
+                var reactionEvent = new ReactionEventEntity
+                {
+                    MessageDiscordId = e.Message.Id,
+                    ChannelDiscordId = e.Channel.Id,
+                    UserDiscordId = e.User.Id,
+                    GuildDiscordId = e.Guild.Id,
+                    EmoteDiscordId = e.Emoji.Id,
+                    EmoteName = e.Emoji.Name ?? string.Empty,
+                    IsAnimated = e.Emoji.IsAnimated,
+                    IsBurst = false,
+                    EventType = ReactionEventType.Added,
+                    EventTimestampUtc = receivedAt,
+                    ReceivedAtUtc = receivedAt,
+                    RawEventJson = rawJson
+                };
+
+                db.ReactionEvents.Add(reactionEvent);
+                await db.SaveChangesAsync();
+            }
+            catch (Exception ex)
+            {
+                logger.LogError(ex, "Error handling reaction added for MessageId={MessageId}", e.Message.Id);
+                using var failureScope = scopeFactory.CreateScope();
+                var failedEventService = failureScope.ServiceProvider.GetRequiredService<FailedEventService>();
+                await failedEventService.RecordFailureAsync(
+                    "MessageReactionAdded", nameof(ReactionEventHandler), ex,
+                    e.Guild?.Id, e.Channel.Id, e.User.Id, rawJson, correlationId: correlationId);
+            }
         }
     }
 
@@ -60,44 +64,48 @@ public class ReactionEventHandler(IServiceScopeFactory scopeFactory, ILogger<Rea
     {
         if (e.Guild is null) return;
 
-        string? rawJson = null;
-        try
+        var correlationId = Guid.NewGuid();
+        using (logger.BeginScope(new Dictionary<string, object> { ["CorrelationId"] = correlationId }))
         {
-            var receivedAt = DateTime.UtcNow;
-            using var scope = scopeFactory.CreateScope();
-            var db = scope.ServiceProvider.GetRequiredService<DiscordDbContext>();
-            var rawEventService = scope.ServiceProvider.GetRequiredService<RawEventLogService>();
-
-            rawJson = await rawEventService.SerializeAndLogAsync(
-                e, "MessageReactionRemoved", e.Guild.Id, e.Channel.Id, e.User.Id);
-
-            var reactionEvent = new ReactionEventEntity
+            string? rawJson = null;
+            try
             {
-                MessageDiscordId = e.Message.Id,
-                ChannelDiscordId = e.Channel.Id,
-                UserDiscordId = e.User.Id,
-                GuildDiscordId = e.Guild.Id,
-                EmoteDiscordId = e.Emoji.Id,
-                EmoteName = e.Emoji.Name ?? string.Empty,
-                IsAnimated = e.Emoji.IsAnimated,
-                IsBurst = false,
-                EventType = ReactionEventType.Removed,
-                EventTimestampUtc = receivedAt,
-                ReceivedAtUtc = receivedAt,
-                RawEventJson = rawJson
-            };
+                var receivedAt = DateTime.UtcNow;
+                using var scope = scopeFactory.CreateScope();
+                var db = scope.ServiceProvider.GetRequiredService<DiscordDbContext>();
+                var rawEventService = scope.ServiceProvider.GetRequiredService<RawEventLogService>();
 
-            db.ReactionEvents.Add(reactionEvent);
-            await db.SaveChangesAsync();
-        }
-        catch (Exception ex)
-        {
-            logger.LogError(ex, "Error handling reaction removed for MessageId={MessageId}", e.Message.Id);
-            using var failureScope = scopeFactory.CreateScope();
-            var failedEventService = failureScope.ServiceProvider.GetRequiredService<FailedEventService>();
-            await failedEventService.RecordFailureAsync(
-                "MessageReactionRemoved", nameof(ReactionEventHandler), ex,
-                e.Guild?.Id, e.Channel.Id, e.User.Id, rawJson);
+                rawJson = await rawEventService.SerializeAndLogAsync(
+                    e, "MessageReactionRemoved", e.Guild.Id, e.Channel.Id, e.User.Id, correlationId: correlationId);
+
+                var reactionEvent = new ReactionEventEntity
+                {
+                    MessageDiscordId = e.Message.Id,
+                    ChannelDiscordId = e.Channel.Id,
+                    UserDiscordId = e.User.Id,
+                    GuildDiscordId = e.Guild.Id,
+                    EmoteDiscordId = e.Emoji.Id,
+                    EmoteName = e.Emoji.Name ?? string.Empty,
+                    IsAnimated = e.Emoji.IsAnimated,
+                    IsBurst = false,
+                    EventType = ReactionEventType.Removed,
+                    EventTimestampUtc = receivedAt,
+                    ReceivedAtUtc = receivedAt,
+                    RawEventJson = rawJson
+                };
+
+                db.ReactionEvents.Add(reactionEvent);
+                await db.SaveChangesAsync();
+            }
+            catch (Exception ex)
+            {
+                logger.LogError(ex, "Error handling reaction removed for MessageId={MessageId}", e.Message.Id);
+                using var failureScope = scopeFactory.CreateScope();
+                var failedEventService = failureScope.ServiceProvider.GetRequiredService<FailedEventService>();
+                await failedEventService.RecordFailureAsync(
+                    "MessageReactionRemoved", nameof(ReactionEventHandler), ex,
+                    e.Guild?.Id, e.Channel.Id, e.User.Id, rawJson, correlationId: correlationId);
+            }
         }
     }
 
@@ -105,44 +113,48 @@ public class ReactionEventHandler(IServiceScopeFactory scopeFactory, ILogger<Rea
     {
         if (e.Guild is null) return;
 
-        string? rawJson = null;
-        try
+        var correlationId = Guid.NewGuid();
+        using (logger.BeginScope(new Dictionary<string, object> { ["CorrelationId"] = correlationId }))
         {
-            var receivedAt = DateTime.UtcNow;
-            using var scope = scopeFactory.CreateScope();
-            var db = scope.ServiceProvider.GetRequiredService<DiscordDbContext>();
-            var rawEventService = scope.ServiceProvider.GetRequiredService<RawEventLogService>();
-
-            rawJson = await rawEventService.SerializeAndLogAsync(
-                e, "MessageReactionsCleared", e.Guild.Id, e.Channel.Id, null);
-
-            var reactionEvent = new ReactionEventEntity
+            string? rawJson = null;
+            try
             {
-                MessageDiscordId = e.Message.Id,
-                ChannelDiscordId = e.Channel.Id,
-                UserDiscordId = 0,
-                GuildDiscordId = e.Guild.Id,
-                EmoteDiscordId = null,
-                EmoteName = string.Empty,
-                IsAnimated = false,
-                IsBurst = false,
-                EventType = ReactionEventType.Cleared,
-                EventTimestampUtc = receivedAt,
-                ReceivedAtUtc = receivedAt,
-                RawEventJson = rawJson
-            };
+                var receivedAt = DateTime.UtcNow;
+                using var scope = scopeFactory.CreateScope();
+                var db = scope.ServiceProvider.GetRequiredService<DiscordDbContext>();
+                var rawEventService = scope.ServiceProvider.GetRequiredService<RawEventLogService>();
 
-            db.ReactionEvents.Add(reactionEvent);
-            await db.SaveChangesAsync();
-        }
-        catch (Exception ex)
-        {
-            logger.LogError(ex, "Error handling reactions cleared for MessageId={MessageId}", e.Message.Id);
-            using var failureScope = scopeFactory.CreateScope();
-            var failedEventService = failureScope.ServiceProvider.GetRequiredService<FailedEventService>();
-            await failedEventService.RecordFailureAsync(
-                "MessageReactionsCleared", nameof(ReactionEventHandler), ex,
-                e.Guild?.Id, e.Channel.Id, null, rawJson);
+                rawJson = await rawEventService.SerializeAndLogAsync(
+                    e, "MessageReactionsCleared", e.Guild.Id, e.Channel.Id, null, correlationId: correlationId);
+
+                var reactionEvent = new ReactionEventEntity
+                {
+                    MessageDiscordId = e.Message.Id,
+                    ChannelDiscordId = e.Channel.Id,
+                    UserDiscordId = 0,
+                    GuildDiscordId = e.Guild.Id,
+                    EmoteDiscordId = null,
+                    EmoteName = string.Empty,
+                    IsAnimated = false,
+                    IsBurst = false,
+                    EventType = ReactionEventType.Cleared,
+                    EventTimestampUtc = receivedAt,
+                    ReceivedAtUtc = receivedAt,
+                    RawEventJson = rawJson
+                };
+
+                db.ReactionEvents.Add(reactionEvent);
+                await db.SaveChangesAsync();
+            }
+            catch (Exception ex)
+            {
+                logger.LogError(ex, "Error handling reactions cleared for MessageId={MessageId}", e.Message.Id);
+                using var failureScope = scopeFactory.CreateScope();
+                var failedEventService = failureScope.ServiceProvider.GetRequiredService<FailedEventService>();
+                await failedEventService.RecordFailureAsync(
+                    "MessageReactionsCleared", nameof(ReactionEventHandler), ex,
+                    e.Guild?.Id, e.Channel.Id, null, rawJson, correlationId: correlationId);
+            }
         }
     }
 
@@ -150,44 +162,48 @@ public class ReactionEventHandler(IServiceScopeFactory scopeFactory, ILogger<Rea
     {
         if (e.Guild is null) return;
 
-        string? rawJson = null;
-        try
+        var correlationId = Guid.NewGuid();
+        using (logger.BeginScope(new Dictionary<string, object> { ["CorrelationId"] = correlationId }))
         {
-            var receivedAt = DateTime.UtcNow;
-            using var scope = scopeFactory.CreateScope();
-            var db = scope.ServiceProvider.GetRequiredService<DiscordDbContext>();
-            var rawEventService = scope.ServiceProvider.GetRequiredService<RawEventLogService>();
-
-            rawJson = await rawEventService.SerializeAndLogAsync(
-                e, "MessageReactionRemovedEmoji", e.Guild.Id, e.Channel.Id, null);
-
-            var reactionEvent = new ReactionEventEntity
+            string? rawJson = null;
+            try
             {
-                MessageDiscordId = e.Message.Id,
-                ChannelDiscordId = e.Channel.Id,
-                UserDiscordId = 0,
-                GuildDiscordId = e.Guild.Id,
-                EmoteDiscordId = e.Emoji.Id,
-                EmoteName = e.Emoji.Name ?? string.Empty,
-                IsAnimated = e.Emoji.IsAnimated,
-                IsBurst = false,
-                EventType = ReactionEventType.EmojiCleared,
-                EventTimestampUtc = receivedAt,
-                ReceivedAtUtc = receivedAt,
-                RawEventJson = rawJson
-            };
+                var receivedAt = DateTime.UtcNow;
+                using var scope = scopeFactory.CreateScope();
+                var db = scope.ServiceProvider.GetRequiredService<DiscordDbContext>();
+                var rawEventService = scope.ServiceProvider.GetRequiredService<RawEventLogService>();
 
-            db.ReactionEvents.Add(reactionEvent);
-            await db.SaveChangesAsync();
-        }
-        catch (Exception ex)
-        {
-            logger.LogError(ex, "Error handling emoji cleared for MessageId={MessageId}", e.Message.Id);
-            using var failureScope = scopeFactory.CreateScope();
-            var failedEventService = failureScope.ServiceProvider.GetRequiredService<FailedEventService>();
-            await failedEventService.RecordFailureAsync(
-                "MessageReactionRemovedEmoji", nameof(ReactionEventHandler), ex,
-                e.Guild?.Id, e.Channel.Id, null, rawJson);
+                rawJson = await rawEventService.SerializeAndLogAsync(
+                    e, "MessageReactionRemovedEmoji", e.Guild.Id, e.Channel.Id, null, correlationId: correlationId);
+
+                var reactionEvent = new ReactionEventEntity
+                {
+                    MessageDiscordId = e.Message.Id,
+                    ChannelDiscordId = e.Channel.Id,
+                    UserDiscordId = 0,
+                    GuildDiscordId = e.Guild.Id,
+                    EmoteDiscordId = e.Emoji.Id,
+                    EmoteName = e.Emoji.Name ?? string.Empty,
+                    IsAnimated = e.Emoji.IsAnimated,
+                    IsBurst = false,
+                    EventType = ReactionEventType.EmojiCleared,
+                    EventTimestampUtc = receivedAt,
+                    ReceivedAtUtc = receivedAt,
+                    RawEventJson = rawJson
+                };
+
+                db.ReactionEvents.Add(reactionEvent);
+                await db.SaveChangesAsync();
+            }
+            catch (Exception ex)
+            {
+                logger.LogError(ex, "Error handling emoji cleared for MessageId={MessageId}", e.Message.Id);
+                using var failureScope = scopeFactory.CreateScope();
+                var failedEventService = failureScope.ServiceProvider.GetRequiredService<FailedEventService>();
+                await failedEventService.RecordFailureAsync(
+                    "MessageReactionRemovedEmoji", nameof(ReactionEventHandler), ex,
+                    e.Guild?.Id, e.Channel.Id, null, rawJson, correlationId: correlationId);
+            }
         }
     }
 }

--- a/src/DiscordEventService/Services/EventHandlers/RoleEventHandler.cs
+++ b/src/DiscordEventService/Services/EventHandlers/RoleEventHandler.cs
@@ -15,178 +15,190 @@ public class RoleEventHandler(IServiceScopeFactory scopeFactory, ILogger<RoleEve
 {
     public async Task HandleEventAsync(DiscordClient sender, GuildRoleCreatedEventArgs e)
     {
-        string? rawJson = null;
-        try
+        var correlationId = Guid.NewGuid();
+        using (logger.BeginScope(new Dictionary<string, object> { ["CorrelationId"] = correlationId }))
         {
-            var receivedAt = DateTime.UtcNow;
-            using var scope = scopeFactory.CreateScope();
-            var db = scope.ServiceProvider.GetRequiredService<DiscordDbContext>();
-            var rawEventService = scope.ServiceProvider.GetRequiredService<RawEventLogService>();
-
-            rawJson = await rawEventService.SerializeAndLogAsync(
-                e, "GuildRoleCreated", e.Guild.Id, null, null);
-
-            // Look up Guild Guid
-            var guild = await db.Guilds.FirstOrDefaultAsync(g => g.DiscordId == e.Guild.Id);
-
-            RoleEventEntity NewRoleEvent() => new()
-            {
-                RoleDiscordId = e.Role.Id,
-                GuildDiscordId = e.Guild.Id,
-                EventType = RoleEventType.Created,
-                NameAfter = e.Role.Name,
-                ColorAfter = e.Role.Color.Value,
-                EventTimestampUtc = receivedAt,
-                ReceivedAtUtc = receivedAt,
-                RawEventJson = rawJson
-            };
-
-            var roleEntity = await db.Roles
-                .FirstOrDefaultAsync(r => r.DiscordId == e.Role.Id);
-
-            if (roleEntity == null)
-            {
-                roleEntity = new RoleEntity
-                {
-                    DiscordId = e.Role.Id,
-                    GuildId = guild?.Id ?? Guid.Empty
-                };
-                db.Roles.Add(roleEntity);
-            }
-
-            UpdateRoleEntity(roleEntity, e.Role);
-            db.RoleEvents.Add(NewRoleEvent());
-
+            string? rawJson = null;
             try
             {
-                await db.SaveChangesAsync();
-            }
-            catch (DbUpdateException dbEx) when (dbEx.InnerException is Npgsql.PostgresException { SqlState: "23505" })
-            {
-                // Concurrent insert won the race. Re-fetch, update, re-add the event.
-                db.ChangeTracker.Clear();
-                var existing = await db.Roles.FirstOrDefaultAsync(r => r.DiscordId == e.Role.Id);
-                if (existing != null)
+                var receivedAt = DateTime.UtcNow;
+                using var scope = scopeFactory.CreateScope();
+                var db = scope.ServiceProvider.GetRequiredService<DiscordDbContext>();
+                var rawEventService = scope.ServiceProvider.GetRequiredService<RawEventLogService>();
+
+                rawJson = await rawEventService.SerializeAndLogAsync(
+                    e, "GuildRoleCreated", e.Guild.Id, null, null, correlationId: correlationId);
+
+                // Look up Guild Guid
+                var guild = await db.Guilds.FirstOrDefaultAsync(g => g.DiscordId == e.Guild.Id);
+
+                RoleEventEntity NewRoleEvent() => new()
                 {
-                    UpdateRoleEntity(existing, e.Role);
+                    RoleDiscordId = e.Role.Id,
+                    GuildDiscordId = e.Guild.Id,
+                    EventType = RoleEventType.Created,
+                    NameAfter = e.Role.Name,
+                    ColorAfter = e.Role.Color.Value,
+                    EventTimestampUtc = receivedAt,
+                    ReceivedAtUtc = receivedAt,
+                    RawEventJson = rawJson
+                };
+
+                var roleEntity = await db.Roles
+                    .FirstOrDefaultAsync(r => r.DiscordId == e.Role.Id);
+
+                if (roleEntity == null)
+                {
+                    roleEntity = new RoleEntity
+                    {
+                        DiscordId = e.Role.Id,
+                        GuildId = guild?.Id ?? Guid.Empty
+                    };
+                    db.Roles.Add(roleEntity);
                 }
+
+                UpdateRoleEntity(roleEntity, e.Role);
                 db.RoleEvents.Add(NewRoleEvent());
-                await db.SaveChangesAsync();
+
+                try
+                {
+                    await db.SaveChangesAsync();
+                }
+                catch (DbUpdateException dbEx) when (dbEx.InnerException is Npgsql.PostgresException { SqlState: "23505" })
+                {
+                    // Concurrent insert won the race. Re-fetch, update, re-add the event.
+                    db.ChangeTracker.Clear();
+                    var existing = await db.Roles.FirstOrDefaultAsync(r => r.DiscordId == e.Role.Id);
+                    if (existing != null)
+                    {
+                        UpdateRoleEntity(existing, e.Role);
+                    }
+                    db.RoleEvents.Add(NewRoleEvent());
+                    await db.SaveChangesAsync();
+                }
             }
-        }
-        catch (Exception ex)
-        {
-            logger.LogError(ex, "Error handling role created for RoleId={RoleId}", e.Role.Id);
-            using var failureScope = scopeFactory.CreateScope();
-            var failedEventService = failureScope.ServiceProvider.GetRequiredService<FailedEventService>();
-            await failedEventService.RecordFailureAsync(
-                "GuildRoleCreated", nameof(RoleEventHandler), ex,
-                e.Guild?.Id, null, null, rawJson);
+            catch (Exception ex)
+            {
+                logger.LogError(ex, "Error handling role created for RoleId={RoleId}", e.Role.Id);
+                using var failureScope = scopeFactory.CreateScope();
+                var failedEventService = failureScope.ServiceProvider.GetRequiredService<FailedEventService>();
+                await failedEventService.RecordFailureAsync(
+                    "GuildRoleCreated", nameof(RoleEventHandler), ex,
+                    e.Guild?.Id, null, null, rawJson, correlationId: correlationId);
+            }
         }
     }
 
     public async Task HandleEventAsync(DiscordClient sender, GuildRoleUpdatedEventArgs e)
     {
-        string? rawJson = null;
-        try
+        var correlationId = Guid.NewGuid();
+        using (logger.BeginScope(new Dictionary<string, object> { ["CorrelationId"] = correlationId }))
         {
-            var receivedAt = DateTime.UtcNow;
-            using var scope = scopeFactory.CreateScope();
-            var db = scope.ServiceProvider.GetRequiredService<DiscordDbContext>();
-            var rawEventService = scope.ServiceProvider.GetRequiredService<RawEventLogService>();
-
-            rawJson = await rawEventService.SerializeAndLogAsync(
-                e, "GuildRoleUpdated", e.Guild.Id, null, null);
-
-            var roleEntity = await db.Roles
-                .FirstOrDefaultAsync(r => r.DiscordId == e.RoleAfter.Id);
-
-            if (roleEntity != null)
+            string? rawJson = null;
+            try
             {
-                UpdateRoleEntity(roleEntity, e.RoleAfter);
+                var receivedAt = DateTime.UtcNow;
+                using var scope = scopeFactory.CreateScope();
+                var db = scope.ServiceProvider.GetRequiredService<DiscordDbContext>();
+                var rawEventService = scope.ServiceProvider.GetRequiredService<RawEventLogService>();
+
+                rawJson = await rawEventService.SerializeAndLogAsync(
+                    e, "GuildRoleUpdated", e.Guild.Id, null, null, correlationId: correlationId);
+
+                var roleEntity = await db.Roles
+                    .FirstOrDefaultAsync(r => r.DiscordId == e.RoleAfter.Id);
+
+                if (roleEntity != null)
+                {
+                    UpdateRoleEntity(roleEntity, e.RoleAfter);
+                }
+
+                var roleEvent = new RoleEventEntity
+                {
+                    RoleDiscordId = e.RoleAfter.Id,
+                    GuildDiscordId = e.Guild.Id,
+                    EventType = RoleEventType.Updated,
+                    EventTimestampUtc = receivedAt,
+                    ReceivedAtUtc = receivedAt,
+                    RawEventJson = rawJson
+                };
+
+                if (e.RoleBefore.Name != e.RoleAfter.Name)
+                {
+                    roleEvent.NameBefore = e.RoleBefore.Name;
+                    roleEvent.NameAfter = e.RoleAfter.Name;
+                }
+
+                if (e.RoleBefore.Color.Value != e.RoleAfter.Color.Value)
+                {
+                    roleEvent.ColorBefore = e.RoleBefore.Color.Value;
+                    roleEvent.ColorAfter = e.RoleAfter.Color.Value;
+                }
+
+                db.RoleEvents.Add(roleEvent);
+                await db.SaveChangesAsync();
             }
-
-            var roleEvent = new RoleEventEntity
+            catch (Exception ex)
             {
-                RoleDiscordId = e.RoleAfter.Id,
-                GuildDiscordId = e.Guild.Id,
-                EventType = RoleEventType.Updated,
-                EventTimestampUtc = receivedAt,
-                ReceivedAtUtc = receivedAt,
-                RawEventJson = rawJson
-            };
-
-            if (e.RoleBefore.Name != e.RoleAfter.Name)
-            {
-                roleEvent.NameBefore = e.RoleBefore.Name;
-                roleEvent.NameAfter = e.RoleAfter.Name;
+                logger.LogError(ex, "Error handling role updated for RoleId={RoleId}", e.RoleAfter.Id);
+                using var failureScope = scopeFactory.CreateScope();
+                var failedEventService = failureScope.ServiceProvider.GetRequiredService<FailedEventService>();
+                await failedEventService.RecordFailureAsync(
+                    "GuildRoleUpdated", nameof(RoleEventHandler), ex,
+                    e.Guild?.Id, null, null, rawJson, correlationId: correlationId);
             }
-
-            if (e.RoleBefore.Color.Value != e.RoleAfter.Color.Value)
-            {
-                roleEvent.ColorBefore = e.RoleBefore.Color.Value;
-                roleEvent.ColorAfter = e.RoleAfter.Color.Value;
-            }
-
-            db.RoleEvents.Add(roleEvent);
-            await db.SaveChangesAsync();
-        }
-        catch (Exception ex)
-        {
-            logger.LogError(ex, "Error handling role updated for RoleId={RoleId}", e.RoleAfter.Id);
-            using var failureScope = scopeFactory.CreateScope();
-            var failedEventService = failureScope.ServiceProvider.GetRequiredService<FailedEventService>();
-            await failedEventService.RecordFailureAsync(
-                "GuildRoleUpdated", nameof(RoleEventHandler), ex,
-                e.Guild?.Id, null, null, rawJson);
         }
     }
 
     public async Task HandleEventAsync(DiscordClient sender, GuildRoleDeletedEventArgs e)
     {
-        string? rawJson = null;
-        try
+        var correlationId = Guid.NewGuid();
+        using (logger.BeginScope(new Dictionary<string, object> { ["CorrelationId"] = correlationId }))
         {
-            var receivedAt = DateTime.UtcNow;
-            using var scope = scopeFactory.CreateScope();
-            var db = scope.ServiceProvider.GetRequiredService<DiscordDbContext>();
-            var rawEventService = scope.ServiceProvider.GetRequiredService<RawEventLogService>();
-
-            rawJson = await rawEventService.SerializeAndLogAsync(
-                e, "GuildRoleDeleted", e.Guild.Id, null, null);
-
-            var roleEntity = await db.Roles
-                .FirstOrDefaultAsync(r => r.DiscordId == e.Role.Id);
-
-            if (roleEntity != null)
+            string? rawJson = null;
+            try
             {
-                roleEntity.IsDeleted = true;
-                roleEntity.DeletedAtUtc = receivedAt;
+                var receivedAt = DateTime.UtcNow;
+                using var scope = scopeFactory.CreateScope();
+                var db = scope.ServiceProvider.GetRequiredService<DiscordDbContext>();
+                var rawEventService = scope.ServiceProvider.GetRequiredService<RawEventLogService>();
+
+                rawJson = await rawEventService.SerializeAndLogAsync(
+                    e, "GuildRoleDeleted", e.Guild.Id, null, null, correlationId: correlationId);
+
+                var roleEntity = await db.Roles
+                    .FirstOrDefaultAsync(r => r.DiscordId == e.Role.Id);
+
+                if (roleEntity != null)
+                {
+                    roleEntity.IsDeleted = true;
+                    roleEntity.DeletedAtUtc = receivedAt;
+                }
+
+                var roleEvent = new RoleEventEntity
+                {
+                    RoleDiscordId = e.Role.Id,
+                    GuildDiscordId = e.Guild.Id,
+                    EventType = RoleEventType.Deleted,
+                    NameBefore = e.Role.Name,
+                    ColorBefore = e.Role.Color.Value,
+                    EventTimestampUtc = receivedAt,
+                    ReceivedAtUtc = receivedAt,
+                    RawEventJson = rawJson
+                };
+
+                db.RoleEvents.Add(roleEvent);
+                await db.SaveChangesAsync();
             }
-
-            var roleEvent = new RoleEventEntity
+            catch (Exception ex)
             {
-                RoleDiscordId = e.Role.Id,
-                GuildDiscordId = e.Guild.Id,
-                EventType = RoleEventType.Deleted,
-                NameBefore = e.Role.Name,
-                ColorBefore = e.Role.Color.Value,
-                EventTimestampUtc = receivedAt,
-                ReceivedAtUtc = receivedAt,
-                RawEventJson = rawJson
-            };
-
-            db.RoleEvents.Add(roleEvent);
-            await db.SaveChangesAsync();
-        }
-        catch (Exception ex)
-        {
-            logger.LogError(ex, "Error handling role deleted for RoleId={RoleId}", e.Role.Id);
-            using var failureScope = scopeFactory.CreateScope();
-            var failedEventService = failureScope.ServiceProvider.GetRequiredService<FailedEventService>();
-            await failedEventService.RecordFailureAsync(
-                "GuildRoleDeleted", nameof(RoleEventHandler), ex,
-                e.Guild?.Id, null, null, rawJson);
+                logger.LogError(ex, "Error handling role deleted for RoleId={RoleId}", e.Role.Id);
+                using var failureScope = scopeFactory.CreateScope();
+                var failedEventService = failureScope.ServiceProvider.GetRequiredService<FailedEventService>();
+                await failedEventService.RecordFailureAsync(
+                    "GuildRoleDeleted", nameof(RoleEventHandler), ex,
+                    e.Guild?.Id, null, null, rawJson, correlationId: correlationId);
+            }
         }
     }
 

--- a/src/DiscordEventService/Services/EventHandlers/ScheduledEventHandler.cs
+++ b/src/DiscordEventService/Services/EventHandlers/ScheduledEventHandler.cs
@@ -18,269 +18,293 @@ public class ScheduledEventHandler(IServiceScopeFactory scopeFactory, ILogger<Sc
 {
     public async Task HandleEventAsync(DiscordClient sender, ScheduledGuildEventCreatedEventArgs e)
     {
-        string? rawJson = null;
-        try
+        var correlationId = Guid.NewGuid();
+        using (logger.BeginScope(new Dictionary<string, object> { ["CorrelationId"] = correlationId }))
         {
-            var now = DateTime.UtcNow;
-            using var scope = scopeFactory.CreateScope();
-            var db = scope.ServiceProvider.GetRequiredService<DiscordDbContext>();
-            var rawEventService = scope.ServiceProvider.GetRequiredService<RawEventLogService>();
-
-            rawJson = await rawEventService.SerializeAndLogAsync(
-                e, "ScheduledGuildEventCreated", e.Guild.Id, e.Channel?.Id, e.Creator?.Id);
-
-            await UpsertScheduledEventAsync(db, e.Event, e.Creator?.Id);
-
-            var entity = new ScheduledEventEntity
+            string? rawJson = null;
+            try
             {
-                EventDiscordId = e.Event.Id,
-                GuildDiscordId = e.Guild.Id,
-                ChannelDiscordId = e.Channel?.Id,
-                CreatorDiscordId = e.Creator?.Id,
-                EventType = ScheduledEventEventType.Created,
-                Name = e.Event.Name,
-                Description = e.Event.Description,
-                Status = (int)e.Event.Status,
-                EntityType = (int)e.Event.Type,
-                ScheduledStartTime = e.Event.StartTime.UtcDateTime,
-                ScheduledEndTime = e.Event.EndTime?.UtcDateTime,
-                EventTimestampUtc = now,
-                ReceivedAtUtc = now,
-                RawEventJson = rawJson
-            };
+                var now = DateTime.UtcNow;
+                using var scope = scopeFactory.CreateScope();
+                var db = scope.ServiceProvider.GetRequiredService<DiscordDbContext>();
+                var rawEventService = scope.ServiceProvider.GetRequiredService<RawEventLogService>();
 
-            db.ScheduledEvents.Add(entity);
-            await db.SaveChangesAsync();
-        }
-        catch (Exception ex)
-        {
-            logger.LogError(ex, "Error handling scheduled event created");
-            using var failureScope = scopeFactory.CreateScope();
-            var failedEventService = failureScope.ServiceProvider.GetRequiredService<FailedEventService>();
-            await failedEventService.RecordFailureAsync(
-                "ScheduledGuildEventCreated", nameof(ScheduledEventHandler), ex,
-                e.Guild?.Id, e.Channel?.Id, e.Creator?.Id, rawJson);
+                rawJson = await rawEventService.SerializeAndLogAsync(
+                    e, "ScheduledGuildEventCreated", e.Guild.Id, e.Channel?.Id, e.Creator?.Id, correlationId: correlationId);
+
+                await UpsertScheduledEventAsync(db, e.Event, e.Creator?.Id);
+
+                var entity = new ScheduledEventEntity
+                {
+                    EventDiscordId = e.Event.Id,
+                    GuildDiscordId = e.Guild.Id,
+                    ChannelDiscordId = e.Channel?.Id,
+                    CreatorDiscordId = e.Creator?.Id,
+                    EventType = ScheduledEventEventType.Created,
+                    Name = e.Event.Name,
+                    Description = e.Event.Description,
+                    Status = (int)e.Event.Status,
+                    EntityType = (int)e.Event.Type,
+                    ScheduledStartTime = e.Event.StartTime.UtcDateTime,
+                    ScheduledEndTime = e.Event.EndTime?.UtcDateTime,
+                    EventTimestampUtc = now,
+                    ReceivedAtUtc = now,
+                    RawEventJson = rawJson
+                };
+
+                db.ScheduledEvents.Add(entity);
+                await db.SaveChangesAsync();
+            }
+            catch (Exception ex)
+            {
+                logger.LogError(ex, "Error handling scheduled event created");
+                using var failureScope = scopeFactory.CreateScope();
+                var failedEventService = failureScope.ServiceProvider.GetRequiredService<FailedEventService>();
+                await failedEventService.RecordFailureAsync(
+                    "ScheduledGuildEventCreated", nameof(ScheduledEventHandler), ex,
+                    e.Guild?.Id, e.Channel?.Id, e.Creator?.Id, rawJson, correlationId: correlationId);
+            }
         }
     }
 
     public async Task HandleEventAsync(DiscordClient sender, ScheduledGuildEventUpdatedEventArgs e)
     {
-        string? rawJson = null;
-        try
+        var correlationId = Guid.NewGuid();
+        using (logger.BeginScope(new Dictionary<string, object> { ["CorrelationId"] = correlationId }))
         {
-            var now = DateTime.UtcNow;
-            using var scope = scopeFactory.CreateScope();
-            var db = scope.ServiceProvider.GetRequiredService<DiscordDbContext>();
-            var rawEventService = scope.ServiceProvider.GetRequiredService<RawEventLogService>();
-
-            rawJson = await rawEventService.SerializeAndLogAsync(
-                e, "ScheduledGuildEventUpdated", e.EventAfter.GuildId, e.EventAfter.ChannelId, e.EventAfter.Creator?.Id);
-
-            await UpsertScheduledEventAsync(db, e.EventAfter, e.EventAfter.Creator?.Id);
-
-            var entity = new ScheduledEventEntity
+            string? rawJson = null;
+            try
             {
-                EventDiscordId = e.EventAfter.Id,
-                GuildDiscordId = e.EventAfter.GuildId,
-                ChannelDiscordId = e.EventAfter.ChannelId,
-                CreatorDiscordId = e.EventAfter.Creator?.Id,
-                EventType = ScheduledEventEventType.Updated,
-                Name = e.EventAfter.Name,
-                Description = e.EventAfter.Description,
-                Status = (int)e.EventAfter.Status,
-                EntityType = (int)e.EventAfter.Type,
-                ScheduledStartTime = e.EventAfter.StartTime.UtcDateTime,
-                ScheduledEndTime = e.EventAfter.EndTime?.UtcDateTime,
-                EventTimestampUtc = now,
-                ReceivedAtUtc = now,
-                RawEventJson = rawJson
-            };
+                var now = DateTime.UtcNow;
+                using var scope = scopeFactory.CreateScope();
+                var db = scope.ServiceProvider.GetRequiredService<DiscordDbContext>();
+                var rawEventService = scope.ServiceProvider.GetRequiredService<RawEventLogService>();
 
-            db.ScheduledEvents.Add(entity);
-            await db.SaveChangesAsync();
-        }
-        catch (Exception ex)
-        {
-            logger.LogError(ex, "Error handling scheduled event updated");
-            using var failureScope = scopeFactory.CreateScope();
-            var failedEventService = failureScope.ServiceProvider.GetRequiredService<FailedEventService>();
-            await failedEventService.RecordFailureAsync(
-                "ScheduledGuildEventUpdated", nameof(ScheduledEventHandler), ex,
-                e.EventAfter?.GuildId, e.EventAfter?.ChannelId, e.EventAfter?.Creator?.Id, rawJson);
+                rawJson = await rawEventService.SerializeAndLogAsync(
+                    e, "ScheduledGuildEventUpdated", e.EventAfter.GuildId, e.EventAfter.ChannelId, e.EventAfter.Creator?.Id, correlationId: correlationId);
+
+                await UpsertScheduledEventAsync(db, e.EventAfter, e.EventAfter.Creator?.Id);
+
+                var entity = new ScheduledEventEntity
+                {
+                    EventDiscordId = e.EventAfter.Id,
+                    GuildDiscordId = e.EventAfter.GuildId,
+                    ChannelDiscordId = e.EventAfter.ChannelId,
+                    CreatorDiscordId = e.EventAfter.Creator?.Id,
+                    EventType = ScheduledEventEventType.Updated,
+                    Name = e.EventAfter.Name,
+                    Description = e.EventAfter.Description,
+                    Status = (int)e.EventAfter.Status,
+                    EntityType = (int)e.EventAfter.Type,
+                    ScheduledStartTime = e.EventAfter.StartTime.UtcDateTime,
+                    ScheduledEndTime = e.EventAfter.EndTime?.UtcDateTime,
+                    EventTimestampUtc = now,
+                    ReceivedAtUtc = now,
+                    RawEventJson = rawJson
+                };
+
+                db.ScheduledEvents.Add(entity);
+                await db.SaveChangesAsync();
+            }
+            catch (Exception ex)
+            {
+                logger.LogError(ex, "Error handling scheduled event updated");
+                using var failureScope = scopeFactory.CreateScope();
+                var failedEventService = failureScope.ServiceProvider.GetRequiredService<FailedEventService>();
+                await failedEventService.RecordFailureAsync(
+                    "ScheduledGuildEventUpdated", nameof(ScheduledEventHandler), ex,
+                    e.EventAfter?.GuildId, e.EventAfter?.ChannelId, e.EventAfter?.Creator?.Id, rawJson, correlationId: correlationId);
+            }
         }
     }
 
     public async Task HandleEventAsync(DiscordClient sender, ScheduledGuildEventDeletedEventArgs e)
     {
-        string? rawJson = null;
-        try
+        var correlationId = Guid.NewGuid();
+        using (logger.BeginScope(new Dictionary<string, object> { ["CorrelationId"] = correlationId }))
         {
-            var now = DateTime.UtcNow;
-            using var scope = scopeFactory.CreateScope();
-            var db = scope.ServiceProvider.GetRequiredService<DiscordDbContext>();
-            var rawEventService = scope.ServiceProvider.GetRequiredService<RawEventLogService>();
-
-            rawJson = await rawEventService.SerializeAndLogAsync(
-                e, "ScheduledGuildEventDeleted", e.Event.GuildId, e.Event.ChannelId, null);
-
-            // Mark as deleted
-            await db.GuildScheduledEvents
-                .Where(s => s.DiscordId == e.Event.Id)
-                .ExecuteUpdateAsync(s => s
-                    .SetProperty(x => x.IsDeleted, true)
-                    .SetProperty(x => x.DeletedAtUtc, (DateTime?)now));
-
-            var entity = new ScheduledEventEntity
+            string? rawJson = null;
+            try
             {
-                EventDiscordId = e.Event.Id,
-                GuildDiscordId = e.Event.GuildId,
-                ChannelDiscordId = e.Event.ChannelId,
-                EventType = ScheduledEventEventType.Deleted,
-                Name = e.Event.Name,
-                EventTimestampUtc = now,
-                ReceivedAtUtc = now,
-                RawEventJson = rawJson
-            };
+                var now = DateTime.UtcNow;
+                using var scope = scopeFactory.CreateScope();
+                var db = scope.ServiceProvider.GetRequiredService<DiscordDbContext>();
+                var rawEventService = scope.ServiceProvider.GetRequiredService<RawEventLogService>();
 
-            db.ScheduledEvents.Add(entity);
-            await db.SaveChangesAsync();
-        }
-        catch (Exception ex)
-        {
-            logger.LogError(ex, "Error handling scheduled event deleted");
-            using var failureScope = scopeFactory.CreateScope();
-            var failedEventService = failureScope.ServiceProvider.GetRequiredService<FailedEventService>();
-            await failedEventService.RecordFailureAsync(
-                "ScheduledGuildEventDeleted", nameof(ScheduledEventHandler), ex,
-                e.Event?.GuildId, e.Event?.ChannelId, null, rawJson);
+                rawJson = await rawEventService.SerializeAndLogAsync(
+                    e, "ScheduledGuildEventDeleted", e.Event.GuildId, e.Event.ChannelId, null, correlationId: correlationId);
+
+                // Mark as deleted
+                await db.GuildScheduledEvents
+                    .Where(s => s.DiscordId == e.Event.Id)
+                    .ExecuteUpdateAsync(s => s
+                        .SetProperty(x => x.IsDeleted, true)
+                        .SetProperty(x => x.DeletedAtUtc, (DateTime?)now));
+
+                var entity = new ScheduledEventEntity
+                {
+                    EventDiscordId = e.Event.Id,
+                    GuildDiscordId = e.Event.GuildId,
+                    ChannelDiscordId = e.Event.ChannelId,
+                    EventType = ScheduledEventEventType.Deleted,
+                    Name = e.Event.Name,
+                    EventTimestampUtc = now,
+                    ReceivedAtUtc = now,
+                    RawEventJson = rawJson
+                };
+
+                db.ScheduledEvents.Add(entity);
+                await db.SaveChangesAsync();
+            }
+            catch (Exception ex)
+            {
+                logger.LogError(ex, "Error handling scheduled event deleted");
+                using var failureScope = scopeFactory.CreateScope();
+                var failedEventService = failureScope.ServiceProvider.GetRequiredService<FailedEventService>();
+                await failedEventService.RecordFailureAsync(
+                    "ScheduledGuildEventDeleted", nameof(ScheduledEventHandler), ex,
+                    e.Event?.GuildId, e.Event?.ChannelId, null, rawJson, correlationId: correlationId);
+            }
         }
     }
 
     public async Task HandleEventAsync(DiscordClient sender, ScheduledGuildEventCompletedEventArgs e)
     {
-        string? rawJson = null;
-        try
+        var correlationId = Guid.NewGuid();
+        using (logger.BeginScope(new Dictionary<string, object> { ["CorrelationId"] = correlationId }))
         {
-            var now = DateTime.UtcNow;
-            using var scope = scopeFactory.CreateScope();
-            var db = scope.ServiceProvider.GetRequiredService<DiscordDbContext>();
-            var rawEventService = scope.ServiceProvider.GetRequiredService<RawEventLogService>();
-
-            rawJson = await rawEventService.SerializeAndLogAsync(
-                e, "ScheduledGuildEventCompleted", e.Event.GuildId, e.Event.ChannelId, null);
-
-            await UpsertScheduledEventAsync(db, e.Event, e.Event.Creator?.Id);
-
-            var entity = new ScheduledEventEntity
+            string? rawJson = null;
+            try
             {
-                EventDiscordId = e.Event.Id,
-                GuildDiscordId = e.Event.GuildId,
-                ChannelDiscordId = e.Event.ChannelId,
-                EventType = ScheduledEventEventType.Completed,
-                Name = e.Event.Name,
-                Status = (int)e.Event.Status,
-                EventTimestampUtc = now,
-                ReceivedAtUtc = now,
-                RawEventJson = rawJson
-            };
+                var now = DateTime.UtcNow;
+                using var scope = scopeFactory.CreateScope();
+                var db = scope.ServiceProvider.GetRequiredService<DiscordDbContext>();
+                var rawEventService = scope.ServiceProvider.GetRequiredService<RawEventLogService>();
 
-            db.ScheduledEvents.Add(entity);
-            await db.SaveChangesAsync();
-        }
-        catch (Exception ex)
-        {
-            logger.LogError(ex, "Error handling scheduled event completed");
-            using var failureScope = scopeFactory.CreateScope();
-            var failedEventService = failureScope.ServiceProvider.GetRequiredService<FailedEventService>();
-            await failedEventService.RecordFailureAsync(
-                "ScheduledGuildEventCompleted", nameof(ScheduledEventHandler), ex,
-                e.Event?.GuildId, e.Event?.ChannelId, null, rawJson);
+                rawJson = await rawEventService.SerializeAndLogAsync(
+                    e, "ScheduledGuildEventCompleted", e.Event.GuildId, e.Event.ChannelId, null, correlationId: correlationId);
+
+                await UpsertScheduledEventAsync(db, e.Event, e.Event.Creator?.Id);
+
+                var entity = new ScheduledEventEntity
+                {
+                    EventDiscordId = e.Event.Id,
+                    GuildDiscordId = e.Event.GuildId,
+                    ChannelDiscordId = e.Event.ChannelId,
+                    EventType = ScheduledEventEventType.Completed,
+                    Name = e.Event.Name,
+                    Status = (int)e.Event.Status,
+                    EventTimestampUtc = now,
+                    ReceivedAtUtc = now,
+                    RawEventJson = rawJson
+                };
+
+                db.ScheduledEvents.Add(entity);
+                await db.SaveChangesAsync();
+            }
+            catch (Exception ex)
+            {
+                logger.LogError(ex, "Error handling scheduled event completed");
+                using var failureScope = scopeFactory.CreateScope();
+                var failedEventService = failureScope.ServiceProvider.GetRequiredService<FailedEventService>();
+                await failedEventService.RecordFailureAsync(
+                    "ScheduledGuildEventCompleted", nameof(ScheduledEventHandler), ex,
+                    e.Event?.GuildId, e.Event?.ChannelId, null, rawJson, correlationId: correlationId);
+            }
         }
     }
 
     public async Task HandleEventAsync(DiscordClient sender, ScheduledGuildEventUserAddedEventArgs e)
     {
-        string? rawJson = null;
-        try
+        var correlationId = Guid.NewGuid();
+        using (logger.BeginScope(new Dictionary<string, object> { ["CorrelationId"] = correlationId }))
         {
-            var now = DateTime.UtcNow;
-            using var scope = scopeFactory.CreateScope();
-            var db = scope.ServiceProvider.GetRequiredService<DiscordDbContext>();
-            var rawEventService = scope.ServiceProvider.GetRequiredService<RawEventLogService>();
-
-            rawJson = await rawEventService.SerializeAndLogAsync(
-                e, "ScheduledGuildEventUserAdded", e.Guild.Id, null, e.User.Id);
-
-            // Increment user count
-            await db.GuildScheduledEvents
-                .Where(s => s.DiscordId == e.Event.Id)
-                .ExecuteUpdateAsync(s => s.SetProperty(x => x.UserCount, x => x.UserCount + 1));
-
-            var entity = new ScheduledEventEntity
+            string? rawJson = null;
+            try
             {
-                EventDiscordId = e.Event.Id,
-                GuildDiscordId = e.Guild.Id,
-                EventType = ScheduledEventEventType.UserAdded,
-                UserDiscordId = e.User.Id,
-                EventTimestampUtc = now,
-                ReceivedAtUtc = now,
-                RawEventJson = rawJson
-            };
+                var now = DateTime.UtcNow;
+                using var scope = scopeFactory.CreateScope();
+                var db = scope.ServiceProvider.GetRequiredService<DiscordDbContext>();
+                var rawEventService = scope.ServiceProvider.GetRequiredService<RawEventLogService>();
 
-            db.ScheduledEvents.Add(entity);
-            await db.SaveChangesAsync();
-        }
-        catch (Exception ex)
-        {
-            logger.LogError(ex, "Error handling scheduled event user added");
-            using var failureScope = scopeFactory.CreateScope();
-            var failedEventService = failureScope.ServiceProvider.GetRequiredService<FailedEventService>();
-            await failedEventService.RecordFailureAsync(
-                "ScheduledGuildEventUserAdded", nameof(ScheduledEventHandler), ex,
-                e.Guild?.Id, null, e.User?.Id, rawJson);
+                rawJson = await rawEventService.SerializeAndLogAsync(
+                    e, "ScheduledGuildEventUserAdded", e.Guild.Id, null, e.User.Id, correlationId: correlationId);
+
+                // Increment user count
+                await db.GuildScheduledEvents
+                    .Where(s => s.DiscordId == e.Event.Id)
+                    .ExecuteUpdateAsync(s => s.SetProperty(x => x.UserCount, x => x.UserCount + 1));
+
+                var entity = new ScheduledEventEntity
+                {
+                    EventDiscordId = e.Event.Id,
+                    GuildDiscordId = e.Guild.Id,
+                    EventType = ScheduledEventEventType.UserAdded,
+                    UserDiscordId = e.User.Id,
+                    EventTimestampUtc = now,
+                    ReceivedAtUtc = now,
+                    RawEventJson = rawJson
+                };
+
+                db.ScheduledEvents.Add(entity);
+                await db.SaveChangesAsync();
+            }
+            catch (Exception ex)
+            {
+                logger.LogError(ex, "Error handling scheduled event user added");
+                using var failureScope = scopeFactory.CreateScope();
+                var failedEventService = failureScope.ServiceProvider.GetRequiredService<FailedEventService>();
+                await failedEventService.RecordFailureAsync(
+                    "ScheduledGuildEventUserAdded", nameof(ScheduledEventHandler), ex,
+                    e.Guild?.Id, null, e.User?.Id, rawJson, correlationId: correlationId);
+            }
         }
     }
 
     public async Task HandleEventAsync(DiscordClient sender, ScheduledGuildEventUserRemovedEventArgs e)
     {
-        string? rawJson = null;
-        try
+        var correlationId = Guid.NewGuid();
+        using (logger.BeginScope(new Dictionary<string, object> { ["CorrelationId"] = correlationId }))
         {
-            var now = DateTime.UtcNow;
-            using var scope = scopeFactory.CreateScope();
-            var db = scope.ServiceProvider.GetRequiredService<DiscordDbContext>();
-            var rawEventService = scope.ServiceProvider.GetRequiredService<RawEventLogService>();
-
-            rawJson = await rawEventService.SerializeAndLogAsync(
-                e, "ScheduledGuildEventUserRemoved", e.Guild.Id, null, e.User.Id);
-
-            // Decrement user count
-            await db.GuildScheduledEvents
-                .Where(s => s.DiscordId == e.Event.Id)
-                .ExecuteUpdateAsync(s => s.SetProperty(x => x.UserCount, x => x.UserCount - 1));
-
-            var entity = new ScheduledEventEntity
+            string? rawJson = null;
+            try
             {
-                EventDiscordId = e.Event.Id,
-                GuildDiscordId = e.Guild.Id,
-                EventType = ScheduledEventEventType.UserRemoved,
-                UserDiscordId = e.User.Id,
-                EventTimestampUtc = now,
-                ReceivedAtUtc = now,
-                RawEventJson = rawJson
-            };
+                var now = DateTime.UtcNow;
+                using var scope = scopeFactory.CreateScope();
+                var db = scope.ServiceProvider.GetRequiredService<DiscordDbContext>();
+                var rawEventService = scope.ServiceProvider.GetRequiredService<RawEventLogService>();
 
-            db.ScheduledEvents.Add(entity);
-            await db.SaveChangesAsync();
-        }
-        catch (Exception ex)
-        {
-            logger.LogError(ex, "Error handling scheduled event user removed");
-            using var failureScope = scopeFactory.CreateScope();
-            var failedEventService = failureScope.ServiceProvider.GetRequiredService<FailedEventService>();
-            await failedEventService.RecordFailureAsync(
-                "ScheduledGuildEventUserRemoved", nameof(ScheduledEventHandler), ex,
-                e.Guild?.Id, null, e.User?.Id, rawJson);
+                rawJson = await rawEventService.SerializeAndLogAsync(
+                    e, "ScheduledGuildEventUserRemoved", e.Guild.Id, null, e.User.Id, correlationId: correlationId);
+
+                // Decrement user count
+                await db.GuildScheduledEvents
+                    .Where(s => s.DiscordId == e.Event.Id)
+                    .ExecuteUpdateAsync(s => s.SetProperty(x => x.UserCount, x => x.UserCount - 1));
+
+                var entity = new ScheduledEventEntity
+                {
+                    EventDiscordId = e.Event.Id,
+                    GuildDiscordId = e.Guild.Id,
+                    EventType = ScheduledEventEventType.UserRemoved,
+                    UserDiscordId = e.User.Id,
+                    EventTimestampUtc = now,
+                    ReceivedAtUtc = now,
+                    RawEventJson = rawJson
+                };
+
+                db.ScheduledEvents.Add(entity);
+                await db.SaveChangesAsync();
+            }
+            catch (Exception ex)
+            {
+                logger.LogError(ex, "Error handling scheduled event user removed");
+                using var failureScope = scopeFactory.CreateScope();
+                var failedEventService = failureScope.ServiceProvider.GetRequiredService<FailedEventService>();
+                await failedEventService.RecordFailureAsync(
+                    "ScheduledGuildEventUserRemoved", nameof(ScheduledEventHandler), ex,
+                    e.Guild?.Id, null, e.User?.Id, rawJson, correlationId: correlationId);
+            }
         }
     }
 

--- a/src/DiscordEventService/Services/EventHandlers/SocketLifecycleHandler.cs
+++ b/src/DiscordEventService/Services/EventHandlers/SocketLifecycleHandler.cs
@@ -24,133 +24,145 @@ public class SocketLifecycleHandler(
 
     public async Task HandleEventAsync(DiscordClient sender, SocketClosedEventArgs e)
     {
-        try
+        var correlationId = Guid.NewGuid();
+        using (logger.BeginScope(new Dictionary<string, object> { ["CorrelationId"] = correlationId }))
         {
-            using var scope = scopeFactory.CreateScope();
-            var tracker = scope.ServiceProvider.GetRequiredService<DowntimeTrackerService>();
-            await tracker.OpenDowntimeAsync(
-                BotDowntimeType.GatewayDisconnect,
-                BotDowntimeDetectionMethod.GatewayEvent,
-                $"socket closed: code={e.CloseCode} message={e.CloseMessage}");
-        }
-        catch (Exception ex)
-        {
-            logger.LogError(ex, "Failed to open downtime row on SocketClosed (code={CloseCode})", e.CloseCode);
+            try
+            {
+                using var scope = scopeFactory.CreateScope();
+                var tracker = scope.ServiceProvider.GetRequiredService<DowntimeTrackerService>();
+                await tracker.OpenDowntimeAsync(
+                    BotDowntimeType.GatewayDisconnect,
+                    BotDowntimeDetectionMethod.GatewayEvent,
+                    $"socket closed: code={e.CloseCode} message={e.CloseMessage}");
+            }
+            catch (Exception ex)
+            {
+                logger.LogError(ex, "Failed to open downtime row on SocketClosed (code={CloseCode})", e.CloseCode);
+            }
         }
     }
 
     public async Task HandleEventAsync(DiscordClient sender, SessionResumedEventArgs e)
     {
-        try
+        var correlationId = Guid.NewGuid();
+        using (logger.BeginScope(new Dictionary<string, object> { ["CorrelationId"] = correlationId }))
         {
-            using var scope = scopeFactory.CreateScope();
-            var tracker = scope.ServiceProvider.GetRequiredService<DowntimeTrackerService>();
-            // Scope to GatewayDisconnect so a routine resume doesn't clobber a
-            // manually-opened Deploy/HostDown row from the ops endpoint.
-            await tracker.CloseOpenDowntimeAsync(DateTime.UtcNow, onlyType: BotDowntimeType.GatewayDisconnect);
-        }
-        catch (Exception ex)
-        {
-            logger.LogError(ex, "Failed to close downtime row on SessionResumed");
+            try
+            {
+                using var scope = scopeFactory.CreateScope();
+                var tracker = scope.ServiceProvider.GetRequiredService<DowntimeTrackerService>();
+                // Scope to GatewayDisconnect so a routine resume doesn't clobber a
+                // manually-opened Deploy/HostDown row from the ops endpoint.
+                await tracker.CloseOpenDowntimeAsync(DateTime.UtcNow, onlyType: BotDowntimeType.GatewayDisconnect);
+            }
+            catch (Exception ex)
+            {
+                logger.LogError(ex, "Failed to close downtime row on SessionResumed");
+            }
         }
     }
 
     public async Task HandleEventAsync(DiscordClient sender, GuildDownloadCompletedEventArgs e)
     {
-        // Cold connect (Ready → guild download complete). Events that happened
-        // while we were disconnected are NOT replayed by Discord, so we need to
-        // backfill messages/reactions across the gap. Resume-paths (warm
-        // reconnect) hit SessionResumed instead and don't reach here.
-        try
+        var correlationId = Guid.NewGuid();
+        using (logger.BeginScope(new Dictionary<string, object> { ["CorrelationId"] = correlationId }))
         {
-            using var scope = scopeFactory.CreateScope();
-            var db = scope.ServiceProvider.GetRequiredService<DiscordDbContext>();
-            var orchestrator = scope.ServiceProvider.GetRequiredService<GuildBackfillOrchestrator>();
-            var tracker = scope.ServiceProvider.GetRequiredService<DowntimeTrackerService>();
-
-            // Ready can fire without a preceding Resumed (session invalidated).
-            await tracker.CloseOpenDowntimeAsync(DateTime.UtcNow, onlyType: BotDowntimeType.GatewayDisconnect);
-
-            // The just-closed downtime row's StartedAtUtc is the authoritative
-            // gap start. Reading heartbeats or raw_event_logs here would race
-            // the post-reconnect data — by now AllShardsConnected is true, the
-            // 5s heartbeat may already have written an IsGatewayConnected=true
-            // row, and DSharpPlus has started dispatching events. Both signals
-            // would show fresh timestamps that mask the real gap.
-            //
-            // The closed row covers every downtime classification:
-            // SocketClosed wrote a GatewayDisconnect (in-process session
-            // invalidation); StopAsync wrote a GracefulShutdown/Deploy
-            // (bot restart); InferStartupGapAsync wrote an Inferred
-            // (hard crash / power loss).
-            var mostRecentGapStart = await db.BotDowntimeIntervals
-                .Where(x => x.EndedAtUtc != null)
-                .OrderByDescending(x => x.EndedAtUtc)
-                .Select(x => (DateTime?)x.StartedAtUtc)
-                .FirstOrDefaultAsync();
-
-            // Fall back to the heartbeat-based heuristic only when no downtime
-            // row exists at all (very first run, no prior shutdown). The
-            // IsGatewayConnected==true filter inside GetLastAliveAtUtcAsync
-            // keeps this conservative even in the fallback case.
-            var lastAlive = mostRecentGapStart
-                ?? (await tracker.GetLastAliveAtUtcAsync()).LastAliveUtc;
-            if (lastAlive is null)
+            // Cold connect (Ready → guild download complete). Events that happened
+            // while we were disconnected are NOT replayed by Discord, so we need to
+            // backfill messages/reactions across the gap. Resume-paths (warm
+            // reconnect) hit SessionResumed instead and don't reach here.
+            try
             {
-                logger.LogInformation("GuildDownloadCompleted: no prior signal, skipping backfill (first run)");
-                return;
-            }
+                using var scope = scopeFactory.CreateScope();
+                var db = scope.ServiceProvider.GetRequiredService<DiscordDbContext>();
+                var orchestrator = scope.ServiceProvider.GetRequiredService<GuildBackfillOrchestrator>();
+                var tracker = scope.ServiceProvider.GetRequiredService<DowntimeTrackerService>();
 
-            var now = DateTime.UtcNow;
-            var gap = now - lastAlive.Value;
-            if (gap < ReconnectGapThreshold)
-            {
-                logger.LogInformation(
-                    "GuildDownloadCompleted: gap {Gap:c} below threshold, running quick-sync only",
-                    gap);
-                foreach (var guildId in e.Guilds.Keys)
+                // Ready can fire without a preceding Resumed (session invalidated).
+                await tracker.CloseOpenDowntimeAsync(DateTime.UtcNow, onlyType: BotDowntimeType.GatewayDisconnect);
+
+                // The just-closed downtime row's StartedAtUtc is the authoritative
+                // gap start. Reading heartbeats or raw_event_logs here would race
+                // the post-reconnect data — by now AllShardsConnected is true, the
+                // 5s heartbeat may already have written an IsGatewayConnected=true
+                // row, and DSharpPlus has started dispatching events. Both signals
+                // would show fresh timestamps that mask the real gap.
+                //
+                // The closed row covers every downtime classification:
+                // SocketClosed wrote a GatewayDisconnect (in-process session
+                // invalidation); StopAsync wrote a GracefulShutdown/Deploy
+                // (bot restart); InferStartupGapAsync wrote an Inferred
+                // (hard crash / power loss).
+                var mostRecentGapStart = await db.BotDowntimeIntervals
+                    .Where(x => x.EndedAtUtc != null)
+                    .OrderByDescending(x => x.EndedAtUtc)
+                    .Select(x => (DateTime?)x.StartedAtUtc)
+                    .FirstOrDefaultAsync();
+
+                // Fall back to the heartbeat-based heuristic only when no downtime
+                // row exists at all (very first run, no prior shutdown). The
+                // IsGatewayConnected==true filter inside GetLastAliveAtUtcAsync
+                // keeps this conservative even in the fallback case.
+                var lastAlive = mostRecentGapStart
+                    ?? (await tracker.GetLastAliveAtUtcAsync()).LastAliveUtc;
+                if (lastAlive is null)
                 {
-                    await quickSyncService.SyncAsync(guildId);
+                    logger.LogInformation("GuildDownloadCompleted: no prior signal, skipping backfill (first run)");
+                    return;
                 }
-                return;
-            }
 
-            var earliestAllowed = now - MaxReconnectBackfillWindow;
-            var afterTimestamp = lastAlive.Value - ReconnectBackfillBuffer;
-            if (afterTimestamp < earliestAllowed)
-            {
-                logger.LogInformation(
-                    "Reconnect backfill window capped to {Window} (gap was {Gap:c}, capped from {Original:O} to {Capped:O})",
-                    MaxReconnectBackfillWindow, gap, afterTimestamp, earliestAllowed);
-                afterTimestamp = earliestAllowed;
-            }
-
-            var inProgressGuilds = await db.BackfillCheckpoints
-                .Where(c => c.Status == BackfillStatus.InProgress)
-                .Select(c => c.GuildDiscordId)
-                .Distinct()
-                .ToListAsync();
-            var inProgressSet = inProgressGuilds.ToHashSet();
-
-            foreach (var guildId in e.Guilds.Keys)
-            {
-                if (inProgressSet.Contains(guildId))
+                var now = DateTime.UtcNow;
+                var gap = now - lastAlive.Value;
+                if (gap < ReconnectGapThreshold)
                 {
                     logger.LogInformation(
-                        "Reconnect backfill skipped for guild {GuildId}: backfill already in progress",
-                        guildId);
-                    continue;
+                        "GuildDownloadCompleted: gap {Gap:c} below threshold, running quick-sync only",
+                        gap);
+                    foreach (var guildId in e.Guilds.Keys)
+                    {
+                        await quickSyncService.SyncAsync(guildId);
+                    }
+                    return;
                 }
 
-                logger.LogInformation(
-                    "Reconnect backfill enqueued for guild {GuildId} after gap {Gap:c} (afterTimestampUtc={After:O})",
-                    guildId, gap, afterTimestamp);
-                orchestrator.EnqueueBackfillFrom(guildId, afterTimestamp);
+                var earliestAllowed = now - MaxReconnectBackfillWindow;
+                var afterTimestamp = lastAlive.Value - ReconnectBackfillBuffer;
+                if (afterTimestamp < earliestAllowed)
+                {
+                    logger.LogInformation(
+                        "Reconnect backfill window capped to {Window} (gap was {Gap:c}, capped from {Original:O} to {Capped:O})",
+                        MaxReconnectBackfillWindow, gap, afterTimestamp, earliestAllowed);
+                    afterTimestamp = earliestAllowed;
+                }
+
+                var inProgressGuilds = await db.BackfillCheckpoints
+                    .Where(c => c.Status == BackfillStatus.InProgress)
+                    .Select(c => c.GuildDiscordId)
+                    .Distinct()
+                    .ToListAsync();
+                var inProgressSet = inProgressGuilds.ToHashSet();
+
+                foreach (var guildId in e.Guilds.Keys)
+                {
+                    if (inProgressSet.Contains(guildId))
+                    {
+                        logger.LogInformation(
+                            "Reconnect backfill skipped for guild {GuildId}: backfill already in progress",
+                            guildId);
+                        continue;
+                    }
+
+                    logger.LogInformation(
+                        "Reconnect backfill enqueued for guild {GuildId} after gap {Gap:c} (afterTimestampUtc={After:O})",
+                        guildId, gap, afterTimestamp);
+                    orchestrator.EnqueueBackfillFrom(guildId, afterTimestamp);
+                }
             }
-        }
-        catch (Exception ex)
-        {
-            logger.LogError(ex, "Failed to enqueue reconnect backfill on GuildDownloadCompleted");
+            catch (Exception ex)
+            {
+                logger.LogError(ex, "Failed to enqueue reconnect backfill on GuildDownloadCompleted");
+            }
         }
     }
 }

--- a/src/DiscordEventService/Services/EventHandlers/StageInstanceEventHandler.cs
+++ b/src/DiscordEventService/Services/EventHandlers/StageInstanceEventHandler.cs
@@ -14,145 +14,157 @@ public class StageInstanceEventHandler(IServiceScopeFactory scopeFactory, ILogge
 {
     public async Task HandleEventAsync(DiscordClient sender, StageInstanceCreatedEventArgs e)
     {
-        string? rawJson = null;
-        try
+        var correlationId = Guid.NewGuid();
+        using (logger.BeginScope(new Dictionary<string, object> { ["CorrelationId"] = correlationId }))
         {
-            var now = DateTime.UtcNow;
-            using var scope = scopeFactory.CreateScope();
-            var db = scope.ServiceProvider.GetRequiredService<DiscordDbContext>();
-            var rawEventService = scope.ServiceProvider.GetRequiredService<RawEventLogService>();
-
-            rawJson = await rawEventService.SerializeAndLogAsync(
-                e, "StageInstanceCreated", e.StageInstance.GuildId, e.StageInstance.ChannelId, null);
-
-            // Look up Guid FKs
-            var guild = await db.Guilds.FirstOrDefaultAsync(g => g.DiscordId == e.StageInstance.GuildId);
-            var channel = await db.Channels.FirstOrDefaultAsync(c => c.DiscordId == e.StageInstance.ChannelId);
-
-            db.StageInstances.Add(new StageInstanceEntity
+            string? rawJson = null;
+            try
             {
-                DiscordId = e.StageInstance.Id,
-                GuildId = guild?.Id ?? Guid.Empty,
-                ChannelId = channel?.Id ?? Guid.Empty,
-                Topic = e.StageInstance.Topic,
-                PrivacyLevel = (int)e.StageInstance.PrivacyLevel
-            });
+                var now = DateTime.UtcNow;
+                using var scope = scopeFactory.CreateScope();
+                var db = scope.ServiceProvider.GetRequiredService<DiscordDbContext>();
+                var rawEventService = scope.ServiceProvider.GetRequiredService<RawEventLogService>();
 
-            db.StageInstanceEvents.Add(new StageInstanceEventEntity
+                rawJson = await rawEventService.SerializeAndLogAsync(
+                    e, "StageInstanceCreated", e.StageInstance.GuildId, e.StageInstance.ChannelId, null, correlationId: correlationId);
+
+                // Look up Guid FKs
+                var guild = await db.Guilds.FirstOrDefaultAsync(g => g.DiscordId == e.StageInstance.GuildId);
+                var channel = await db.Channels.FirstOrDefaultAsync(c => c.DiscordId == e.StageInstance.ChannelId);
+
+                db.StageInstances.Add(new StageInstanceEntity
+                {
+                    DiscordId = e.StageInstance.Id,
+                    GuildId = guild?.Id ?? Guid.Empty,
+                    ChannelId = channel?.Id ?? Guid.Empty,
+                    Topic = e.StageInstance.Topic,
+                    PrivacyLevel = (int)e.StageInstance.PrivacyLevel
+                });
+
+                db.StageInstanceEvents.Add(new StageInstanceEventEntity
+                {
+                    StageInstanceDiscordId = e.StageInstance.Id,
+                    GuildDiscordId = e.StageInstance.GuildId,
+                    ChannelDiscordId = e.StageInstance.ChannelId,
+                    EventType = StageInstanceEventType.Created,
+                    TopicAfter = e.StageInstance.Topic,
+                    PrivacyLevelAfter = (int)e.StageInstance.PrivacyLevel,
+                    EventTimestampUtc = now,
+                    ReceivedAtUtc = now,
+                    RawEventJson = rawJson
+                });
+
+                await db.SaveChangesAsync();
+            }
+            catch (Exception ex)
             {
-                StageInstanceDiscordId = e.StageInstance.Id,
-                GuildDiscordId = e.StageInstance.GuildId,
-                ChannelDiscordId = e.StageInstance.ChannelId,
-                EventType = StageInstanceEventType.Created,
-                TopicAfter = e.StageInstance.Topic,
-                PrivacyLevelAfter = (int)e.StageInstance.PrivacyLevel,
-                EventTimestampUtc = now,
-                ReceivedAtUtc = now,
-                RawEventJson = rawJson
-            });
-
-            await db.SaveChangesAsync();
-        }
-        catch (Exception ex)
-        {
-            logger.LogError(ex, "Error handling stage instance created");
-            using var failureScope = scopeFactory.CreateScope();
-            var failedEventService = failureScope.ServiceProvider.GetRequiredService<FailedEventService>();
-            await failedEventService.RecordFailureAsync(
-                "StageInstanceCreated", nameof(StageInstanceEventHandler), ex,
-                e.StageInstance?.GuildId, e.StageInstance?.ChannelId, null, rawJson);
+                logger.LogError(ex, "Error handling stage instance created");
+                using var failureScope = scopeFactory.CreateScope();
+                var failedEventService = failureScope.ServiceProvider.GetRequiredService<FailedEventService>();
+                await failedEventService.RecordFailureAsync(
+                    "StageInstanceCreated", nameof(StageInstanceEventHandler), ex,
+                    e.StageInstance?.GuildId, e.StageInstance?.ChannelId, null, rawJson, correlationId: correlationId);
+            }
         }
     }
 
     public async Task HandleEventAsync(DiscordClient sender, StageInstanceUpdatedEventArgs e)
     {
-        string? rawJson = null;
-        try
+        var correlationId = Guid.NewGuid();
+        using (logger.BeginScope(new Dictionary<string, object> { ["CorrelationId"] = correlationId }))
         {
-            var now = DateTime.UtcNow;
-            using var scope = scopeFactory.CreateScope();
-            var db = scope.ServiceProvider.GetRequiredService<DiscordDbContext>();
-            var rawEventService = scope.ServiceProvider.GetRequiredService<RawEventLogService>();
-
-            rawJson = await rawEventService.SerializeAndLogAsync(
-                e, "StageInstanceUpdated", e.StageInstanceAfter.GuildId, e.StageInstanceAfter.ChannelId, null);
-
-            await db.StageInstances
-                .Where(s => s.DiscordId == e.StageInstanceAfter.Id)
-                .ExecuteUpdateAsync(s => s
-                    .SetProperty(st => st.Topic, e.StageInstanceAfter.Topic)
-                    .SetProperty(st => st.PrivacyLevel, (int)e.StageInstanceAfter.PrivacyLevel));
-
-            db.StageInstanceEvents.Add(new StageInstanceEventEntity
+            string? rawJson = null;
+            try
             {
-                StageInstanceDiscordId = e.StageInstanceAfter.Id,
-                GuildDiscordId = e.StageInstanceAfter.GuildId,
-                ChannelDiscordId = e.StageInstanceAfter.ChannelId,
-                EventType = StageInstanceEventType.Updated,
-                TopicBefore = e.StageInstanceBefore?.Topic,
-                TopicAfter = e.StageInstanceAfter.Topic,
-                PrivacyLevelBefore = e.StageInstanceBefore != null ? (int)e.StageInstanceBefore.PrivacyLevel : null,
-                PrivacyLevelAfter = (int)e.StageInstanceAfter.PrivacyLevel,
-                EventTimestampUtc = now,
-                ReceivedAtUtc = now,
-                RawEventJson = rawJson
-            });
+                var now = DateTime.UtcNow;
+                using var scope = scopeFactory.CreateScope();
+                var db = scope.ServiceProvider.GetRequiredService<DiscordDbContext>();
+                var rawEventService = scope.ServiceProvider.GetRequiredService<RawEventLogService>();
 
-            await db.SaveChangesAsync();
-        }
-        catch (Exception ex)
-        {
-            logger.LogError(ex, "Error handling stage instance updated");
-            using var failureScope = scopeFactory.CreateScope();
-            var failedEventService = failureScope.ServiceProvider.GetRequiredService<FailedEventService>();
-            await failedEventService.RecordFailureAsync(
-                "StageInstanceUpdated", nameof(StageInstanceEventHandler), ex,
-                e.StageInstanceAfter?.GuildId, e.StageInstanceAfter?.ChannelId, null, rawJson);
+                rawJson = await rawEventService.SerializeAndLogAsync(
+                    e, "StageInstanceUpdated", e.StageInstanceAfter.GuildId, e.StageInstanceAfter.ChannelId, null, correlationId: correlationId);
+
+                await db.StageInstances
+                    .Where(s => s.DiscordId == e.StageInstanceAfter.Id)
+                    .ExecuteUpdateAsync(s => s
+                        .SetProperty(st => st.Topic, e.StageInstanceAfter.Topic)
+                        .SetProperty(st => st.PrivacyLevel, (int)e.StageInstanceAfter.PrivacyLevel));
+
+                db.StageInstanceEvents.Add(new StageInstanceEventEntity
+                {
+                    StageInstanceDiscordId = e.StageInstanceAfter.Id,
+                    GuildDiscordId = e.StageInstanceAfter.GuildId,
+                    ChannelDiscordId = e.StageInstanceAfter.ChannelId,
+                    EventType = StageInstanceEventType.Updated,
+                    TopicBefore = e.StageInstanceBefore?.Topic,
+                    TopicAfter = e.StageInstanceAfter.Topic,
+                    PrivacyLevelBefore = e.StageInstanceBefore != null ? (int)e.StageInstanceBefore.PrivacyLevel : null,
+                    PrivacyLevelAfter = (int)e.StageInstanceAfter.PrivacyLevel,
+                    EventTimestampUtc = now,
+                    ReceivedAtUtc = now,
+                    RawEventJson = rawJson
+                });
+
+                await db.SaveChangesAsync();
+            }
+            catch (Exception ex)
+            {
+                logger.LogError(ex, "Error handling stage instance updated");
+                using var failureScope = scopeFactory.CreateScope();
+                var failedEventService = failureScope.ServiceProvider.GetRequiredService<FailedEventService>();
+                await failedEventService.RecordFailureAsync(
+                    "StageInstanceUpdated", nameof(StageInstanceEventHandler), ex,
+                    e.StageInstanceAfter?.GuildId, e.StageInstanceAfter?.ChannelId, null, rawJson, correlationId: correlationId);
+            }
         }
     }
 
     public async Task HandleEventAsync(DiscordClient sender, StageInstanceDeletedEventArgs e)
     {
-        string? rawJson = null;
-        try
+        var correlationId = Guid.NewGuid();
+        using (logger.BeginScope(new Dictionary<string, object> { ["CorrelationId"] = correlationId }))
         {
-            var now = DateTime.UtcNow;
-            using var scope = scopeFactory.CreateScope();
-            var db = scope.ServiceProvider.GetRequiredService<DiscordDbContext>();
-            var rawEventService = scope.ServiceProvider.GetRequiredService<RawEventLogService>();
-
-            rawJson = await rawEventService.SerializeAndLogAsync(
-                e, "StageInstanceDeleted", e.StageInstance.GuildId, e.StageInstance.ChannelId, null);
-
-            await db.StageInstances
-                .Where(s => s.DiscordId == e.StageInstance.Id)
-                .ExecuteUpdateAsync(s => s
-                    .SetProperty(st => st.IsDeleted, true)
-                    .SetProperty(st => st.DeletedAtUtc, (DateTime?)now));
-
-            db.StageInstanceEvents.Add(new StageInstanceEventEntity
+            string? rawJson = null;
+            try
             {
-                StageInstanceDiscordId = e.StageInstance.Id,
-                GuildDiscordId = e.StageInstance.GuildId,
-                ChannelDiscordId = e.StageInstance.ChannelId,
-                EventType = StageInstanceEventType.Deleted,
-                TopicBefore = e.StageInstance.Topic,
-                PrivacyLevelBefore = (int)e.StageInstance.PrivacyLevel,
-                EventTimestampUtc = now,
-                ReceivedAtUtc = now,
-                RawEventJson = rawJson
-            });
+                var now = DateTime.UtcNow;
+                using var scope = scopeFactory.CreateScope();
+                var db = scope.ServiceProvider.GetRequiredService<DiscordDbContext>();
+                var rawEventService = scope.ServiceProvider.GetRequiredService<RawEventLogService>();
 
-            await db.SaveChangesAsync();
-        }
-        catch (Exception ex)
-        {
-            logger.LogError(ex, "Error handling stage instance deleted");
-            using var failureScope = scopeFactory.CreateScope();
-            var failedEventService = failureScope.ServiceProvider.GetRequiredService<FailedEventService>();
-            await failedEventService.RecordFailureAsync(
-                "StageInstanceDeleted", nameof(StageInstanceEventHandler), ex,
-                e.StageInstance?.GuildId, e.StageInstance?.ChannelId, null, rawJson);
+                rawJson = await rawEventService.SerializeAndLogAsync(
+                    e, "StageInstanceDeleted", e.StageInstance.GuildId, e.StageInstance.ChannelId, null, correlationId: correlationId);
+
+                await db.StageInstances
+                    .Where(s => s.DiscordId == e.StageInstance.Id)
+                    .ExecuteUpdateAsync(s => s
+                        .SetProperty(st => st.IsDeleted, true)
+                        .SetProperty(st => st.DeletedAtUtc, (DateTime?)now));
+
+                db.StageInstanceEvents.Add(new StageInstanceEventEntity
+                {
+                    StageInstanceDiscordId = e.StageInstance.Id,
+                    GuildDiscordId = e.StageInstance.GuildId,
+                    ChannelDiscordId = e.StageInstance.ChannelId,
+                    EventType = StageInstanceEventType.Deleted,
+                    TopicBefore = e.StageInstance.Topic,
+                    PrivacyLevelBefore = (int)e.StageInstance.PrivacyLevel,
+                    EventTimestampUtc = now,
+                    ReceivedAtUtc = now,
+                    RawEventJson = rawJson
+                });
+
+                await db.SaveChangesAsync();
+            }
+            catch (Exception ex)
+            {
+                logger.LogError(ex, "Error handling stage instance deleted");
+                using var failureScope = scopeFactory.CreateScope();
+                var failedEventService = failureScope.ServiceProvider.GetRequiredService<FailedEventService>();
+                await failedEventService.RecordFailureAsync(
+                    "StageInstanceDeleted", nameof(StageInstanceEventHandler), ex,
+                    e.StageInstance?.GuildId, e.StageInstance?.ChannelId, null, rawJson, correlationId: correlationId);
+            }
         }
     }
 }

--- a/src/DiscordEventService/Services/EventHandlers/StickerEventHandler.cs
+++ b/src/DiscordEventService/Services/EventHandlers/StickerEventHandler.cs
@@ -13,95 +13,99 @@ public class StickerEventHandler(IServiceScopeFactory scopeFactory, ILogger<Stic
 {
     public async Task HandleEventAsync(DiscordClient sender, GuildStickersUpdatedEventArgs e)
     {
-        string? rawJson = null;
-        try
+        var correlationId = Guid.NewGuid();
+        using (logger.BeginScope(new Dictionary<string, object> { ["CorrelationId"] = correlationId }))
         {
-            var now = DateTime.UtcNow;
-            using var scope = scopeFactory.CreateScope();
-            var db = scope.ServiceProvider.GetRequiredService<DiscordDbContext>();
-            var rawEventService = scope.ServiceProvider.GetRequiredService<RawEventLogService>();
-
-            rawJson = await rawEventService.SerializeAndLogAsync(
-                e, "GuildStickersUpdated", e.Guild.Id, null, null);
-
-            // Look up Guild Guid
-            var guild = await db.Guilds.FirstOrDefaultAsync(g => g.DiscordId == e.Guild.Id);
-
-            var beforeIds = e.StickersBefore.Keys.ToHashSet();
-            var afterIds = e.StickersAfter.Keys.ToHashSet();
-
-            var addedIds = afterIds.Except(beforeIds).ToList();
-            var removedIds = beforeIds.Except(afterIds).ToList();
-            var updatedIds = beforeIds.Intersect(afterIds)
-                .Where(id => e.StickersBefore[id].Name != e.StickersAfter[id].Name ||
-                             e.StickersBefore[id].Description != e.StickersAfter[id].Description)
-                .ToList();
-
-            // Upsert stickers
-            foreach (var sticker in e.StickersAfter.Values)
+            string? rawJson = null;
+            try
             {
-                var existing = await db.Stickers.FirstOrDefaultAsync(s => s.DiscordId == sticker.Id);
-                if (existing == null)
+                var now = DateTime.UtcNow;
+                using var scope = scopeFactory.CreateScope();
+                var db = scope.ServiceProvider.GetRequiredService<DiscordDbContext>();
+                var rawEventService = scope.ServiceProvider.GetRequiredService<RawEventLogService>();
+
+                rawJson = await rawEventService.SerializeAndLogAsync(
+                    e, "GuildStickersUpdated", e.Guild.Id, null, null, correlationId: correlationId);
+
+                // Look up Guild Guid
+                var guild = await db.Guilds.FirstOrDefaultAsync(g => g.DiscordId == e.Guild.Id);
+
+                var beforeIds = e.StickersBefore.Keys.ToHashSet();
+                var afterIds = e.StickersAfter.Keys.ToHashSet();
+
+                var addedIds = afterIds.Except(beforeIds).ToList();
+                var removedIds = beforeIds.Except(afterIds).ToList();
+                var updatedIds = beforeIds.Intersect(afterIds)
+                    .Where(id => e.StickersBefore[id].Name != e.StickersAfter[id].Name ||
+                                 e.StickersBefore[id].Description != e.StickersAfter[id].Description)
+                    .ToList();
+
+                // Upsert stickers
+                foreach (var sticker in e.StickersAfter.Values)
                 {
-                    db.Stickers.Add(new StickerEntity
+                    var existing = await db.Stickers.FirstOrDefaultAsync(s => s.DiscordId == sticker.Id);
+                    if (existing == null)
                     {
-                        DiscordId = sticker.Id,
-                        GuildId = guild?.Id,
-                        Name = sticker.Name ?? string.Empty,
-                        Description = sticker.Description,
-                        Tags = sticker.Tags != null ? string.Join(",", sticker.Tags) : null,
-                        Type = (int)sticker.Type,
-                        FormatType = (int)sticker.FormatType,
-                        IsAvailable = true
-                    });
+                        db.Stickers.Add(new StickerEntity
+                        {
+                            DiscordId = sticker.Id,
+                            GuildId = guild?.Id,
+                            Name = sticker.Name ?? string.Empty,
+                            Description = sticker.Description,
+                            Tags = sticker.Tags != null ? string.Join(",", sticker.Tags) : null,
+                            Type = (int)sticker.Type,
+                            FormatType = (int)sticker.FormatType,
+                            IsAvailable = true
+                        });
+                    }
+                    else
+                    {
+                        existing.Name = sticker.Name ?? string.Empty;
+                        existing.Description = sticker.Description;
+                        existing.Tags = sticker.Tags != null ? string.Join(",", sticker.Tags) : null;
+                        existing.IsDeleted = false;
+                        existing.DeletedAtUtc = null;
+                    }
                 }
-                else
+
+                // Mark removed as deleted
+                foreach (var id in removedIds)
                 {
-                    existing.Name = sticker.Name ?? string.Empty;
-                    existing.Description = sticker.Description;
-                    existing.Tags = sticker.Tags != null ? string.Join(",", sticker.Tags) : null;
-                    existing.IsDeleted = false;
-                    existing.DeletedAtUtc = null;
+                    await db.Stickers.Where(s => s.DiscordId == id)
+                        .ExecuteUpdateAsync(s => s
+                            .SetProperty(st => st.IsDeleted, true)
+                            .SetProperty(st => st.DeletedAtUtc, (DateTime?)now));
                 }
+
+                var stickerEvent = new StickerEventEntity
+                {
+                    GuildDiscordId = e.Guild.Id,
+                    StickersAddedJson = addedIds.Count > 0
+                        ? JsonSerializer.Serialize(addedIds.Select(id => new { Id = id, e.StickersAfter[id].Name }))
+                        : null,
+                    StickersRemovedJson = removedIds.Count > 0
+                        ? JsonSerializer.Serialize(removedIds.Select(id => new { Id = id, e.StickersBefore[id].Name }))
+                        : null,
+                    StickersUpdatedJson = updatedIds.Count > 0
+                        ? JsonSerializer.Serialize(updatedIds.Select(id => new { Id = id, NameBefore = e.StickersBefore[id].Name, NameAfter = e.StickersAfter[id].Name }))
+                        : null,
+                    EventTimestampUtc = now,
+                    ReceivedAtUtc = now,
+                    RawEventJson = rawJson
+                };
+
+                db.StickerEvents.Add(stickerEvent);
+                await db.SaveChangesAsync();
             }
-
-            // Mark removed as deleted
-            foreach (var id in removedIds)
+            catch (Exception ex)
             {
-                await db.Stickers.Where(s => s.DiscordId == id)
-                    .ExecuteUpdateAsync(s => s
-                        .SetProperty(st => st.IsDeleted, true)
-                        .SetProperty(st => st.DeletedAtUtc, (DateTime?)now));
+                logger.LogError(ex, "Error handling stickers updated for GuildId={GuildId}", e.Guild.Id);
+                using var failureScope = scopeFactory.CreateScope();
+                var failedEventService = failureScope.ServiceProvider.GetRequiredService<FailedEventService>();
+                await failedEventService.RecordFailureAsync(
+                    "GuildStickersUpdated", nameof(StickerEventHandler), ex,
+                    e.Guild?.Id, null, null, rawJson, correlationId: correlationId);
             }
-
-            var stickerEvent = new StickerEventEntity
-            {
-                GuildDiscordId = e.Guild.Id,
-                StickersAddedJson = addedIds.Count > 0
-                    ? JsonSerializer.Serialize(addedIds.Select(id => new { Id = id, e.StickersAfter[id].Name }))
-                    : null,
-                StickersRemovedJson = removedIds.Count > 0
-                    ? JsonSerializer.Serialize(removedIds.Select(id => new { Id = id, e.StickersBefore[id].Name }))
-                    : null,
-                StickersUpdatedJson = updatedIds.Count > 0
-                    ? JsonSerializer.Serialize(updatedIds.Select(id => new { Id = id, NameBefore = e.StickersBefore[id].Name, NameAfter = e.StickersAfter[id].Name }))
-                    : null,
-                EventTimestampUtc = now,
-                ReceivedAtUtc = now,
-                RawEventJson = rawJson
-            };
-
-            db.StickerEvents.Add(stickerEvent);
-            await db.SaveChangesAsync();
-        }
-        catch (Exception ex)
-        {
-            logger.LogError(ex, "Error handling stickers updated for GuildId={GuildId}", e.Guild.Id);
-            using var failureScope = scopeFactory.CreateScope();
-            var failedEventService = failureScope.ServiceProvider.GetRequiredService<FailedEventService>();
-            await failedEventService.RecordFailureAsync(
-                "GuildStickersUpdated", nameof(StickerEventHandler), ex,
-                e.Guild?.Id, null, null, rawJson);
         }
     }
 }

--- a/src/DiscordEventService/Services/EventHandlers/ThreadEventHandler.cs
+++ b/src/DiscordEventService/Services/EventHandlers/ThreadEventHandler.cs
@@ -15,209 +15,225 @@ public class ThreadEventHandler(IServiceScopeFactory scopeFactory, ILogger<Threa
 {
     public async Task HandleEventAsync(DiscordClient sender, ThreadCreatedEventArgs e)
     {
-        string? rawJson = null;
-        try
+        var correlationId = Guid.NewGuid();
+        using (logger.BeginScope(new Dictionary<string, object> { ["CorrelationId"] = correlationId }))
         {
-            using var scope = scopeFactory.CreateScope();
-            var db = scope.ServiceProvider.GetRequiredService<DiscordDbContext>();
-            var rawEventService = scope.ServiceProvider.GetRequiredService<RawEventLogService>();
-            var guildUpsert = scope.ServiceProvider.GetRequiredService<GuildUpsertService>();
-            var channelUpsert = scope.ServiceProvider.GetRequiredService<ChannelUpsertService>();
-
-            rawJson = await rawEventService.SerializeAndLogAsync(
-                e, "ThreadCreated", e.Guild.Id, e.Thread.Id, e.Thread.CreatorId);
-
-            // Flush the raw event row before any upsert; the upsert services' 23505 catch path
-            // calls ChangeTracker.Clear() which would otherwise drop the staged raw_event_logs row.
-            await db.SaveChangesAsync();
-
-            // Threads are channels (ADR-0003): upsert the thread into `channels` so messages
-            // sent into it have a non-null channel_id from the first event onward.
-            var guildId = await guildUpsert.UpsertGuildAsync(e.Guild);
-            await channelUpsert.UpsertChannelAsync(e.Thread, guildId);
-
-            // For message threads (parent is text/news), thread ID == starter message ID
-            var isMessageThread = e.Parent?.Type is DiscordChannelType.Text or DiscordChannelType.News;
-
-            var threadEvent = new ThreadEventEntity
+            string? rawJson = null;
+            try
             {
-                ThreadDiscordId = e.Thread.Id,
-                ParentChannelDiscordId = e.Thread.ParentId ?? 0,
-                GuildDiscordId = e.Guild.Id,
-                EventType = ThreadEventType.Created,
-                Name = e.Thread.Name,
-                OwnerDiscordId = e.Thread.CreatorId,
-                StarterMessageDiscordId = isMessageThread ? e.Thread.Id : null,
-                IsArchived = e.Thread.ThreadMetadata?.IsArchived ?? false,
-                IsLocked = e.Thread.ThreadMetadata?.IsLocked ?? false,
-                EventTimestampUtc = DateTime.UtcNow,
-                ReceivedAtUtc = DateTime.UtcNow,
-                RawEventJson = rawJson
-            };
+                using var scope = scopeFactory.CreateScope();
+                var db = scope.ServiceProvider.GetRequiredService<DiscordDbContext>();
+                var rawEventService = scope.ServiceProvider.GetRequiredService<RawEventLogService>();
+                var guildUpsert = scope.ServiceProvider.GetRequiredService<GuildUpsertService>();
+                var channelUpsert = scope.ServiceProvider.GetRequiredService<ChannelUpsertService>();
 
-            db.ThreadEvents.Add(threadEvent);
-            await db.SaveChangesAsync();
-        }
-        catch (Exception ex)
-        {
-            logger.LogError(ex, "Error handling thread created for ThreadId={ThreadId}", e.Thread.Id);
-            using var failureScope = scopeFactory.CreateScope();
-            var failedEventService = failureScope.ServiceProvider.GetRequiredService<FailedEventService>();
-            await failedEventService.RecordFailureAsync(
-                "ThreadCreated", nameof(ThreadEventHandler), ex,
-                e.Guild?.Id, e.Thread?.Id, e.Thread?.CreatorId, rawJson);
+                rawJson = await rawEventService.SerializeAndLogAsync(
+                    e, "ThreadCreated", e.Guild.Id, e.Thread.Id, e.Thread.CreatorId, correlationId: correlationId);
+
+                // Flush the raw event row before any upsert; the upsert services' 23505 catch path
+                // calls ChangeTracker.Clear() which would otherwise drop the staged raw_event_logs row.
+                await db.SaveChangesAsync();
+
+                // Threads are channels (ADR-0003): upsert the thread into `channels` so messages
+                // sent into it have a non-null channel_id from the first event onward.
+                var guildId = await guildUpsert.UpsertGuildAsync(e.Guild);
+                await channelUpsert.UpsertChannelAsync(e.Thread, guildId);
+
+                // For message threads (parent is text/news), thread ID == starter message ID
+                var isMessageThread = e.Parent?.Type is DiscordChannelType.Text or DiscordChannelType.News;
+
+                var threadEvent = new ThreadEventEntity
+                {
+                    ThreadDiscordId = e.Thread.Id,
+                    ParentChannelDiscordId = e.Thread.ParentId ?? 0,
+                    GuildDiscordId = e.Guild.Id,
+                    EventType = ThreadEventType.Created,
+                    Name = e.Thread.Name,
+                    OwnerDiscordId = e.Thread.CreatorId,
+                    StarterMessageDiscordId = isMessageThread ? e.Thread.Id : null,
+                    IsArchived = e.Thread.ThreadMetadata?.IsArchived ?? false,
+                    IsLocked = e.Thread.ThreadMetadata?.IsLocked ?? false,
+                    EventTimestampUtc = DateTime.UtcNow,
+                    ReceivedAtUtc = DateTime.UtcNow,
+                    RawEventJson = rawJson
+                };
+
+                db.ThreadEvents.Add(threadEvent);
+                await db.SaveChangesAsync();
+            }
+            catch (Exception ex)
+            {
+                logger.LogError(ex, "Error handling thread created for ThreadId={ThreadId}", e.Thread.Id);
+                using var failureScope = scopeFactory.CreateScope();
+                var failedEventService = failureScope.ServiceProvider.GetRequiredService<FailedEventService>();
+                await failedEventService.RecordFailureAsync(
+                    "ThreadCreated", nameof(ThreadEventHandler), ex,
+                    e.Guild?.Id, e.Thread?.Id, e.Thread?.CreatorId, rawJson, correlationId: correlationId);
+            }
         }
     }
 
     public async Task HandleEventAsync(DiscordClient sender, ThreadUpdatedEventArgs e)
     {
-        string? rawJson = null;
-        try
+        var correlationId = Guid.NewGuid();
+        using (logger.BeginScope(new Dictionary<string, object> { ["CorrelationId"] = correlationId }))
         {
-            using var scope = scopeFactory.CreateScope();
-            var db = scope.ServiceProvider.GetRequiredService<DiscordDbContext>();
-            var rawEventService = scope.ServiceProvider.GetRequiredService<RawEventLogService>();
-            var guildUpsert = scope.ServiceProvider.GetRequiredService<GuildUpsertService>();
-            var channelUpsert = scope.ServiceProvider.GetRequiredService<ChannelUpsertService>();
-
-            rawJson = await rawEventService.SerializeAndLogAsync(
-                e, "ThreadUpdated", e.Guild.Id, e.ThreadAfter.Id, e.ThreadAfter.CreatorId);
-
-            await db.SaveChangesAsync();
-
-            var guildId = await guildUpsert.UpsertGuildAsync(e.Guild);
-            await channelUpsert.UpsertChannelAsync(e.ThreadAfter, guildId);
-
-            var threadEvent = new ThreadEventEntity
+            string? rawJson = null;
+            try
             {
-                ThreadDiscordId = e.ThreadAfter.Id,
-                ParentChannelDiscordId = e.ThreadAfter.ParentId ?? 0,
-                GuildDiscordId = e.Guild.Id,
-                EventType = ThreadEventType.Updated,
-                Name = e.ThreadAfter.Name,
-                OwnerDiscordId = e.ThreadAfter.CreatorId,
-                IsArchived = e.ThreadAfter.ThreadMetadata?.IsArchived ?? false,
-                IsLocked = e.ThreadAfter.ThreadMetadata?.IsLocked ?? false,
-                EventTimestampUtc = DateTime.UtcNow,
-                ReceivedAtUtc = DateTime.UtcNow,
-                RawEventJson = rawJson
-            };
+                using var scope = scopeFactory.CreateScope();
+                var db = scope.ServiceProvider.GetRequiredService<DiscordDbContext>();
+                var rawEventService = scope.ServiceProvider.GetRequiredService<RawEventLogService>();
+                var guildUpsert = scope.ServiceProvider.GetRequiredService<GuildUpsertService>();
+                var channelUpsert = scope.ServiceProvider.GetRequiredService<ChannelUpsertService>();
 
-            db.ThreadEvents.Add(threadEvent);
-            await db.SaveChangesAsync();
-        }
-        catch (Exception ex)
-        {
-            logger.LogError(ex, "Error handling thread updated for ThreadId={ThreadId}", e.ThreadAfter.Id);
-            using var failureScope = scopeFactory.CreateScope();
-            var failedEventService = failureScope.ServiceProvider.GetRequiredService<FailedEventService>();
-            await failedEventService.RecordFailureAsync(
-                "ThreadUpdated", nameof(ThreadEventHandler), ex,
-                e.Guild?.Id, e.ThreadAfter?.Id, e.ThreadAfter?.CreatorId, rawJson);
+                rawJson = await rawEventService.SerializeAndLogAsync(
+                    e, "ThreadUpdated", e.Guild.Id, e.ThreadAfter.Id, e.ThreadAfter.CreatorId, correlationId: correlationId);
+
+                await db.SaveChangesAsync();
+
+                var guildId = await guildUpsert.UpsertGuildAsync(e.Guild);
+                await channelUpsert.UpsertChannelAsync(e.ThreadAfter, guildId);
+
+                var threadEvent = new ThreadEventEntity
+                {
+                    ThreadDiscordId = e.ThreadAfter.Id,
+                    ParentChannelDiscordId = e.ThreadAfter.ParentId ?? 0,
+                    GuildDiscordId = e.Guild.Id,
+                    EventType = ThreadEventType.Updated,
+                    Name = e.ThreadAfter.Name,
+                    OwnerDiscordId = e.ThreadAfter.CreatorId,
+                    IsArchived = e.ThreadAfter.ThreadMetadata?.IsArchived ?? false,
+                    IsLocked = e.ThreadAfter.ThreadMetadata?.IsLocked ?? false,
+                    EventTimestampUtc = DateTime.UtcNow,
+                    ReceivedAtUtc = DateTime.UtcNow,
+                    RawEventJson = rawJson
+                };
+
+                db.ThreadEvents.Add(threadEvent);
+                await db.SaveChangesAsync();
+            }
+            catch (Exception ex)
+            {
+                logger.LogError(ex, "Error handling thread updated for ThreadId={ThreadId}", e.ThreadAfter.Id);
+                using var failureScope = scopeFactory.CreateScope();
+                var failedEventService = failureScope.ServiceProvider.GetRequiredService<FailedEventService>();
+                await failedEventService.RecordFailureAsync(
+                    "ThreadUpdated", nameof(ThreadEventHandler), ex,
+                    e.Guild?.Id, e.ThreadAfter?.Id, e.ThreadAfter?.CreatorId, rawJson, correlationId: correlationId);
+            }
         }
     }
 
     public async Task HandleEventAsync(DiscordClient sender, ThreadDeletedEventArgs e)
     {
-        string? rawJson = null;
-        try
+        var correlationId = Guid.NewGuid();
+        using (logger.BeginScope(new Dictionary<string, object> { ["CorrelationId"] = correlationId }))
         {
-            using var scope = scopeFactory.CreateScope();
-            var db = scope.ServiceProvider.GetRequiredService<DiscordDbContext>();
-            var rawEventService = scope.ServiceProvider.GetRequiredService<RawEventLogService>();
-            var channelUpsert = scope.ServiceProvider.GetRequiredService<ChannelUpsertService>();
-
-            rawJson = await rawEventService.SerializeAndLogAsync(
-                e, "ThreadDeleted", e.Guild.Id, e.Thread.Id, e.Thread.CreatorId);
-
-            await db.SaveChangesAsync();
-
-            await channelUpsert.MarkDeletedAsync(e.Thread.Id, DateTime.UtcNow);
-
-            var threadEvent = new ThreadEventEntity
+            string? rawJson = null;
+            try
             {
-                ThreadDiscordId = e.Thread.Id,
-                ParentChannelDiscordId = e.Thread.ParentId ?? 0,
-                GuildDiscordId = e.Guild.Id,
-                EventType = ThreadEventType.Deleted,
-                Name = e.Thread.Name,
-                OwnerDiscordId = e.Thread.CreatorId,
-                IsArchived = e.Thread.ThreadMetadata?.IsArchived ?? false,
-                IsLocked = e.Thread.ThreadMetadata?.IsLocked ?? false,
-                EventTimestampUtc = DateTime.UtcNow,
-                ReceivedAtUtc = DateTime.UtcNow,
-                RawEventJson = rawJson
-            };
+                using var scope = scopeFactory.CreateScope();
+                var db = scope.ServiceProvider.GetRequiredService<DiscordDbContext>();
+                var rawEventService = scope.ServiceProvider.GetRequiredService<RawEventLogService>();
+                var channelUpsert = scope.ServiceProvider.GetRequiredService<ChannelUpsertService>();
 
-            db.ThreadEvents.Add(threadEvent);
-            await db.SaveChangesAsync();
-        }
-        catch (Exception ex)
-        {
-            logger.LogError(ex, "Error handling thread deleted for ThreadId={ThreadId}", e.Thread.Id);
-            using var failureScope = scopeFactory.CreateScope();
-            var failedEventService = failureScope.ServiceProvider.GetRequiredService<FailedEventService>();
-            await failedEventService.RecordFailureAsync(
-                "ThreadDeleted", nameof(ThreadEventHandler), ex,
-                e.Guild?.Id, e.Thread?.Id, e.Thread?.CreatorId, rawJson);
+                rawJson = await rawEventService.SerializeAndLogAsync(
+                    e, "ThreadDeleted", e.Guild.Id, e.Thread.Id, e.Thread.CreatorId, correlationId: correlationId);
+
+                await db.SaveChangesAsync();
+
+                await channelUpsert.MarkDeletedAsync(e.Thread.Id, DateTime.UtcNow);
+
+                var threadEvent = new ThreadEventEntity
+                {
+                    ThreadDiscordId = e.Thread.Id,
+                    ParentChannelDiscordId = e.Thread.ParentId ?? 0,
+                    GuildDiscordId = e.Guild.Id,
+                    EventType = ThreadEventType.Deleted,
+                    Name = e.Thread.Name,
+                    OwnerDiscordId = e.Thread.CreatorId,
+                    IsArchived = e.Thread.ThreadMetadata?.IsArchived ?? false,
+                    IsLocked = e.Thread.ThreadMetadata?.IsLocked ?? false,
+                    EventTimestampUtc = DateTime.UtcNow,
+                    ReceivedAtUtc = DateTime.UtcNow,
+                    RawEventJson = rawJson
+                };
+
+                db.ThreadEvents.Add(threadEvent);
+                await db.SaveChangesAsync();
+            }
+            catch (Exception ex)
+            {
+                logger.LogError(ex, "Error handling thread deleted for ThreadId={ThreadId}", e.Thread.Id);
+                using var failureScope = scopeFactory.CreateScope();
+                var failedEventService = failureScope.ServiceProvider.GetRequiredService<FailedEventService>();
+                await failedEventService.RecordFailureAsync(
+                    "ThreadDeleted", nameof(ThreadEventHandler), ex,
+                    e.Guild?.Id, e.Thread?.Id, e.Thread?.CreatorId, rawJson, correlationId: correlationId);
+            }
         }
     }
 
     public async Task HandleEventAsync(DiscordClient sender, ThreadMembersUpdatedEventArgs e)
     {
-        string? rawJson = null;
-        try
+        var correlationId = Guid.NewGuid();
+        using (logger.BeginScope(new Dictionary<string, object> { ["CorrelationId"] = correlationId }))
         {
-            using var scope = scopeFactory.CreateScope();
-            var db = scope.ServiceProvider.GetRequiredService<DiscordDbContext>();
-            var rawEventService = scope.ServiceProvider.GetRequiredService<RawEventLogService>();
-
-            rawJson = await rawEventService.SerializeAndLogAsync(
-                e, "ThreadMembersUpdated", e.Guild.Id, e.Thread.Id, null);
-
-            string? membersAddedJson = null;
-            string? membersRemovedJson = null;
-
-            if (e.AddedMembers.Count > 0)
+            string? rawJson = null;
+            try
             {
-                var addedMemberIds = e.AddedMembers.Select(m => m.Id).ToList();
-                membersAddedJson = JsonSerializer.Serialize(addedMemberIds);
+                using var scope = scopeFactory.CreateScope();
+                var db = scope.ServiceProvider.GetRequiredService<DiscordDbContext>();
+                var rawEventService = scope.ServiceProvider.GetRequiredService<RawEventLogService>();
+
+                rawJson = await rawEventService.SerializeAndLogAsync(
+                    e, "ThreadMembersUpdated", e.Guild.Id, e.Thread.Id, null, correlationId: correlationId);
+
+                string? membersAddedJson = null;
+                string? membersRemovedJson = null;
+
+                if (e.AddedMembers.Count > 0)
+                {
+                    var addedMemberIds = e.AddedMembers.Select(m => m.Id).ToList();
+                    membersAddedJson = JsonSerializer.Serialize(addedMemberIds);
+                }
+
+                if (e.RemovedMembers.Count > 0)
+                {
+                    var removedMemberIds = e.RemovedMembers.Select(m => m.Id).ToList();
+                    membersRemovedJson = JsonSerializer.Serialize(removedMemberIds);
+                }
+
+                var threadEvent = new ThreadEventEntity
+                {
+                    ThreadDiscordId = e.Thread.Id,
+                    ParentChannelDiscordId = e.Thread.ParentId ?? 0,
+                    GuildDiscordId = e.Guild.Id,
+                    EventType = ThreadEventType.MembersUpdated,
+                    Name = e.Thread.Name,
+                    OwnerDiscordId = e.Thread.CreatorId,
+                    IsArchived = e.Thread.ThreadMetadata?.IsArchived ?? false,
+                    IsLocked = e.Thread.ThreadMetadata?.IsLocked ?? false,
+                    MembersAddedJson = membersAddedJson,
+                    MembersRemovedJson = membersRemovedJson,
+                    EventTimestampUtc = DateTime.UtcNow,
+                    ReceivedAtUtc = DateTime.UtcNow,
+                    RawEventJson = rawJson
+                };
+
+                db.ThreadEvents.Add(threadEvent);
+                await db.SaveChangesAsync();
             }
-
-            if (e.RemovedMembers.Count > 0)
+            catch (Exception ex)
             {
-                var removedMemberIds = e.RemovedMembers.Select(m => m.Id).ToList();
-                membersRemovedJson = JsonSerializer.Serialize(removedMemberIds);
+                logger.LogError(ex, "Error handling thread members updated for ThreadId={ThreadId}", e.Thread.Id);
+                using var failureScope = scopeFactory.CreateScope();
+                var failedEventService = failureScope.ServiceProvider.GetRequiredService<FailedEventService>();
+                await failedEventService.RecordFailureAsync(
+                    "ThreadMembersUpdated", nameof(ThreadEventHandler), ex,
+                    e.Guild?.Id, e.Thread?.Id, null, rawJson, correlationId: correlationId);
             }
-
-            var threadEvent = new ThreadEventEntity
-            {
-                ThreadDiscordId = e.Thread.Id,
-                ParentChannelDiscordId = e.Thread.ParentId ?? 0,
-                GuildDiscordId = e.Guild.Id,
-                EventType = ThreadEventType.MembersUpdated,
-                Name = e.Thread.Name,
-                OwnerDiscordId = e.Thread.CreatorId,
-                IsArchived = e.Thread.ThreadMetadata?.IsArchived ?? false,
-                IsLocked = e.Thread.ThreadMetadata?.IsLocked ?? false,
-                MembersAddedJson = membersAddedJson,
-                MembersRemovedJson = membersRemovedJson,
-                EventTimestampUtc = DateTime.UtcNow,
-                ReceivedAtUtc = DateTime.UtcNow,
-                RawEventJson = rawJson
-            };
-
-            db.ThreadEvents.Add(threadEvent);
-            await db.SaveChangesAsync();
-        }
-        catch (Exception ex)
-        {
-            logger.LogError(ex, "Error handling thread members updated for ThreadId={ThreadId}", e.Thread.Id);
-            using var failureScope = scopeFactory.CreateScope();
-            var failedEventService = failureScope.ServiceProvider.GetRequiredService<FailedEventService>();
-            await failedEventService.RecordFailureAsync(
-                "ThreadMembersUpdated", nameof(ThreadEventHandler), ex,
-                e.Guild?.Id, e.Thread?.Id, null, rawJson);
         }
     }
 }

--- a/src/DiscordEventService/Services/EventHandlers/ThreadSyncHandler.cs
+++ b/src/DiscordEventService/Services/EventHandlers/ThreadSyncHandler.cs
@@ -17,45 +17,49 @@ public class ThreadSyncHandler(IServiceScopeFactory scopeFactory, ILogger<Thread
 
     public async Task HandleEventAsync(DiscordClient sender, ThreadListSyncedEventArgs args)
     {
-        string? rawJson = null;
-        try
+        var correlationId = Guid.NewGuid();
+        using (logger.BeginScope(new Dictionary<string, object> { ["CorrelationId"] = correlationId }))
         {
-            var now = DateTime.UtcNow;
-
-            using var scope = scopeFactory.CreateScope();
-            var db = scope.ServiceProvider.GetRequiredService<DiscordDbContext>();
-            var rawEventService = scope.ServiceProvider.GetRequiredService<RawEventLogService>();
-
-            rawJson = await rawEventService.SerializeAndLogAsync(
-                args, "ThreadListSynced", args.Guild.Id, null, null);
-
-            var syncEvent = new ThreadSyncEventEntity
+            string? rawJson = null;
+            try
             {
-                GuildDiscordId = args.Guild.Id,
-                ThreadCount = args.Threads.Count,
-                ThreadIdsJson = JsonSerializer.Serialize(args.Threads.Select(t => t.Id.ToString()), JsonOptions),
-                ChannelIdsJson = args.Channels?.Count > 0
-                    ? JsonSerializer.Serialize(args.Channels.Select(c => c.Id.ToString()), JsonOptions)
-                    : null,
-                EventTimestampUtc = now,
-                ReceivedAtUtc = now,
-                RawEventJson = rawJson
-            };
+                var now = DateTime.UtcNow;
 
-            await db.ThreadSyncEvents.AddAsync(syncEvent);
-            await db.SaveChangesAsync();
+                using var scope = scopeFactory.CreateScope();
+                var db = scope.ServiceProvider.GetRequiredService<DiscordDbContext>();
+                var rawEventService = scope.ServiceProvider.GetRequiredService<RawEventLogService>();
 
-            logger.LogDebug("Recorded thread list sync for guild {GuildId} with {ThreadCount} threads",
-                args.Guild.Id, args.Threads.Count);
-        }
-        catch (Exception ex)
-        {
-            logger.LogError(ex, "Error handling thread list sync for guild {GuildId}", args.Guild.Id);
-            using var failureScope = scopeFactory.CreateScope();
-            var failedEventService = failureScope.ServiceProvider.GetRequiredService<FailedEventService>();
-            await failedEventService.RecordFailureAsync(
-                "ThreadListSynced", nameof(ThreadSyncHandler), ex,
-                args.Guild?.Id, null, null, rawJson);
+                rawJson = await rawEventService.SerializeAndLogAsync(
+                    args, "ThreadListSynced", args.Guild.Id, null, null, correlationId: correlationId);
+
+                var syncEvent = new ThreadSyncEventEntity
+                {
+                    GuildDiscordId = args.Guild.Id,
+                    ThreadCount = args.Threads.Count,
+                    ThreadIdsJson = JsonSerializer.Serialize(args.Threads.Select(t => t.Id.ToString()), JsonOptions),
+                    ChannelIdsJson = args.Channels?.Count > 0
+                        ? JsonSerializer.Serialize(args.Channels.Select(c => c.Id.ToString()), JsonOptions)
+                        : null,
+                    EventTimestampUtc = now,
+                    ReceivedAtUtc = now,
+                    RawEventJson = rawJson
+                };
+
+                await db.ThreadSyncEvents.AddAsync(syncEvent);
+                await db.SaveChangesAsync();
+
+                logger.LogDebug("Recorded thread list sync for guild {GuildId} with {ThreadCount} threads",
+                    args.Guild.Id, args.Threads.Count);
+            }
+            catch (Exception ex)
+            {
+                logger.LogError(ex, "Error handling thread list sync for guild {GuildId}", args.Guild.Id);
+                using var failureScope = scopeFactory.CreateScope();
+                var failedEventService = failureScope.ServiceProvider.GetRequiredService<FailedEventService>();
+                await failedEventService.RecordFailureAsync(
+                    "ThreadListSynced", nameof(ThreadSyncHandler), ex,
+                    args.Guild?.Id, null, null, rawJson, correlationId: correlationId);
+            }
         }
     }
 }

--- a/src/DiscordEventService/Services/EventHandlers/TypingEventHandler.cs
+++ b/src/DiscordEventService/Services/EventHandlers/TypingEventHandler.cs
@@ -13,45 +13,49 @@ public class TypingEventHandler(IServiceScopeFactory scopeFactory, ILogger<Typin
 
     public async Task HandleEventAsync(DiscordClient sender, TypingStartedEventArgs e)
     {
-        string? rawJson = null;
-        try
+        var correlationId = Guid.NewGuid();
+        using (logger.BeginScope(new Dictionary<string, object> { ["CorrelationId"] = correlationId }))
         {
-            // Throttle: skip if we've seen this user+channel combo recently
-            var cacheKey = $"typing:{e.User.Id}:{e.Channel.Id}";
-            if (cache.TryGetValue(cacheKey, out _))
+            string? rawJson = null;
+            try
             {
-                return;
+                // Throttle: skip if we've seen this user+channel combo recently
+                var cacheKey = $"typing:{e.User.Id}:{e.Channel.Id}";
+                if (cache.TryGetValue(cacheKey, out _))
+                {
+                    return;
+                }
+                cache.Set(cacheKey, true, ThrottleWindow);
+
+                using var scope = scopeFactory.CreateScope();
+                var db = scope.ServiceProvider.GetRequiredService<DiscordDbContext>();
+                var rawEventService = scope.ServiceProvider.GetRequiredService<RawEventLogService>();
+
+                rawJson = await rawEventService.SerializeAndLogAsync(
+                    e, "TypingStarted", e.Guild?.Id ?? 0, e.Channel.Id, e.User.Id, correlationId: correlationId);
+
+                var entity = new TypingEventEntity
+                {
+                    UserDiscordId = e.User.Id,
+                    ChannelDiscordId = e.Channel.Id,
+                    GuildDiscordId = e.Guild?.Id,
+                    StartedAt = e.StartedAt.UtcDateTime,
+                    ReceivedAtUtc = DateTime.UtcNow,
+                    RawEventJson = rawJson
+                };
+
+                db.TypingEvents.Add(entity);
+                await db.SaveChangesAsync();
             }
-            cache.Set(cacheKey, true, ThrottleWindow);
-
-            using var scope = scopeFactory.CreateScope();
-            var db = scope.ServiceProvider.GetRequiredService<DiscordDbContext>();
-            var rawEventService = scope.ServiceProvider.GetRequiredService<RawEventLogService>();
-
-            rawJson = await rawEventService.SerializeAndLogAsync(
-                e, "TypingStarted", e.Guild?.Id ?? 0, e.Channel.Id, e.User.Id);
-
-            var entity = new TypingEventEntity
+            catch (Exception ex)
             {
-                UserDiscordId = e.User.Id,
-                ChannelDiscordId = e.Channel.Id,
-                GuildDiscordId = e.Guild?.Id,
-                StartedAt = e.StartedAt.UtcDateTime,
-                ReceivedAtUtc = DateTime.UtcNow,
-                RawEventJson = rawJson
-            };
-
-            db.TypingEvents.Add(entity);
-            await db.SaveChangesAsync();
-        }
-        catch (Exception ex)
-        {
-            logger.LogError(ex, "Error handling typing started");
-            using var failureScope = scopeFactory.CreateScope();
-            var failedEventService = failureScope.ServiceProvider.GetRequiredService<FailedEventService>();
-            await failedEventService.RecordFailureAsync(
-                "TypingStarted", nameof(TypingEventHandler), ex,
-                e.Guild?.Id, e.Channel?.Id, e.User?.Id, rawJson);
+                logger.LogError(ex, "Error handling typing started");
+                using var failureScope = scopeFactory.CreateScope();
+                var failedEventService = failureScope.ServiceProvider.GetRequiredService<FailedEventService>();
+                await failedEventService.RecordFailureAsync(
+                    "TypingStarted", nameof(TypingEventHandler), ex,
+                    e.Guild?.Id, e.Channel?.Id, e.User?.Id, rawJson, correlationId: correlationId);
+            }
         }
     }
 }

--- a/src/DiscordEventService/Services/EventHandlers/VoiceEventHandler.cs
+++ b/src/DiscordEventService/Services/EventHandlers/VoiceEventHandler.cs
@@ -11,65 +11,69 @@ public class VoiceEventHandler(IServiceScopeFactory scopeFactory, ILogger<VoiceE
 {
     public async Task HandleEventAsync(DiscordClient sender, VoiceStateUpdatedEventArgs args)
     {
-        try
+        var correlationId = Guid.NewGuid();
+        using (logger.BeginScope(new Dictionary<string, object> { ["CorrelationId"] = correlationId }))
         {
-            var now = DateTime.UtcNow;
-            var eventType = DetermineEventType(args);
-
-            using var scope = scopeFactory.CreateScope();
-            var db = scope.ServiceProvider.GetRequiredService<DiscordDbContext>();
-            var rawEventService = scope.ServiceProvider.GetRequiredService<RawEventLogService>();
-
-            var rawJson = await rawEventService.SerializeAndLogAsync(
-                args, "VoiceStateUpdated", args.Guild.Id, args.After?.Channel?.Id, args.User.Id);
-
-            var voiceEvent = new VoiceStateEventEntity
+            try
             {
-                UserDiscordId = args.User.Id,
-                GuildDiscordId = args.Guild.Id,
-                ChannelDiscordIdBefore = args.Before?.Channel?.Id,
-                ChannelDiscordIdAfter = args.After?.Channel?.Id,
-                EventType = eventType,
+                var now = DateTime.UtcNow;
+                var eventType = DetermineEventType(args);
 
-                // Before state flags
-                WasSelfMuted = args.Before?.IsSelfMuted ?? false,
-                WasSelfDeafened = args.Before?.IsSelfDeafened ?? false,
-                WasServerMuted = args.Before?.IsServerMuted ?? false,
-                WasServerDeafened = args.Before?.IsServerDeafened ?? false,
-                WasStreaming = args.Before?.IsSelfStream ?? false,
-                WasVideo = args.Before?.IsSelfVideo ?? false,
-                WasSuppressed = args.Before?.IsSuppressed ?? false,
+                using var scope = scopeFactory.CreateScope();
+                var db = scope.ServiceProvider.GetRequiredService<DiscordDbContext>();
+                var rawEventService = scope.ServiceProvider.GetRequiredService<RawEventLogService>();
 
-                // After state flags
-                IsSelfMuted = args.After?.IsSelfMuted ?? false,
-                IsSelfDeafened = args.After?.IsSelfDeafened ?? false,
-                IsServerMuted = args.After?.IsServerMuted ?? false,
-                IsServerDeafened = args.After?.IsServerDeafened ?? false,
-                IsStreaming = args.After?.IsSelfStream ?? false,
-                IsVideo = args.After?.IsSelfVideo ?? false,
-                IsSuppressed = args.After?.IsSuppressed ?? false,
+                var rawJson = await rawEventService.SerializeAndLogAsync(
+                    args, "VoiceStateUpdated", args.Guild.Id, args.After?.Channel?.Id, args.User.Id, correlationId: correlationId);
 
-                SessionId = args.After?.SessionId,
-                EventTimestampUtc = now,
-                ReceivedAtUtc = now,
-                RawEventJson = rawJson
-            };
+                var voiceEvent = new VoiceStateEventEntity
+                {
+                    UserDiscordId = args.User.Id,
+                    GuildDiscordId = args.Guild.Id,
+                    ChannelDiscordIdBefore = args.Before?.Channel?.Id,
+                    ChannelDiscordIdAfter = args.After?.Channel?.Id,
+                    EventType = eventType,
 
-            db.VoiceStateEvents.Add(voiceEvent);
-            await db.SaveChangesAsync();
+                    // Before state flags
+                    WasSelfMuted = args.Before?.IsSelfMuted ?? false,
+                    WasSelfDeafened = args.Before?.IsSelfDeafened ?? false,
+                    WasServerMuted = args.Before?.IsServerMuted ?? false,
+                    WasServerDeafened = args.Before?.IsServerDeafened ?? false,
+                    WasStreaming = args.Before?.IsSelfStream ?? false,
+                    WasVideo = args.Before?.IsSelfVideo ?? false,
+                    WasSuppressed = args.Before?.IsSuppressed ?? false,
 
-            logger.LogDebug("Recorded voice event: {EventType} for user {UserId} in guild {GuildId}",
-                eventType, args.User.Id, args.Guild.Id);
-        }
-        catch (Exception ex)
-        {
-            logger.LogError(ex, "Error handling voice state update for user {UserId} in guild {GuildId}",
-                args.User.Id, args.Guild.Id);
-            using var failureScope = scopeFactory.CreateScope();
-            var failedEventService = failureScope.ServiceProvider.GetRequiredService<FailedEventService>();
-            await failedEventService.RecordFailureAsync(
-                "VoiceStateUpdated", nameof(VoiceEventHandler), ex,
-                args.Guild.Id, args.After?.Channel?.Id, args.User.Id);
+                    // After state flags
+                    IsSelfMuted = args.After?.IsSelfMuted ?? false,
+                    IsSelfDeafened = args.After?.IsSelfDeafened ?? false,
+                    IsServerMuted = args.After?.IsServerMuted ?? false,
+                    IsServerDeafened = args.After?.IsServerDeafened ?? false,
+                    IsStreaming = args.After?.IsSelfStream ?? false,
+                    IsVideo = args.After?.IsSelfVideo ?? false,
+                    IsSuppressed = args.After?.IsSuppressed ?? false,
+
+                    SessionId = args.After?.SessionId,
+                    EventTimestampUtc = now,
+                    ReceivedAtUtc = now,
+                    RawEventJson = rawJson
+                };
+
+                db.VoiceStateEvents.Add(voiceEvent);
+                await db.SaveChangesAsync();
+
+                logger.LogDebug("Recorded voice event: {EventType} for user {UserId} in guild {GuildId}",
+                    eventType, args.User.Id, args.Guild.Id);
+            }
+            catch (Exception ex)
+            {
+                logger.LogError(ex, "Error handling voice state update for user {UserId} in guild {GuildId}",
+                    args.User.Id, args.Guild.Id);
+                using var failureScope = scopeFactory.CreateScope();
+                var failedEventService = failureScope.ServiceProvider.GetRequiredService<FailedEventService>();
+                await failedEventService.RecordFailureAsync(
+                    "VoiceStateUpdated", nameof(VoiceEventHandler), ex,
+                    args.Guild.Id, args.After?.Channel?.Id, args.User.Id, correlationId: correlationId);
+            }
         }
     }
 

--- a/src/DiscordEventService/Services/EventHandlers/VoiceServerEventHandler.cs
+++ b/src/DiscordEventService/Services/EventHandlers/VoiceServerEventHandler.cs
@@ -10,42 +10,46 @@ public class VoiceServerEventHandler(IServiceScopeFactory scopeFactory, ILogger<
 {
     public async Task HandleEventAsync(DiscordClient sender, VoiceServerUpdatedEventArgs args)
     {
-        try
+        var correlationId = Guid.NewGuid();
+        using (logger.BeginScope(new Dictionary<string, object> { ["CorrelationId"] = correlationId }))
         {
-            var now = DateTime.UtcNow;
-
-            using var scope = scopeFactory.CreateScope();
-            var db = scope.ServiceProvider.GetRequiredService<DiscordDbContext>();
-            var rawEventService = scope.ServiceProvider.GetRequiredService<RawEventLogService>();
-
-            // TODO: VoiceServerUpdatedEventArgs contains a Token property that may be serialized to raw JSON.
-            // Investigate if this is a security concern and consider excluding it from serialization.
-            var rawJson = await rawEventService.SerializeAndLogAsync(
-                args, "VoiceServerUpdated", args.Guild.Id, null, null);
-
-            var voiceServerEvent = new VoiceServerEventEntity
+            try
             {
-                GuildDiscordId = args.Guild.Id,
-                Endpoint = args.Endpoint,
-                EventTimestampUtc = now,
-                ReceivedAtUtc = now,
-                RawEventJson = rawJson
-            };
+                var now = DateTime.UtcNow;
 
-            await db.VoiceServerEvents.AddAsync(voiceServerEvent);
-            await db.SaveChangesAsync();
+                using var scope = scopeFactory.CreateScope();
+                var db = scope.ServiceProvider.GetRequiredService<DiscordDbContext>();
+                var rawEventService = scope.ServiceProvider.GetRequiredService<RawEventLogService>();
 
-            logger.LogDebug("Recorded voice server event for guild {GuildId}, endpoint {Endpoint}",
-                args.Guild.Id, args.Endpoint);
-        }
-        catch (Exception ex)
-        {
-            logger.LogError(ex, "Error handling voice server update for guild {GuildId}", args.Guild.Id);
-            using var failureScope = scopeFactory.CreateScope();
-            var failedEventService = failureScope.ServiceProvider.GetRequiredService<FailedEventService>();
-            await failedEventService.RecordFailureAsync(
-                "VoiceServerUpdated", nameof(VoiceServerEventHandler), ex,
-                args.Guild.Id, null, null);
+                // TODO: VoiceServerUpdatedEventArgs contains a Token property that may be serialized to raw JSON.
+                // Investigate if this is a security concern and consider excluding it from serialization.
+                var rawJson = await rawEventService.SerializeAndLogAsync(
+                    args, "VoiceServerUpdated", args.Guild.Id, null, null, correlationId: correlationId);
+
+                var voiceServerEvent = new VoiceServerEventEntity
+                {
+                    GuildDiscordId = args.Guild.Id,
+                    Endpoint = args.Endpoint,
+                    EventTimestampUtc = now,
+                    ReceivedAtUtc = now,
+                    RawEventJson = rawJson
+                };
+
+                await db.VoiceServerEvents.AddAsync(voiceServerEvent);
+                await db.SaveChangesAsync();
+
+                logger.LogDebug("Recorded voice server event for guild {GuildId}, endpoint {Endpoint}",
+                    args.Guild.Id, args.Endpoint);
+            }
+            catch (Exception ex)
+            {
+                logger.LogError(ex, "Error handling voice server update for guild {GuildId}", args.Guild.Id);
+                using var failureScope = scopeFactory.CreateScope();
+                var failedEventService = failureScope.ServiceProvider.GetRequiredService<FailedEventService>();
+                await failedEventService.RecordFailureAsync(
+                    "VoiceServerUpdated", nameof(VoiceServerEventHandler), ex,
+                    args.Guild.Id, null, null, correlationId: correlationId);
+            }
         }
     }
 }

--- a/src/DiscordEventService/Services/EventHandlers/WebhookEventHandler.cs
+++ b/src/DiscordEventService/Services/EventHandlers/WebhookEventHandler.cs
@@ -10,36 +10,40 @@ public class WebhookEventHandler(IServiceScopeFactory scopeFactory, ILogger<Webh
 {
     public async Task HandleEventAsync(DiscordClient sender, WebhooksUpdatedEventArgs e)
     {
-        string? rawJson = null;
-        try
+        var correlationId = Guid.NewGuid();
+        using (logger.BeginScope(new Dictionary<string, object> { ["CorrelationId"] = correlationId }))
         {
-            var now = DateTime.UtcNow;
-            using var scope = scopeFactory.CreateScope();
-            var db = scope.ServiceProvider.GetRequiredService<DiscordDbContext>();
-            var rawEventService = scope.ServiceProvider.GetRequiredService<RawEventLogService>();
-
-            rawJson = await rawEventService.SerializeAndLogAsync(
-                e, "WebhooksUpdated", e.Guild.Id, e.Channel.Id, null);
-
-            db.WebhookEvents.Add(new WebhookEventEntity
+            string? rawJson = null;
+            try
             {
-                GuildDiscordId = e.Guild.Id,
-                ChannelDiscordId = e.Channel.Id,
-                EventTimestampUtc = now,
-                ReceivedAtUtc = now,
-                RawEventJson = rawJson
-            });
+                var now = DateTime.UtcNow;
+                using var scope = scopeFactory.CreateScope();
+                var db = scope.ServiceProvider.GetRequiredService<DiscordDbContext>();
+                var rawEventService = scope.ServiceProvider.GetRequiredService<RawEventLogService>();
 
-            await db.SaveChangesAsync();
-        }
-        catch (Exception ex)
-        {
-            logger.LogError(ex, "Error handling webhooks updated for ChannelId={ChannelId}", e.Channel.Id);
-            using var failureScope = scopeFactory.CreateScope();
-            var failedEventService = failureScope.ServiceProvider.GetRequiredService<FailedEventService>();
-            await failedEventService.RecordFailureAsync(
-                "WebhooksUpdated", nameof(WebhookEventHandler), ex,
-                e.Guild?.Id, e.Channel?.Id, null, rawJson);
+                rawJson = await rawEventService.SerializeAndLogAsync(
+                    e, "WebhooksUpdated", e.Guild.Id, e.Channel.Id, null, correlationId: correlationId);
+
+                db.WebhookEvents.Add(new WebhookEventEntity
+                {
+                    GuildDiscordId = e.Guild.Id,
+                    ChannelDiscordId = e.Channel.Id,
+                    EventTimestampUtc = now,
+                    ReceivedAtUtc = now,
+                    RawEventJson = rawJson
+                });
+
+                await db.SaveChangesAsync();
+            }
+            catch (Exception ex)
+            {
+                logger.LogError(ex, "Error handling webhooks updated for ChannelId={ChannelId}", e.Channel.Id);
+                using var failureScope = scopeFactory.CreateScope();
+                var failedEventService = failureScope.ServiceProvider.GetRequiredService<FailedEventService>();
+                await failedEventService.RecordFailureAsync(
+                    "WebhooksUpdated", nameof(WebhookEventHandler), ex,
+                    e.Guild?.Id, e.Channel?.Id, null, rawJson, correlationId: correlationId);
+            }
         }
     }
 }

--- a/src/DiscordEventService/Services/FailedEventService.cs
+++ b/src/DiscordEventService/Services/FailedEventService.cs
@@ -16,7 +16,8 @@ public class FailedEventService(DiscordDbContext db, ILogger<FailedEventService>
         ulong? channelId = null,
         ulong? userId = null,
         string? eventJson = null,
-        DateTime? eventReceivedAt = null)
+        DateTime? eventReceivedAt = null,
+        Guid? correlationId = null)
     {
         try
         {
@@ -32,7 +33,8 @@ public class FailedEventService(DiscordDbContext db, ILogger<FailedEventService>
                 ExceptionMessage = exception.Message,
                 StackTrace = exception.StackTrace,
                 FailedAtUtc = DateTime.UtcNow,
-                EventReceivedAtUtc = eventReceivedAt ?? DateTime.UtcNow
+                EventReceivedAtUtc = eventReceivedAt ?? DateTime.UtcNow,
+                CorrelationId = correlationId
             };
 
             await db.FailedEvents.AddAsync(failedEvent);

--- a/src/DiscordEventService/Services/RawEventLogService.cs
+++ b/src/DiscordEventService/Services/RawEventLogService.cs
@@ -58,7 +58,8 @@ public class RawEventLogService(DiscordDbContext dbContext, ILogger<RawEventLogS
         string eventJson,
         ulong guildId = 0,
         ulong? channelId = null,
-        ulong? userId = null)
+        ulong? userId = null,
+        Guid? correlationId = null)
     {
         try
         {
@@ -70,7 +71,8 @@ public class RawEventLogService(DiscordDbContext dbContext, ILogger<RawEventLogS
                 UserDiscordId = userId,
                 EventJson = eventJson,
                 JsonSizeBytes = System.Text.Encoding.UTF8.GetByteCount(eventJson),
-                ReceivedAtUtc = DateTime.UtcNow
+                ReceivedAtUtc = DateTime.UtcNow,
+                CorrelationId = correlationId
             };
 
             await dbContext.RawEventLogs.AddAsync(rawEvent);
@@ -90,10 +92,11 @@ public class RawEventLogService(DiscordDbContext dbContext, ILogger<RawEventLogS
         string eventType,
         ulong guildId = 0,
         ulong? channelId = null,
-        ulong? userId = null) where T : class
+        ulong? userId = null,
+        Guid? correlationId = null) where T : class
     {
         var json = SerializeEvent(eventArgs);
-        await LogRawEventAsync(eventType, json, guildId, channelId, userId);
+        await LogRawEventAsync(eventType, json, guildId, channelId, userId, correlationId);
         return json;
     }
 

--- a/src/DiscordEventService/appsettings.json
+++ b/src/DiscordEventService/appsettings.json
@@ -4,6 +4,9 @@
       "Default": "Information",
       "Microsoft.AspNetCore": "Warning",
       "Microsoft.EntityFrameworkCore": "Warning"
+    },
+    "Console": {
+      "IncludeScopes": true
     }
   },
   "AllowedHosts": "*",


### PR DESCRIPTION
## Summary
- Adds `correlation_id` (nullable uuid) column to `raw_event_logs` and `failed_events` tables
- Threads correlation ID through `RawEventLogService.SerializeAndLogAsync` and `FailedEventService.RecordFailureAsync`
- Wraps every `HandleEventAsync` method (28 handlers, 67 methods) in `logger.BeginScope` with `CorrelationId` — all log lines for a single event processing share the same ID
- Enables `IncludeScopes: true` on console logger so correlation IDs appear in log output
- Includes EF migration `P4_3_CorrelationIds`

## Test plan
- [ ] Run locally, send a message in dev Discord — verify logs show `=> CorrelationId:...` scope
- [ ] Check `raw_event_logs` table has non-null `correlation_id` on new rows
- [ ] Trigger a handler failure — verify `failed_events.correlation_id` matches the log lines
- [ ] Migration applies cleanly (`dotnet ef database update`)
- [ ] CI green

Closes #85

🤖 Generated with [Claude Code](https://claude.com/claude-code)