### PR TITLE
fix: exclude VoiceToken from raw_event_logs serialization (#147)

### DIFF
--- a/src/DiscordEventService/Services/EventHandlers/VoiceServerEventHandler.cs
+++ b/src/DiscordEventService/Services/EventHandlers/VoiceServerEventHandler.cs
@@ -22,8 +22,6 @@ public class VoiceServerEventHandler(IServiceScopeFactory scopeFactory, ILogger<
                 var db = scope.ServiceProvider.GetRequiredService<DiscordDbContext>();
                 var rawEventService = scope.ServiceProvider.GetRequiredService<RawEventLogService>();
 
-                // TODO: VoiceServerUpdatedEventArgs contains a Token property that may be serialized to raw JSON.
-                // Investigate if this is a security concern and consider excluding it from serialization.
                 rawJson = await rawEventService.SerializeAndLogAsync(
                     args, "VoiceServerUpdated", args.Guild.Id, null, null, correlationId: correlationId);
 

--- a/src/DiscordEventService/Services/RawEventLogService.cs
+++ b/src/DiscordEventService/Services/RawEventLogService.cs
@@ -107,6 +107,11 @@ public class RawEventLogService(DiscordDbContext dbContext, ILogger<RawEventLogS
         // recursion. Strip it so the default object/dictionary serializer runs.
         private const string ProblemConverterName = "SnowflakeArrayAsDictionaryJsonConverter";
 
+        private static readonly HashSet<string> SensitiveProperties = new(StringComparer.OrdinalIgnoreCase)
+        {
+            "VoiceToken"
+        };
+
         protected override JsonProperty CreateProperty(MemberInfo member, MemberSerialization memberSerialization)
         {
             var property = base.CreateProperty(member, memberSerialization);
@@ -116,6 +121,8 @@ public class RawEventLogService(DiscordDbContext dbContext, ILogger<RawEventLogS
                 property.MemberConverter = null;
             if (property.ItemConverter?.GetType().Name == ProblemConverterName)
                 property.ItemConverter = null;
+            if (SensitiveProperties.Contains(member.Name))
+                property.ShouldSerialize = _ => false;
             return property;
         }
 


### PR DESCRIPTION
## Summary

- Add `SensitiveProperties` filter to `BypassRecursiveConverterResolver` in `RawEventLogService` that skips `VoiceToken` during Newtonsoft serialization
- Ephemeral voice server tokens are no longer stored in `raw_event_logs.event_json`
- Remove resolved TODO comment from `VoiceServerEventHandler`

## Test plan

- [x] `dotnet build` — 0 errors
- [ ] After deploy, join a voice channel and verify `raw_event_logs` row for `VoiceServerUpdated` does not contain a `voiceToken` field

Closes #147.

🤖 Generated with [Claude Code](https://claude.com/claude-code)