### PR TITLE
feat: migrate Typing, Pin, Poll handlers to EventPipeline

### DIFF
--- a/src/DiscordEventService/Services/EventHandlers/PinEventHandler.cs
+++ b/src/DiscordEventService/Services/EventHandlers/PinEventHandler.cs
@@ -1,52 +1,31 @@
-using DiscordEventService.Data;
 using DiscordEventService.Data.Entities.Events;
+using DiscordEventService.Services.Pipeline;
 using DSharpPlus;
 using DSharpPlus.EventArgs;
 
 namespace DiscordEventService.Services.EventHandlers;
 
-public class PinEventHandler(IServiceScopeFactory scopeFactory, ILogger<PinEventHandler> logger) :
+public sealed class PinEventHandler(EventPipeline pipeline) :
     IEventHandler<ChannelPinsUpdatedEventArgs>
 {
     public async Task HandleEventAsync(DiscordClient sender, ChannelPinsUpdatedEventArgs e)
     {
         if (e.Guild is null) return;
 
-        var correlationId = Guid.NewGuid();
-        using (logger.BeginScope(new Dictionary<string, object> { ["CorrelationId"] = correlationId }))
-        {
-            string? rawJson = null;
-            try
+        await pipeline.Execute(e, "ChannelPinsUpdated", nameof(PinEventHandler),
+            e.Guild.Id, e.Channel.Id, null, async ctx =>
             {
-                var now = DateTime.UtcNow;
-                using var scope = scopeFactory.CreateScope();
-                var db = scope.ServiceProvider.GetRequiredService<DiscordDbContext>();
-                var rawEventService = scope.ServiceProvider.GetRequiredService<RawEventLogService>();
-
-                rawJson = await rawEventService.SerializeAndLogAsync(
-                    e, "ChannelPinsUpdated", e.Guild.Id, e.Channel.Id, null, correlationId: correlationId);
-
-                db.PinEvents.Add(new PinEventEntity
+                ctx.Db.PinEvents.Add(new PinEventEntity
                 {
                     ChannelDiscordId = e.Channel.Id,
                     GuildDiscordId = e.Guild.Id,
                     LastPinTimestampUtc = e.LastPinTimestamp?.UtcDateTime,
-                    EventTimestampUtc = now,
-                    ReceivedAtUtc = now,
-                    RawEventJson = rawJson
+                    EventTimestampUtc = ctx.ReceivedAtUtc,
+                    ReceivedAtUtc = ctx.ReceivedAtUtc,
+                    RawEventJson = ctx.RawJson
                 });
 
-                await db.SaveChangesAsync();
-            }
-            catch (Exception ex)
-            {
-                logger.LogError(ex, "Error handling pins updated for ChannelId={ChannelId}", e.Channel.Id);
-                using var failureScope = scopeFactory.CreateScope();
-                var failedEventService = failureScope.ServiceProvider.GetRequiredService<FailedEventService>();
-                await failedEventService.RecordFailureAsync(
-                    "ChannelPinsUpdated", nameof(PinEventHandler), ex,
-                    e.Guild?.Id, e.Channel?.Id, null, rawJson, correlationId: correlationId);
-            }
-        }
+                await ctx.Db.SaveChangesAsync();
+            });
     }
 }

--- a/src/DiscordEventService/Services/EventHandlers/PollEventHandler.cs
+++ b/src/DiscordEventService/Services/EventHandlers/PollEventHandler.cs
@@ -1,11 +1,11 @@
-using DiscordEventService.Data;
 using DiscordEventService.Data.Entities.Events;
+using DiscordEventService.Services.Pipeline;
 using DSharpPlus;
 using DSharpPlus.EventArgs;
 
 namespace DiscordEventService.Services.EventHandlers;
 
-public class PollEventHandler(IServiceScopeFactory scopeFactory, ILogger<PollEventHandler> logger) :
+public sealed class PollEventHandler(EventPipeline pipeline) :
     IEventHandler<MessagePollVotedEventArgs>
 {
     public async Task HandleEventAsync(DiscordClient sender, MessagePollVotedEventArgs e)
@@ -13,44 +13,23 @@ public class PollEventHandler(IServiceScopeFactory scopeFactory, ILogger<PollEve
         var update = e.PollVoteUpdate;
         if (update.Guild is null) return;
 
-        var correlationId = Guid.NewGuid();
-        using (logger.BeginScope(new Dictionary<string, object> { ["CorrelationId"] = correlationId }))
-        {
-            string? rawJson = null;
-            try
+        await pipeline.Execute(e, "MessagePollVoted", nameof(PollEventHandler),
+            update.Guild.Id, update.Message?.ChannelId, update.User?.Id, async ctx =>
             {
-                var now = DateTime.UtcNow;
-                using var scope = scopeFactory.CreateScope();
-                var db = scope.ServiceProvider.GetRequiredService<DiscordDbContext>();
-                var rawEventService = scope.ServiceProvider.GetRequiredService<RawEventLogService>();
-
-                rawJson = await rawEventService.SerializeAndLogAsync(
-                    e, "MessagePollVoted", update.Guild.Id, update.Message?.ChannelId, update.User?.Id, correlationId: correlationId);
-
-                db.PollEvents.Add(new PollEventEntity
+                ctx.Db.PollEvents.Add(new PollEventEntity
                 {
                     MessageDiscordId = update.Message?.Id ?? 0,
                     ChannelDiscordId = update.Message?.ChannelId ?? 0,
                     GuildDiscordId = update.Guild.Id,
                     UserDiscordId = update.User?.Id ?? 0,
-                    AnswerId = 0, // AnswerId not exposed in this event
+                    AnswerId = 0,
                     EventType = update.WasAdded ? PollEventType.VoteAdded : PollEventType.VoteRemoved,
-                    EventTimestampUtc = now,
-                    ReceivedAtUtc = now,
-                    RawEventJson = rawJson
+                    EventTimestampUtc = ctx.ReceivedAtUtc,
+                    ReceivedAtUtc = ctx.ReceivedAtUtc,
+                    RawEventJson = ctx.RawJson
                 });
 
-                await db.SaveChangesAsync();
-            }
-            catch (Exception ex)
-            {
-                logger.LogError(ex, "Error handling poll vote");
-                using var failureScope = scopeFactory.CreateScope();
-                var failedEventService = failureScope.ServiceProvider.GetRequiredService<FailedEventService>();
-                await failedEventService.RecordFailureAsync(
-                    "MessagePollVoted", nameof(PollEventHandler), ex,
-                    update.Guild?.Id, update.Message?.ChannelId, update.User?.Id, rawJson, correlationId: correlationId);
-            }
-        }
+                await ctx.Db.SaveChangesAsync();
+            });
     }
 }

