### PR TITLE
fix: batch-load open role snapshots instead of per-role queries (#146)

### DIFF
--- a/src/DiscordEventService/Services/MemberRoleSnapshotBackfillService.cs
+++ b/src/DiscordEventService/Services/MemberRoleSnapshotBackfillService.cs
@@ -66,11 +66,15 @@ public class MemberRoleSnapshotBackfillService(
                 ? JsonSerializer.Deserialize<List<ulong>>(evt.RolesRemovedJson) ?? []
                 : [];
 
+            var openRoles = (await db.MemberRoleSnapshots
+                .Where(s => s.MemberId == memberId && s.RevokedAtUtc == null)
+                .Select(s => s.RoleDiscordId)
+                .ToListAsync(ct))
+                .ToHashSet();
+
             foreach (var roleId in rolesAdded)
             {
-                var alreadyOpen = await db.MemberRoleSnapshots
-                    .AnyAsync(s => s.MemberId == memberId && s.RoleDiscordId == roleId && s.RevokedAtUtc == null, ct);
-                if (alreadyOpen)
+                if (openRoles.Contains(roleId))
                     continue;
 
                 try
@@ -148,12 +152,15 @@ public class MemberRoleSnapshotBackfillService(
                 if (!memberLookup.TryGetValue((member.Id, guildDiscordId), out var memberId))
                     continue;
 
+                var openRolesForMember = (await db.MemberRoleSnapshots
+                    .Where(s => s.MemberId == memberId && s.RevokedAtUtc == null)
+                    .Select(s => s.RoleDiscordId)
+                    .ToListAsync(ct))
+                    .ToHashSet();
+
                 foreach (var role in member.Roles)
                 {
-                    var hasOpen = await db.MemberRoleSnapshots
-                        .AnyAsync(s => s.MemberId == memberId && s.RoleDiscordId == role.Id && s.RevokedAtUtc == null, ct);
-
-                    if (hasOpen)
+                    if (openRolesForMember.Contains(role.Id))
                         continue;
 
                     try


### PR DESCRIPTION
## Summary

Replace N+1 `AnyAsync` queries in `MemberRoleSnapshotBackfillService` with a single batch query per member. Both the event-replay loop and the current-role seeding loop had the same pattern: one DB round-trip per role per event/member.

### Before
```csharp
foreach (var roleId in rolesAdded)
{
    var alreadyOpen = await db.MemberRoleSnapshots
        .AnyAsync(s => s.MemberId == memberId && s.RoleDiscordId == roleId && s.RevokedAtUtc == null);
    // O(roles × events) queries
}
```

### After
```csharp
var openRoles = (await db.MemberRoleSnapshots
    .Where(s => s.MemberId == memberId && s.RevokedAtUtc == null)
    .Select(s => s.RoleDiscordId)
    .ToListAsync()).ToHashSet();
// O(1) query per member, HashSet lookup per role
```

## Test plan

- [x] `dotnet build` — 0 errors
- [ ] Next role-snapshot backfill run completes faster

Closes #146.

🤖 Generated with [Claude Code](https://claude.com/claude-code)