### PR TITLE
feat: pass rawJson to all RecordFailureAsync calls (#148)

### DIFF
--- a/src/DiscordEventService/Services/EventHandlers/MessageEventHandler.cs
+++ b/src/DiscordEventService/Services/EventHandlers/MessageEventHandler.cs
@@ -174,6 +174,7 @@ public class MessageEventHandler(IServiceScopeFactory scopeFactory, ILogger<Mess
         var correlationId = Guid.NewGuid();
         using (logger.BeginScope(new Dictionary<string, object> { ["CorrelationId"] = correlationId }))
         {
+            string? rawJson = null;
             try
             {
                 var receivedAt = DateTime.UtcNow;
@@ -181,7 +182,7 @@ public class MessageEventHandler(IServiceScopeFactory scopeFactory, ILogger<Mess
                 var db = scope.ServiceProvider.GetRequiredService<DiscordDbContext>();
                 var rawEventService = scope.ServiceProvider.GetRequiredService<RawEventLogService>();
 
-                var rawJson = await rawEventService.SerializeAndLogAsync(
+                rawJson = await rawEventService.SerializeAndLogAsync(
                     e, "MessageUpdated", e.Guild.Id, e.Channel.Id, e.Author?.Id, correlationId: correlationId);
 
                 var attachmentsJson = e.Message.Attachments.Count > 0
@@ -303,7 +304,7 @@ public class MessageEventHandler(IServiceScopeFactory scopeFactory, ILogger<Mess
                 var failedEventService = failureScope.ServiceProvider.GetRequiredService<FailedEventService>();
                 await failedEventService.RecordFailureAsync(
                     "MessageUpdated", nameof(MessageEventHandler), ex,
-                    e.Guild?.Id, e.Channel.Id, e.Author?.Id, correlationId: correlationId);
+                    e.Guild?.Id, e.Channel.Id, e.Author?.Id, eventJson: rawJson, correlationId: correlationId);
             }
         }
     }
@@ -315,6 +316,7 @@ public class MessageEventHandler(IServiceScopeFactory scopeFactory, ILogger<Mess
         var correlationId = Guid.NewGuid();
         using (logger.BeginScope(new Dictionary<string, object> { ["CorrelationId"] = correlationId }))
         {
+            string? rawJson = null;
             try
             {
                 var receivedAt = DateTime.UtcNow;
@@ -322,7 +324,7 @@ public class MessageEventHandler(IServiceScopeFactory scopeFactory, ILogger<Mess
                 var db = scope.ServiceProvider.GetRequiredService<DiscordDbContext>();
                 var rawEventService = scope.ServiceProvider.GetRequiredService<RawEventLogService>();
 
-                var rawJson = await rawEventService.SerializeAndLogAsync(
+                rawJson = await rawEventService.SerializeAndLogAsync(
                     e, "MessageDeleted", e.Guild.Id, e.Channel.Id, e.Message.Author?.Id, correlationId: correlationId);
 
                 // Mark message as deleted
@@ -354,7 +356,7 @@ public class MessageEventHandler(IServiceScopeFactory scopeFactory, ILogger<Mess
                 var failedEventService = failureScope.ServiceProvider.GetRequiredService<FailedEventService>();
                 await failedEventService.RecordFailureAsync(
                     "MessageDeleted", nameof(MessageEventHandler), ex,
-                    e.Guild?.Id, e.Channel.Id, e.Message.Author?.Id, correlationId: correlationId);
+                    e.Guild?.Id, e.Channel.Id, e.Message.Author?.Id, eventJson: rawJson, correlationId: correlationId);
             }
         }
     }
@@ -439,6 +441,7 @@ public class MessageEventHandler(IServiceScopeFactory scopeFactory, ILogger<Mess
         var correlationId = Guid.NewGuid();
         using (logger.BeginScope(new Dictionary<string, object> { ["CorrelationId"] = correlationId }))
         {
+            string? rawJson = null;
             try
             {
                 var receivedAt = DateTime.UtcNow;
@@ -446,7 +449,7 @@ public class MessageEventHandler(IServiceScopeFactory scopeFactory, ILogger<Mess
                 var db = scope.ServiceProvider.GetRequiredService<DiscordDbContext>();
                 var rawEventService = scope.ServiceProvider.GetRequiredService<RawEventLogService>();
 
-                var rawJson = await rawEventService.SerializeAndLogAsync(
+                rawJson = await rawEventService.SerializeAndLogAsync(
                     e, "MessagesBulkDeleted", e.Guild.Id, e.Channel.Id, null, correlationId: correlationId);
 
                 // Mark all messages as deleted
@@ -480,7 +483,7 @@ public class MessageEventHandler(IServiceScopeFactory scopeFactory, ILogger<Mess
                 var failedEventService = failureScope.ServiceProvider.GetRequiredService<FailedEventService>();
                 await failedEventService.RecordFailureAsync(
                     "MessagesBulkDeleted", nameof(MessageEventHandler), ex,
-                    e.Guild?.Id, e.Channel.Id, null, correlationId: correlationId);
+                    e.Guild?.Id, e.Channel.Id, null, eventJson: rawJson, correlationId: correlationId);
             }
         }
     }

--- a/src/DiscordEventService/Services/EventHandlers/PresenceEventHandler.cs
+++ b/src/DiscordEventService/Services/EventHandlers/PresenceEventHandler.cs
@@ -25,6 +25,7 @@ public class PresenceEventHandler(IServiceScopeFactory scopeFactory, ILogger<Pre
         var correlationId = Guid.NewGuid();
         using (logger.BeginScope(new Dictionary<string, object> { ["CorrelationId"] = correlationId }))
         {
+            string? rawJson = null;
             try
             {
                 var now = DateTime.UtcNow;
@@ -57,7 +58,7 @@ public class PresenceEventHandler(IServiceScopeFactory scopeFactory, ILogger<Pre
                     }
                 };
 
-                var rawJson = await rawEventService.SerializeAndLogAsync(
+                rawJson = await rawEventService.SerializeAndLogAsync(
                     eventDto, "PresenceUpdated", guildId, null, args.User.Id, correlationId: correlationId);
 
                 // Record the presence event
@@ -115,7 +116,7 @@ public class PresenceEventHandler(IServiceScopeFactory scopeFactory, ILogger<Pre
                 var failedEventService = failureScope.ServiceProvider.GetRequiredService<FailedEventService>();
                 await failedEventService.RecordFailureAsync(
                     "PresenceUpdated", nameof(PresenceEventHandler), ex,
-                    null, null, args.User.Id, correlationId: correlationId);
+                    null, null, args.User.Id, eventJson: rawJson, correlationId: correlationId);
             }
         }
     }

--- a/src/DiscordEventService/Services/EventHandlers/VoiceEventHandler.cs
+++ b/src/DiscordEventService/Services/EventHandlers/VoiceEventHandler.cs
@@ -14,6 +14,7 @@ public class VoiceEventHandler(IServiceScopeFactory scopeFactory, ILogger<VoiceE
         var correlationId = Guid.NewGuid();
         using (logger.BeginScope(new Dictionary<string, object> { ["CorrelationId"] = correlationId }))
         {
+            string? rawJson = null;
             try
             {
                 var now = DateTime.UtcNow;
@@ -23,7 +24,7 @@ public class VoiceEventHandler(IServiceScopeFactory scopeFactory, ILogger<VoiceE
                 var db = scope.ServiceProvider.GetRequiredService<DiscordDbContext>();
                 var rawEventService = scope.ServiceProvider.GetRequiredService<RawEventLogService>();
 
-                var rawJson = await rawEventService.SerializeAndLogAsync(
+                rawJson = await rawEventService.SerializeAndLogAsync(
                     args, "VoiceStateUpdated", args.Guild.Id, args.After?.Channel?.Id, args.User.Id, correlationId: correlationId);
 
                 var voiceEvent = new VoiceStateEventEntity
@@ -72,7 +73,7 @@ public class VoiceEventHandler(IServiceScopeFactory scopeFactory, ILogger<VoiceE
                 var failedEventService = failureScope.ServiceProvider.GetRequiredService<FailedEventService>();
                 await failedEventService.RecordFailureAsync(
                     "VoiceStateUpdated", nameof(VoiceEventHandler), ex,
-                    args.Guild.Id, args.After?.Channel?.Id, args.User.Id, correlationId: correlationId);
+                    args.Guild.Id, args.After?.Channel?.Id, args.User.Id, eventJson: rawJson, correlationId: correlationId);
             }
         }
     }

--- a/src/DiscordEventService/Services/EventHandlers/VoiceServerEventHandler.cs
+++ b/src/DiscordEventService/Services/EventHandlers/VoiceServerEventHandler.cs
@@ -13,6 +13,7 @@ public class VoiceServerEventHandler(IServiceScopeFactory scopeFactory, ILogger<
         var correlationId = Guid.NewGuid();
         using (logger.BeginScope(new Dictionary<string, object> { ["CorrelationId"] = correlationId }))
         {
+            string? rawJson = null;
             try
             {
                 var now = DateTime.UtcNow;
@@ -23,7 +24,7 @@ public class VoiceServerEventHandler(IServiceScopeFactory scopeFactory, ILogger<
 
                 // TODO: VoiceServerUpdatedEventArgs contains a Token property that may be serialized to raw JSON.
                 // Investigate if this is a security concern and consider excluding it from serialization.
-                var rawJson = await rawEventService.SerializeAndLogAsync(
+                rawJson = await rawEventService.SerializeAndLogAsync(
                     args, "VoiceServerUpdated", args.Guild.Id, null, null, correlationId: correlationId);
 
                 var voiceServerEvent = new VoiceServerEventEntity
@@ -48,7 +49,7 @@ public class VoiceServerEventHandler(IServiceScopeFactory scopeFactory, ILogger<
                 var failedEventService = failureScope.ServiceProvider.GetRequiredService<FailedEventService>();
                 await failedEventService.RecordFailureAsync(
                     "VoiceServerUpdated", nameof(VoiceServerEventHandler), ex,
-                    args.Guild.Id, null, null, correlationId: correlationId);
+                    args.Guild.Id, null, null, eventJson: rawJson, correlationId: correlationId);
             }
         }
     }


### PR DESCRIPTION
## Summary

- Move `rawJson` declaration from inside `try` to before `try` block in 4 handlers (6 methods) so the `catch` block can access it
- Add `eventJson: rawJson` to 6 `RecordFailureAsync` calls that were missing it

### Handlers changed

| Handler | Methods fixed |
|---------|--------------|
| MessageEventHandler | MessageUpdated, MessageDeleted, MessagesBulkDeleted |
| PresenceEventHandler | HandleEventAsync |
| VoiceEventHandler | HandleEventAsync |
| VoiceServerEventHandler | HandleEventAsync |

All 61 `RecordFailureAsync` calls (excluding `GuildEventHandler` which has no serialization) now pass the serialized event payload. If an error occurs after serialization, `failed_events` rows will contain the raw JSON for debugging and potential replay.

## Test plan

- [x] `dotnet build` — 0 errors
- [x] `VALIDATE_AND_EXIT=1 dotnet run` — DI validation passes
- [ ] Deploy and verify failed_events rows (if any) contain event_json

🤖 Generated with [Claude Code](https://claude.com/claude-code)