### PR TITLE
feat: migrate thin event handlers to EventPipeline (#157)

### DIFF
--- a/src/DiscordEventService/Services/EventHandlers/AuditLogEventHandler.cs
+++ b/src/DiscordEventService/Services/EventHandlers/AuditLogEventHandler.cs
@@ -1,30 +1,19 @@
-using DiscordEventService.Data;
 using DiscordEventService.Data.Entities.Events;
+using DiscordEventService.Services.Pipeline;
 using DSharpPlus;
 using DSharpPlus.EventArgs;
 
 namespace DiscordEventService.Services.EventHandlers;
 
-public class AuditLogEventHandler(IServiceScopeFactory scopeFactory, ILogger<AuditLogEventHandler> logger) :
+public sealed class AuditLogEventHandler(EventPipeline pipeline) :
     IEventHandler<GuildAuditLogCreatedEventArgs>
 {
     public async Task HandleEventAsync(DiscordClient sender, GuildAuditLogCreatedEventArgs e)
     {
-        var correlationId = Guid.NewGuid();
-        using (logger.BeginScope(new Dictionary<string, object> { ["CorrelationId"] = correlationId }))
-        {
-            string? rawJson = null;
-            try
+        await pipeline.Execute(e, "GuildAuditLogCreated", nameof(AuditLogEventHandler),
+            e.Guild.Id, null, e.AuditLogEntry.UserResponsible?.Id, async ctx =>
             {
-                var now = DateTime.UtcNow;
-                using var scope = scopeFactory.CreateScope();
-                var db = scope.ServiceProvider.GetRequiredService<DiscordDbContext>();
-                var rawEventService = scope.ServiceProvider.GetRequiredService<RawEventLogService>();
-
-                rawJson = await rawEventService.SerializeAndLogAsync(
-                    e, "GuildAuditLogCreated", e.Guild.Id, null, e.AuditLogEntry.UserResponsible?.Id, correlationId: correlationId);
-
-                db.AuditLogEvents.Add(new AuditLogEventEntity
+                ctx.Db.AuditLogEvents.Add(new AuditLogEventEntity
                 {
                     AuditLogDiscordId = e.AuditLogEntry.Id,
                     GuildDiscordId = e.Guild.Id,
@@ -34,22 +23,12 @@ public class AuditLogEventHandler(IServiceScopeFactory scopeFactory, ILogger<Aud
                     Reason = e.AuditLogEntry.Reason,
                     ChangesJson = null,
                     OptionsJson = null,
-                    EventTimestampUtc = now,
-                    ReceivedAtUtc = now,
-                    RawEventJson = rawJson
+                    EventTimestampUtc = ctx.ReceivedAtUtc,
+                    ReceivedAtUtc = ctx.ReceivedAtUtc,
+                    RawEventJson = ctx.RawJson
                 });
 
-                await db.SaveChangesAsync();
-            }
-            catch (Exception ex)
-            {
-                logger.LogError(ex, "Error handling audit log entry");
-                using var failureScope = scopeFactory.CreateScope();
-                var failedEventService = failureScope.ServiceProvider.GetRequiredService<FailedEventService>();
-                await failedEventService.RecordFailureAsync(
-                    "GuildAuditLogCreated", nameof(AuditLogEventHandler), ex,
-                    e.Guild?.Id, null, e.AuditLogEntry?.UserResponsible?.Id, rawJson, correlationId: correlationId);
-            }
-        }
+                await ctx.Db.SaveChangesAsync();
+            });
     }
 }

--- a/src/DiscordEventService/Services/EventHandlers/ThreadSyncHandler.cs
+++ b/src/DiscordEventService/Services/EventHandlers/ThreadSyncHandler.cs
@@ -1,12 +1,12 @@
-using DiscordEventService.Data;
 using DiscordEventService.Data.Entities.Events;
+using DiscordEventService.Services.Pipeline;
 using DSharpPlus;
 using DSharpPlus.EventArgs;
 using System.Text.Json;
 
 namespace DiscordEventService.Services.EventHandlers;
 
-public class ThreadSyncHandler(IServiceScopeFactory scopeFactory, ILogger<ThreadSyncHandler> logger) :
+public sealed class ThreadSyncHandler(EventPipeline pipeline) :
     IEventHandler<ThreadListSyncedEventArgs>
 {
     private static readonly JsonSerializerOptions JsonOptions = new()
@@ -17,22 +17,10 @@ public class ThreadSyncHandler(IServiceScopeFactory scopeFactory, ILogger<Thread
 
     public async Task HandleEventAsync(DiscordClient sender, ThreadListSyncedEventArgs args)
     {
-        var correlationId = Guid.NewGuid();
-        using (logger.BeginScope(new Dictionary<string, object> { ["CorrelationId"] = correlationId }))
-        {
-            string? rawJson = null;
-            try
+        await pipeline.Execute(args, "ThreadListSynced", nameof(ThreadSyncHandler),
+            args.Guild.Id, null, null, async ctx =>
             {
-                var now = DateTime.UtcNow;
-
-                using var scope = scopeFactory.CreateScope();
-                var db = scope.ServiceProvider.GetRequiredService<DiscordDbContext>();
-                var rawEventService = scope.ServiceProvider.GetRequiredService<RawEventLogService>();
-
-                rawJson = await rawEventService.SerializeAndLogAsync(
-                    args, "ThreadListSynced", args.Guild.Id, null, null, correlationId: correlationId);
-
-                var syncEvent = new ThreadSyncEventEntity
+                ctx.Db.ThreadSyncEvents.Add(new ThreadSyncEventEntity
                 {
                     GuildDiscordId = args.Guild.Id,
                     ThreadCount = args.Threads.Count,
@@ -40,26 +28,15 @@ public class ThreadSyncHandler(IServiceScopeFactory scopeFactory, ILogger<Thread
                     ChannelIdsJson = args.Channels?.Count > 0
                         ? JsonSerializer.Serialize(args.Channels.Select(c => c.Id.ToString()), JsonOptions)
                         : null,
-                    EventTimestampUtc = now,
-                    ReceivedAtUtc = now,
-                    RawEventJson = rawJson
-                };
+                    EventTimestampUtc = ctx.ReceivedAtUtc,
+                    ReceivedAtUtc = ctx.ReceivedAtUtc,
+                    RawEventJson = ctx.RawJson
+                });
 
-                await db.ThreadSyncEvents.AddAsync(syncEvent);
-                await db.SaveChangesAsync();
+                await ctx.Db.SaveChangesAsync();
 
-                logger.LogDebug("Recorded thread list sync for guild {GuildId} with {ThreadCount} threads",
+                ctx.Logger.LogDebug("Recorded thread list sync for guild {GuildId} with {ThreadCount} threads",
                     args.Guild.Id, args.Threads.Count);
-            }
-            catch (Exception ex)
-            {
-                logger.LogError(ex, "Error handling thread list sync for guild {GuildId}", args.Guild.Id);
-                using var failureScope = scopeFactory.CreateScope();
-                var failedEventService = failureScope.ServiceProvider.GetRequiredService<FailedEventService>();
-                await failedEventService.RecordFailureAsync(
-                    "ThreadListSynced", nameof(ThreadSyncHandler), ex,
-                    args.Guild?.Id, null, null, rawJson, correlationId: correlationId);
-            }
-        }
+            });
     }
 }

--- a/src/DiscordEventService/Services/EventHandlers/VoiceEventHandler.cs
+++ b/src/DiscordEventService/Services/EventHandlers/VoiceEventHandler.cs
@@ -1,33 +1,21 @@
-using DiscordEventService.Data;
 using DiscordEventService.Data.Entities.Events;
-using DiscordEventService.Services;
+using DiscordEventService.Services.Pipeline;
 using DSharpPlus;
 using DSharpPlus.EventArgs;
 
 namespace DiscordEventService.Services.EventHandlers;
 
-public class VoiceEventHandler(IServiceScopeFactory scopeFactory, ILogger<VoiceEventHandler> logger) :
+public sealed class VoiceEventHandler(EventPipeline pipeline) :
     IEventHandler<VoiceStateUpdatedEventArgs>
 {
     public async Task HandleEventAsync(DiscordClient sender, VoiceStateUpdatedEventArgs args)
     {
-        var correlationId = Guid.NewGuid();
-        using (logger.BeginScope(new Dictionary<string, object> { ["CorrelationId"] = correlationId }))
-        {
-            string? rawJson = null;
-            try
+        var eventType = DetermineEventType(args);
+
+        await pipeline.Execute(args, "VoiceStateUpdated", nameof(VoiceEventHandler),
+            args.Guild.Id, args.After?.Channel?.Id, args.User.Id, async ctx =>
             {
-                var now = DateTime.UtcNow;
-                var eventType = DetermineEventType(args);
-
-                using var scope = scopeFactory.CreateScope();
-                var db = scope.ServiceProvider.GetRequiredService<DiscordDbContext>();
-                var rawEventService = scope.ServiceProvider.GetRequiredService<RawEventLogService>();
-
-                rawJson = await rawEventService.SerializeAndLogAsync(
-                    args, "VoiceStateUpdated", args.Guild.Id, args.After?.Channel?.Id, args.User.Id, correlationId: correlationId);
-
-                var voiceEvent = new VoiceStateEventEntity
+                ctx.Db.VoiceStateEvents.Add(new VoiceStateEventEntity
                 {
                     UserDiscordId = args.User.Id,
                     GuildDiscordId = args.Guild.Id,
@@ -54,28 +42,16 @@ public class VoiceEventHandler(IServiceScopeFactory scopeFactory, ILogger<VoiceE
                     IsSuppressed = args.After?.IsSuppressed ?? false,
 
                     SessionId = args.After?.SessionId,
-                    EventTimestampUtc = now,
-                    ReceivedAtUtc = now,
-                    RawEventJson = rawJson
-                };
+                    EventTimestampUtc = ctx.ReceivedAtUtc,
+                    ReceivedAtUtc = ctx.ReceivedAtUtc,
+                    RawEventJson = ctx.RawJson
+                });
 
-                db.VoiceStateEvents.Add(voiceEvent);
-                await db.SaveChangesAsync();
+                await ctx.Db.SaveChangesAsync();
 
-                logger.LogDebug("Recorded voice event: {EventType} for user {UserId} in guild {GuildId}",
+                ctx.Logger.LogDebug("Recorded voice event: {EventType} for user {UserId} in guild {GuildId}",
                     eventType, args.User.Id, args.Guild.Id);
-            }
-            catch (Exception ex)
-            {
-                logger.LogError(ex, "Error handling voice state update for user {UserId} in guild {GuildId}",
-                    args.User.Id, args.Guild.Id);
-                using var failureScope = scopeFactory.CreateScope();
-                var failedEventService = failureScope.ServiceProvider.GetRequiredService<FailedEventService>();
-                await failedEventService.RecordFailureAsync(
-                    "VoiceStateUpdated", nameof(VoiceEventHandler), ex,
-                    args.Guild.Id, args.After?.Channel?.Id, args.User.Id, eventJson: rawJson, correlationId: correlationId);
-            }
-        }
+            });
     }
 
     private static VoiceEventType DetermineEventType(VoiceStateUpdatedEventArgs args)

--- a/src/DiscordEventService/Services/EventHandlers/VoiceServerEventHandler.cs
+++ b/src/DiscordEventService/Services/EventHandlers/VoiceServerEventHandler.cs
@@ -1,54 +1,31 @@
-using DiscordEventService.Data;
 using DiscordEventService.Data.Entities.Events;
+using DiscordEventService.Services.Pipeline;
 using DSharpPlus;
 using DSharpPlus.EventArgs;
 
 namespace DiscordEventService.Services.EventHandlers;
 
-public class VoiceServerEventHandler(IServiceScopeFactory scopeFactory, ILogger<VoiceServerEventHandler> logger) :
+public sealed class VoiceServerEventHandler(EventPipeline pipeline) :
     IEventHandler<VoiceServerUpdatedEventArgs>
 {
     public async Task HandleEventAsync(DiscordClient sender, VoiceServerUpdatedEventArgs args)
     {
-        var correlationId = Guid.NewGuid();
-        using (logger.BeginScope(new Dictionary<string, object> { ["CorrelationId"] = correlationId }))
-        {
-            string? rawJson = null;
-            try
+        await pipeline.Execute(args, "VoiceServerUpdated", nameof(VoiceServerEventHandler),
+            args.Guild.Id, null, null, async ctx =>
             {
-                var now = DateTime.UtcNow;
-
-                using var scope = scopeFactory.CreateScope();
-                var db = scope.ServiceProvider.GetRequiredService<DiscordDbContext>();
-                var rawEventService = scope.ServiceProvider.GetRequiredService<RawEventLogService>();
-
-                rawJson = await rawEventService.SerializeAndLogAsync(
-                    args, "VoiceServerUpdated", args.Guild.Id, null, null, correlationId: correlationId);
-
-                var voiceServerEvent = new VoiceServerEventEntity
+                ctx.Db.VoiceServerEvents.Add(new VoiceServerEventEntity
                 {
                     GuildDiscordId = args.Guild.Id,
                     Endpoint = args.Endpoint,
-                    EventTimestampUtc = now,
-                    ReceivedAtUtc = now,
-                    RawEventJson = rawJson
-                };
+                    EventTimestampUtc = ctx.ReceivedAtUtc,
+                    ReceivedAtUtc = ctx.ReceivedAtUtc,
+                    RawEventJson = ctx.RawJson
+                });
 
-                await db.VoiceServerEvents.AddAsync(voiceServerEvent);
-                await db.SaveChangesAsync();
+                await ctx.Db.SaveChangesAsync();
 
-                logger.LogDebug("Recorded voice server event for guild {GuildId}, endpoint {Endpoint}",
+                ctx.Logger.LogDebug("Recorded voice server event for guild {GuildId}, endpoint {Endpoint}",
                     args.Guild.Id, args.Endpoint);
-            }
-            catch (Exception ex)
-            {
-                logger.LogError(ex, "Error handling voice server update for guild {GuildId}", args.Guild.Id);
-                using var failureScope = scopeFactory.CreateScope();
-                var failedEventService = failureScope.ServiceProvider.GetRequiredService<FailedEventService>();
-                await failedEventService.RecordFailureAsync(
-                    "VoiceServerUpdated", nameof(VoiceServerEventHandler), ex,
-                    args.Guild.Id, null, null, eventJson: rawJson, correlationId: correlationId);
-            }
-        }
+            });
     }
 }

--- a/src/DiscordEventService/Services/EventHandlers/WebhookEventHandler.cs
+++ b/src/DiscordEventService/Services/EventHandlers/WebhookEventHandler.cs
@@ -1,49 +1,28 @@
-using DiscordEventService.Data;
 using DiscordEventService.Data.Entities.Events;
+using DiscordEventService.Services.Pipeline;
 using DSharpPlus;
 using DSharpPlus.EventArgs;
 
 namespace DiscordEventService.Services.EventHandlers;
 
-public class WebhookEventHandler(IServiceScopeFactory scopeFactory, ILogger<WebhookEventHandler> logger) :
+public sealed class WebhookEventHandler(EventPipeline pipeline) :
     IEventHandler<WebhooksUpdatedEventArgs>
 {
     public async Task HandleEventAsync(DiscordClient sender, WebhooksUpdatedEventArgs e)
     {
-        var correlationId = Guid.NewGuid();
-        using (logger.BeginScope(new Dictionary<string, object> { ["CorrelationId"] = correlationId }))
-        {
-            string? rawJson = null;
-            try
+        await pipeline.Execute(e, "WebhooksUpdated", nameof(WebhookEventHandler),
+            e.Guild.Id, e.Channel.Id, null, async ctx =>
             {
-                var now = DateTime.UtcNow;
-                using var scope = scopeFactory.CreateScope();
-                var db = scope.ServiceProvider.GetRequiredService<DiscordDbContext>();
-                var rawEventService = scope.ServiceProvider.GetRequiredService<RawEventLogService>();
-
-                rawJson = await rawEventService.SerializeAndLogAsync(
-                    e, "WebhooksUpdated", e.Guild.Id, e.Channel.Id, null, correlationId: correlationId);
-
-                db.WebhookEvents.Add(new WebhookEventEntity
+                ctx.Db.WebhookEvents.Add(new WebhookEventEntity
                 {
                     GuildDiscordId = e.Guild.Id,
                     ChannelDiscordId = e.Channel.Id,
-                    EventTimestampUtc = now,
-                    ReceivedAtUtc = now,
-                    RawEventJson = rawJson
+                    EventTimestampUtc = ctx.ReceivedAtUtc,
+                    ReceivedAtUtc = ctx.ReceivedAtUtc,
+                    RawEventJson = ctx.RawJson
                 });
 
-                await db.SaveChangesAsync();
-            }
-            catch (Exception ex)
-            {
-                logger.LogError(ex, "Error handling webhooks updated for ChannelId={ChannelId}", e.Channel.Id);
-                using var failureScope = scopeFactory.CreateScope();
-                var failedEventService = failureScope.ServiceProvider.GetRequiredService<FailedEventService>();
-                await failedEventService.RecordFailureAsync(
-                    "WebhooksUpdated", nameof(WebhookEventHandler), ex,
-                    e.Guild?.Id, e.Channel?.Id, null, rawJson, correlationId: correlationId);
-            }
-        }
+                await ctx.Db.SaveChangesAsync();
+            });
     }
 }


### PR DESCRIPTION
## Summary
Part 1 of §A1.3 (#157) — migrates the **5 thin handlers** (no upsert services) onto `EventPipeline`, removing per-handler DI-scope / correlation-ID / raw-event-serialization / try-catch-failure ceremony.

- `WebhookEventHandler`, `AuditLogEventHandler`, `VoiceServerEventHandler`, `VoiceEventHandler`, `ThreadSyncHandler`
- Each now takes `EventPipeline` via primary ctor and writes its event row inside `pipeline.Execute(...)` using `ctx.Db` / `ctx.RawJson` / `ctx.ReceivedAtUtc` / `ctx.Logger`
- Net **-112 lines** (58 insertions, 170 deletions)
- No DI registration changes (handlers stay `Scoped`, depend on the `EventPipeline` singleton)

Follow-ups in this issue: PR2 multi-method (AutoMod/StageInstance/Scheduled), PR3 upsert (Ban/Emoji/Sticker/Integration/Invite/AutoModRule), PR4 entity-upsert+23505 (Channel/Role/Thread).

## Test plan
- [x] `dotnet build` — 0 errors (pre-existing warnings only, none in changed files)
- [x] `VALIDATE_AND_EXIT=1 dotnet run` — DSharpPlus child container DI validation passed
- [x] Local live test (dev bot + dev server), zero `Error handling` lines, zero failure rows:
  - [x] `VoiceStateUpdated` — join+leave → `voice_state_events` +2
  - [x] `GuildAuditLogCreated` — channel rename + webhook ops → `audit_log_events` +4
  - [x] `WebhooksUpdated` — webhook create+delete → `webhook_events` +2
- [ ] `VoiceServerUpdated` / `ThreadListSynced` — not on-demand triggerable (fire on bot voice-connect / guild-sync); structurally identical migration, will confirm via Loki post-deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)