### PR TITLE
feat: extract EventPipeline — scope, correlation, raw-event flush, failure recording

### DIFF
--- a/src/DiscordEventService/Program.cs
+++ b/src/DiscordEventService/Program.cs
@@ -4,6 +4,7 @@ using DiscordEventService.Endpoints;
 using DiscordEventService.Jobs;
 using DiscordEventService.Services;
 using DiscordEventService.Services.EventHandlers;
+using DiscordEventService.Services.Pipeline;
 using DotNetEnv;
 using DSharpPlus;
 using Hangfire;
@@ -81,6 +82,7 @@ builder.Services.AddSingleton(rootSp =>
             .UseSnakeCaseNamingConvention());
 
         services.AddSingleton<IHostEnvironment>(builder.Environment);
+        services.AddSingleton<EventPipeline>();
         services.AddScoped<UserService>();
         services.AddScoped<GuildUpsertService>();
         services.AddScoped<ChannelUpsertService>();

--- a/src/DiscordEventService/Services/EventHandlers/ReactionEventHandler.cs
+++ b/src/DiscordEventService/Services/EventHandlers/ReactionEventHandler.cs
@@ -1,11 +1,11 @@
-using DiscordEventService.Data;
 using DiscordEventService.Data.Entities.Events;
+using DiscordEventService.Services.Pipeline;
 using DSharpPlus;
 using DSharpPlus.EventArgs;
 
 namespace DiscordEventService.Services.EventHandlers;
 
-public class ReactionEventHandler(IServiceScopeFactory scopeFactory, ILogger<ReactionEventHandler> logger) :
+public sealed class ReactionEventHandler(EventPipeline pipeline) :
     IEventHandler<MessageReactionAddedEventArgs>,
     IEventHandler<MessageReactionRemovedEventArgs>,
     IEventHandler<MessageReactionsClearedEventArgs>,