--- a/src/DiscordEventService/Services/EventHandlers/TypingEventHandler.cs
+++ b/src/DiscordEventService/Services/EventHandlers/TypingEventHandler.cs
@@ -1,61 +1,38 @@
-using DiscordEventService.Data;
 using DiscordEventService.Data.Entities.Events;
+using DiscordEventService.Services.Pipeline;
 using DSharpPlus;
 using DSharpPlus.EventArgs;
 using Microsoft.Extensions.Caching.Memory;
 
 namespace DiscordEventService.Services.EventHandlers;
 
-public class TypingEventHandler(IServiceScopeFactory scopeFactory, ILogger<TypingEventHandler> logger, IMemoryCache cache) :
+public sealed class TypingEventHandler(EventPipeline pipeline, IMemoryCache cache) :
     IEventHandler<TypingStartedEventArgs>
 {
     private static readonly TimeSpan ThrottleWindow = TimeSpan.FromSeconds(10);
 
     public async Task HandleEventAsync(DiscordClient sender, TypingStartedEventArgs e)
     {
-        var correlationId = Guid.NewGuid();
-        using (logger.BeginScope(new Dictionary<string, object> { ["CorrelationId"] = correlationId }))
-        {
-            string? rawJson = null;
-            try
+        var cacheKey = $"typing:{e.User.Id}:{e.Channel.Id}";
+        if (cache.TryGetValue(cacheKey, out _))
+            return;
+        cache.Set(cacheKey, true, ThrottleWindow);
+
+        await pipeline.Execute(e, "TypingStarted", nameof(TypingEventHandler),
+            e.Guild?.Id ?? 0, e.Channel.Id, e.User.Id, async ctx =>
             {
-                // Throttle: skip if we've seen this user+channel combo recently
-                var cacheKey = $"typing:{e.User.Id}:{e.Channel.Id}";
-                if (cache.TryGetValue(cacheKey, out _))
-                {
-                    return;
-                }
-                cache.Set(cacheKey, true, ThrottleWindow);
-
-                using var scope = scopeFactory.CreateScope();
-                var db = scope.ServiceProvider.GetRequiredService<DiscordDbContext>();
-                var rawEventService = scope.ServiceProvider.GetRequiredService<RawEventLogService>();
-
-                rawJson = await rawEventService.SerializeAndLogAsync(
-                    e, "TypingStarted", e.Guild?.Id ?? 0, e.Channel.Id, e.User.Id, correlationId: correlationId);
-
                 var entity = new TypingEventEntity
                 {
                     UserDiscordId = e.User.Id,
                     ChannelDiscordId = e.Channel.Id,
                     GuildDiscordId = e.Guild?.Id,
                     StartedAt = e.StartedAt.UtcDateTime,
-                    ReceivedAtUtc = DateTime.UtcNow,
-                    RawEventJson = rawJson
+                    ReceivedAtUtc = ctx.ReceivedAtUtc,
+                    RawEventJson = ctx.RawJson
                 };
 
-                db.TypingEvents.Add(entity);
-                await db.SaveChangesAsync();
-            }
-            catch (Exception ex)
-            {
-                logger.LogError(ex, "Error handling typing started");
-                using var failureScope = scopeFactory.CreateScope();
-                var failedEventService = failureScope.ServiceProvider.GetRequiredService<FailedEventService>();
-                await failedEventService.RecordFailureAsync(
-                    "TypingStarted", nameof(TypingEventHandler), ex,
-                    e.Guild?.Id, e.Channel?.Id, e.User?.Id, rawJson, correlationId: correlationId);
-            }
-        }
+                ctx.Db.TypingEvents.Add(entity);
+                await ctx.Db.SaveChangesAsync();
+            });
     }
 }


### PR DESCRIPTION
## Summary
- Migrate `TypingEventHandler`, `PinEventHandler`, `PollEventHandler` onto `EventPipeline` from #155
- Each handler loses all ceremony (scope, correlation, raw-event flush, try/catch/failure recording)
- `TypingEventHandler` retains its `IMemoryCache` throttle before the pipeline call
- Net: -65 lines (35 added, 100 removed)

Closes #156

## Test plan
- [ ] `dotnet build` — 0 errors
- [ ] `VALIDATE_AND_EXIT=1 dotnet run` — DI validation passes (13 services)
- [ ] Live test: type in dev Discord → verify `typing_events` row
- [ ] Live test: pin/unpin a message → verify `pin_events` row
- [ ] No regressions in other event handlers

🤖 Generated with [Claude Code](https://claude.com/claude-code)