### PR TITLE
fix: exclude graceful shutdowns from crash-loop detection

### DIFF
--- a/src/DiscordEventService/Jobs/HealthCheckJob.cs
+++ b/src/DiscordEventService/Jobs/HealthCheckJob.cs
@@ -120,7 +120,9 @@ public class HealthCheckJob(
     {
         var windowStart = now.AddMinutes(-30);
         var recentRestarts = await db.BotDowntimeIntervals
-            .Where(d => d.StartedAtUtc > windowStart && d.EndedAtUtc != null)
+            .Where(d => d.StartedAtUtc > windowStart && d.EndedAtUtc != null
+                && d.Type != Data.Entities.Core.BotDowntimeType.GracefulShutdown
+                && d.Type != Data.Entities.Core.BotDowntimeType.Deploy)
             .CountAsync();
 
         if (recentRestarts < 3)


### PR DESCRIPTION
## Summary

Crash-loop detection was alerting on normal deploys. Filter out `GracefulShutdown` and `Deploy` downtime types — only alert on unexpected restarts (HostDown, GatewayDisconnect, Inferred, DbUnreachable).

Triggered by 3 deploys in 30 minutes today producing a false alarm.

## Test plan

- [x] `dotnet build` — 0 errors
- [ ] Deploy multiple times without triggering crash-loop alert

🤖 Generated with [Claude Code](https://claude.com/claude-code)