@@ -15,20 +15,9 @@ public class ReactionEventHandler(IServiceScopeFactory scopeFactory, ILogger<Rea
     {
         if (e.Guild is null) return;
 
-        var correlationId = Guid.NewGuid();
-        using (logger.BeginScope(new Dictionary<string, object> { ["CorrelationId"] = correlationId }))
-        {
-            string? rawJson = null;
-            try
+        await pipeline.Execute(e, "MessageReactionAdded", nameof(ReactionEventHandler),
+            e.Guild.Id, e.Channel.Id, e.User.Id, async ctx =>
             {
-                var receivedAt = DateTime.UtcNow;
-                using var scope = scopeFactory.CreateScope();
-                var db = scope.ServiceProvider.GetRequiredService<DiscordDbContext>();
-                var rawEventService = scope.ServiceProvider.GetRequiredService<RawEventLogService>();
-
-                rawJson = await rawEventService.SerializeAndLogAsync(
-                    e, "MessageReactionAdded", e.Guild.Id, e.Channel.Id, e.User.Id, correlationId: correlationId);
-
                 var reactionEvent = new ReactionEventEntity
                 {
                     MessageDiscordId = e.Message.Id,
@@ -40,44 +29,23 @@ public class ReactionEventHandler(IServiceScopeFactory scopeFactory, ILogger<Rea
                     IsAnimated = e.Emoji.IsAnimated,
                     IsBurst = false,
                     EventType = ReactionEventType.Added,
-                    EventTimestampUtc = receivedAt,
-                    ReceivedAtUtc = receivedAt,
-                    RawEventJson = rawJson
+                    EventTimestampUtc = ctx.ReceivedAtUtc,
+                    ReceivedAtUtc = ctx.ReceivedAtUtc,
+                    RawEventJson = ctx.RawJson
                 };
 
-                db.ReactionEvents.Add(reactionEvent);
-                await db.SaveChangesAsync();
-            }
-            catch (Exception ex)
-            {
-                logger.LogError(ex, "Error handling reaction added for MessageId={MessageId}", e.Message.Id);
-                using var failureScope = scopeFactory.CreateScope();
-                var failedEventService = failureScope.ServiceProvider.GetRequiredService<FailedEventService>();
-                await failedEventService.RecordFailureAsync(
-                    "MessageReactionAdded", nameof(ReactionEventHandler), ex,
-                    e.Guild?.Id, e.Channel.Id, e.User.Id, rawJson, correlationId: correlationId);
-            }
-        }
+                ctx.Db.ReactionEvents.Add(reactionEvent);
+                await ctx.Db.SaveChangesAsync();
+            });
     }
 
     public async Task HandleEventAsync(DiscordClient sender, MessageReactionRemovedEventArgs e)
     {
         if (e.Guild is null) return;
 
-        var correlationId = Guid.NewGuid();
-        using (logger.BeginScope(new Dictionary<string, object> { ["CorrelationId"] = correlationId }))
-        {
-            string? rawJson = null;
-            try
+        await pipeline.Execute(e, "MessageReactionRemoved", nameof(ReactionEventHandler),
+            e.Guild.Id, e.Channel.Id, e.User.Id, async ctx =>
             {
-                var receivedAt = DateTime.UtcNow;
-                using var scope = scopeFactory.CreateScope();
-                var db = scope.ServiceProvider.GetRequiredService<DiscordDbContext>();
-                var rawEventService = scope.ServiceProvider.GetRequiredService<RawEventLogService>();
-
-                rawJson = await rawEventService.SerializeAndLogAsync(
-                    e, "MessageReactionRemoved", e.Guild.Id, e.Channel.Id, e.User.Id, correlationId: correlationId);
-
                 var reactionEvent = new ReactionEventEntity
                 {
                     MessageDiscordId = e.Message.Id,
@@ -89,44 +57,23 @@ public class ReactionEventHandler(IServiceScopeFactory scopeFactory, ILogger<Rea
                     IsAnimated = e.Emoji.IsAnimated,
                     IsBurst = false,
                     EventType = ReactionEventType.Removed,
-                    EventTimestampUtc = receivedAt,
-                    ReceivedAtUtc = receivedAt,
-                    RawEventJson = rawJson
+                    EventTimestampUtc = ctx.ReceivedAtUtc,
+                    ReceivedAtUtc = ctx.ReceivedAtUtc,
+                    RawEventJson = ctx.RawJson
                 };
 
-                db.ReactionEvents.Add(reactionEvent);
-                await db.SaveChangesAsync();
-            }
-            catch (Exception ex)
-            {
-                logger.LogError(ex, "Error handling reaction removed for MessageId={MessageId}", e.Message.Id);
-                using var failureScope = scopeFactory.CreateScope();
-                var failedEventService = failureScope.ServiceProvider.GetRequiredService<FailedEventService>();
-                await failedEventService.RecordFailureAsync(
-                    "MessageReactionRemoved", nameof(ReactionEventHandler), ex,
-                    e.Guild?.Id, e.Channel.Id, e.User.Id, rawJson, correlationId: correlationId);
-            }
-        }
+                ctx.Db.ReactionEvents.Add(reactionEvent);
+                await ctx.Db.SaveChangesAsync();
+            });
     }
 
     public async Task HandleEventAsync(DiscordClient sender, MessageReactionsClearedEventArgs e)
     {
         if (e.Guild is null) return;
 
-        var correlationId = Guid.NewGuid();
-        using (logger.BeginScope(new Dictionary<string, object> { ["CorrelationId"] = correlationId }))
-        {
-            string? rawJson = null;
-            try
+        await pipeline.Execute(e, "MessageReactionsCleared", nameof(ReactionEventHandler),
+            e.Guild.Id, e.Channel.Id, null, async ctx =>
             {
-                var receivedAt = DateTime.UtcNow;
-                using var scope = scopeFactory.CreateScope();
-                var db = scope.ServiceProvider.GetRequiredService<DiscordDbContext>();
-                var rawEventService = scope.ServiceProvider.GetRequiredService<RawEventLogService>();
-
-                rawJson = await rawEventService.SerializeAndLogAsync(
-                    e, "MessageReactionsCleared", e.Guild.Id, e.Channel.Id, null, correlationId: correlationId);
-
                 var reactionEvent = new ReactionEventEntity
                 {
                     MessageDiscordId = e.Message.Id,
@@ -138,44 +85,23 @@ public class ReactionEventHandler(IServiceScopeFactory scopeFactory, ILogger<Rea
                     IsAnimated = false,
                     IsBurst = false,
                     EventType = ReactionEventType.Cleared,
-                    EventTimestampUtc = receivedAt,
-                    ReceivedAtUtc = receivedAt,
-                    RawEventJson = rawJson
+                    EventTimestampUtc = ctx.ReceivedAtUtc,
+                    ReceivedAtUtc = ctx.ReceivedAtUtc,
+                    RawEventJson = ctx.RawJson
                 };
 
-                db.ReactionEvents.Add(reactionEvent);
-                await db.SaveChangesAsync();
-            }
-            catch (Exception ex)
-            {
-                logger.LogError(ex, "Error handling reactions cleared for MessageId={MessageId}", e.Message.Id);
-                using var failureScope = scopeFactory.CreateScope();
-                var failedEventService = failureScope.ServiceProvider.GetRequiredService<FailedEventService>();
-                await failedEventService.RecordFailureAsync(
-                    "MessageReactionsCleared", nameof(ReactionEventHandler), ex,
-                    e.Guild?.Id, e.Channel.Id, null, rawJson, correlationId: correlationId);
-            }
-        }
+                ctx.Db.ReactionEvents.Add(reactionEvent);
+                await ctx.Db.SaveChangesAsync();
+            });
     }
 
     public async Task HandleEventAsync(DiscordClient sender, MessageReactionRemovedEmojiEventArgs e)
     {
         if (e.Guild is null) return;
 
-        var correlationId = Guid.NewGuid();
-        using (logger.BeginScope(new Dictionary<string, object> { ["CorrelationId"] = correlationId }))
-        {
-            string? rawJson = null;
-            try
+        await pipeline.Execute(e, "MessageReactionRemovedEmoji", nameof(ReactionEventHandler),
+            e.Guild.Id, e.Channel.Id, null, async ctx =>
             {
-                var receivedAt = DateTime.UtcNow;
-                using var scope = scopeFactory.CreateScope();
-                var db = scope.ServiceProvider.GetRequiredService<DiscordDbContext>();
-                var rawEventService = scope.ServiceProvider.GetRequiredService<RawEventLogService>();
-
-                rawJson = await rawEventService.SerializeAndLogAsync(
-                    e, "MessageReactionRemovedEmoji", e.Guild.Id, e.Channel.Id, null, correlationId: correlationId);
-
                 var reactionEvent = new ReactionEventEntity
                 {
                     MessageDiscordId = e.Message.Id,
@@ -187,23 +113,13 @@ public class ReactionEventHandler(IServiceScopeFactory scopeFactory, ILogger<Rea
                     IsAnimated = e.Emoji.IsAnimated,
                     IsBurst = false,
                     EventType = ReactionEventType.EmojiCleared,
-                    EventTimestampUtc = receivedAt,
-                    ReceivedAtUtc = receivedAt,
-                    RawEventJson = rawJson
+                    EventTimestampUtc = ctx.ReceivedAtUtc,
+                    ReceivedAtUtc = ctx.ReceivedAtUtc,
+                    RawEventJson = ctx.RawJson
                 };
 
-                db.ReactionEvents.Add(reactionEvent);
-                await db.SaveChangesAsync();
-            }
-            catch (Exception ex)
-            {
-                logger.LogError(ex, "Error handling emoji cleared for MessageId={MessageId}", e.Message.Id);
-                using var failureScope = scopeFactory.CreateScope();
-                var failedEventService = failureScope.ServiceProvider.GetRequiredService<FailedEventService>();
-                await failedEventService.RecordFailureAsync(
-                    "MessageReactionRemovedEmoji", nameof(ReactionEventHandler), ex,
-                    e.Guild?.Id, e.Channel.Id, null, rawJson, correlationId: correlationId);
-            }
-        }
+                ctx.Db.ReactionEvents.Add(reactionEvent);
+                await ctx.Db.SaveChangesAsync();
+            });
     }
 }

