### PR TITLE
fix: add thread channels to ReactionsBackfillJob + explicit Newtonsoft.Json dep (#145, #149)

### DIFF
--- a/src/DiscordEventService/DiscordEventService.csproj
+++ b/src/DiscordEventService/DiscordEventService.csproj
@@ -9,6 +9,7 @@
   <ItemGroup>
     <PackageReference Include="DotNetEnv" Version="3.1.1" />
     <PackageReference Include="DSharpPlus" Version="5.0.0-nightly-02485" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="10.0.0" />
     <PackageReference Include="EFCore.NamingConventions" Version="10.0.1" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="10.0.2">

--- a/src/DiscordEventService/Jobs/ReactionsBackfillJob.cs
+++ b/src/DiscordEventService/Jobs/ReactionsBackfillJob.cs
@@ -54,7 +54,11 @@ public class ReactionsBackfillJob(
 
             // Get all text channels
             var textChannels = channels
-                .Where(c => c.Type is DiscordChannelType.Text or DiscordChannelType.News)
+                .Where(c => c.Type is DiscordChannelType.Text
+                         or DiscordChannelType.News
+                         or DiscordChannelType.PublicThread
+                         or DiscordChannelType.PrivateThread
+                         or DiscordChannelType.NewsThread)
                 .OrderBy(c => c.Id)
                 .ToList();
 


### PR DESCRIPTION
## Summary

- **#145**: Add `PublicThread | PrivateThread | NewsThread` to `ReactionsBackfillJob` channel filter, matching `MessagesBackfillJob`
- **#149**: Add explicit `Newtonsoft.Json 13.0.3` PackageReference (was transitive from DSharpPlus)

## Test plan

- [x] `dotnet build` — 0 errors
- [ ] Reactions backfill includes thread channels on next run

Closes #145, closes #149.

🤖 Generated with [Claude Code](https://claude.com/claude-code)