--- a/src/DiscordEventService/Services/Pipeline/EventContext.cs
+++ b/src/DiscordEventService/Services/Pipeline/EventContext.cs
@@ -1,0 +1,11 @@
+using DiscordEventService.Data;
+
+namespace DiscordEventService.Services.Pipeline;
+
+public record EventContext(
+    DiscordDbContext Db,
+    IServiceProvider Services,
+    Guid CorrelationId,
+    string? RawJson,
+    DateTime ReceivedAtUtc,
+    ILogger Logger);

--- a/src/DiscordEventService/Services/Pipeline/EventPipeline.cs
+++ b/src/DiscordEventService/Services/Pipeline/EventPipeline.cs
@@ -1,0 +1,49 @@
+using DiscordEventService.Data;
+
+namespace DiscordEventService.Services.Pipeline;
+
+public sealed class EventPipeline(IServiceScopeFactory scopeFactory, ILoggerFactory loggerFactory)
+{
+    public async Task Execute<TEventArgs>(
+        TEventArgs e,
+        string eventType,
+        string handlerName,
+        ulong guildId,
+        ulong? channelId,
+        ulong? userId,
+        Func<EventContext, Task> handler) where TEventArgs : class
+    {
+        var logger = loggerFactory.CreateLogger(handlerName);
+        var correlationId = Guid.NewGuid();
+        using (logger.BeginScope(new Dictionary<string, object> { ["CorrelationId"] = correlationId }))
+        {
+            string? rawJson = null;
+            try
+            {
+                var receivedAt = DateTime.UtcNow;
+                using var scope = scopeFactory.CreateScope();
+                var db = scope.ServiceProvider.GetRequiredService<DiscordDbContext>();
+                var rawEventService = scope.ServiceProvider.GetRequiredService<RawEventLogService>();
+
+                rawJson = await rawEventService.SerializeAndLogAsync(
+                    e, eventType, guildId, channelId, userId, correlationId: correlationId);
+
+                // Flush the raw event row before handler logic. Any ChangeTracker.Clear()
+                // in upsert services would silently drop staged raw_event_logs rows otherwise.
+                await db.SaveChangesAsync();
+
+                var context = new EventContext(db, scope.ServiceProvider, correlationId, rawJson, receivedAt, logger);
+                await handler(context);
+            }
+            catch (Exception ex)
+            {
+                logger.LogError(ex, "Error handling {EventType} in {HandlerName}", eventType, handlerName);
+                using var failureScope = scopeFactory.CreateScope();
+                var failedEventService = failureScope.ServiceProvider.GetRequiredService<FailedEventService>();
+                await failedEventService.RecordFailureAsync(
+                    eventType, handlerName, ex,
+                    guildId, channelId, userId, rawJson, correlationId: correlationId);
+            }
+        }
+    }
+}

--- a/src/DiscordEventService/Services/StartupValidator.cs
+++ b/src/DiscordEventService/Services/StartupValidator.cs
@@ -1,5 +1,6 @@
 using DiscordEventService.Data;
 using DiscordEventService.Jobs;
+using DiscordEventService.Services.Pipeline;
 using Hangfire;
 using Microsoft.Extensions.Caching.Memory;
 
@@ -30,6 +31,7 @@ public static class StartupValidator
         typeof(IHostEnvironment),
         typeof(IMemoryCache),
         typeof(BootQuickSyncService),
+        typeof(EventPipeline),
     ];
 
     public static void ValidateChildContainer(IServiceProvider childProvider, ILogger logger)


### PR DESCRIPTION
## Summary
- Introduce `EventPipeline` + `EventContext` that centralize all event handler ceremony: DI scope lifecycle, correlation ID generation + logger scope, raw-event serialization/flush (before handler logic), and exception → failure recording with an isolated scope
- Migrate `ReactionEventHandler` as proof (209→125 lines, 4 event methods, zero ceremony remaining)
- Old-style and new-style handlers coexist — incremental migration path for remaining 27 handlers

Closes #155

## Test plan
- [ ] `dotnet build` — 0 errors
- [ ] `VALIDATE_AND_EXIT=1 dotnet run` — DI validation passes (13 services)
- [ ] Live test: send reaction in dev Discord → verify `raw_event_logs` + `reaction_events` rows with matching `correlation_id`
- [ ] Remove reaction → verify same
- [ ] Clear reactions → verify same
- [ ] Verify no regressions in other event handlers (they are unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)