### PR TITLE
feat: migrate multi-method event handlers to EventPipeline (#157)

### DIFF
--- a/src/DiscordEventService/Services/EventHandlers/AutoModEventHandler.cs
+++ b/src/DiscordEventService/Services/EventHandlers/AutoModEventHandler.cs
@@ -1,11 +1,11 @@
-using DiscordEventService.Data;
 using DiscordEventService.Data.Entities.Events;
+using DiscordEventService.Services.Pipeline;
 using DSharpPlus;
 using DSharpPlus.EventArgs;
 
 namespace DiscordEventService.Services.EventHandlers;
 
-public class AutoModEventHandler(IServiceScopeFactory scopeFactory, ILogger<AutoModEventHandler> logger) :
+public sealed class AutoModEventHandler(EventPipeline pipeline) :
     IEventHandler<AutoModerationRuleCreatedEventArgs>,
     IEventHandler<AutoModerationRuleUpdatedEventArgs>,
     IEventHandler<AutoModerationRuleDeletedEventArgs>,
@@ -13,157 +13,80 @@ public class AutoModEventHandler(IServiceScopeFactory scopeFactory, ILogger<Auto
 {
     public async Task HandleEventAsync(DiscordClient sender, AutoModerationRuleCreatedEventArgs e)
     {
-        var correlationId = Guid.NewGuid();
-        using (logger.BeginScope(new Dictionary<string, object> { ["CorrelationId"] = correlationId }))
-        {
-            string? rawJson = null;
-            try
+        if (e.Rule?.Guild is null) return;
+
+        await pipeline.Execute(e, "AutoModRuleCreated", nameof(AutoModEventHandler),
+            e.Rule.Guild.Id, null, e.Rule.Creator?.Id, async ctx =>
             {
-                if (e.Rule?.Guild is null) return;
-
-                var now = DateTime.UtcNow;
-                using var scope = scopeFactory.CreateScope();
-                var db = scope.ServiceProvider.GetRequiredService<DiscordDbContext>();
-                var rawEventService = scope.ServiceProvider.GetRequiredService<RawEventLogService>();
-
-                rawJson = await rawEventService.SerializeAndLogAsync(
-                    e, "AutoModRuleCreated", e.Rule.Guild.Id, null, e.Rule.Creator?.Id, correlationId: correlationId);
-
-                var entity = new AutoModEventEntity
+                ctx.Db.AutoModEvents.Add(new AutoModEventEntity
                 {
                     GuildDiscordId = e.Rule.Guild.Id,
                     RuleDiscordId = e.Rule.Id,
                     EventType = AutoModEventType.RuleCreated,
                     RuleName = e.Rule.Name,
                     TriggerType = (int)e.Rule.TriggerType,
-                    EventTimestampUtc = now,
-                    ReceivedAtUtc = now,
-                    RawEventJson = rawJson
-                };
+                    EventTimestampUtc = ctx.ReceivedAtUtc,
+                    ReceivedAtUtc = ctx.ReceivedAtUtc,
+                    RawEventJson = ctx.RawJson
+                });
 
-                db.AutoModEvents.Add(entity);
-                await db.SaveChangesAsync();
-            }
-            catch (Exception ex)
-            {
-                logger.LogError(ex, "Error handling automod rule created");
-                using var failureScope = scopeFactory.CreateScope();
-                var failedEventService = failureScope.ServiceProvider.GetRequiredService<FailedEventService>();
-                await failedEventService.RecordFailureAsync(
-                    "AutoModRuleCreated", nameof(AutoModEventHandler), ex,
-                    e.Rule?.Guild?.Id, null, e.Rule?.Creator?.Id, rawJson, correlationId: correlationId);
-            }
-        }
+                await ctx.Db.SaveChangesAsync();
+            });
     }
 
     public async Task HandleEventAsync(DiscordClient sender, AutoModerationRuleUpdatedEventArgs e)
     {
-        var correlationId = Guid.NewGuid();
-        using (logger.BeginScope(new Dictionary<string, object> { ["CorrelationId"] = correlationId }))
-        {
-            string? rawJson = null;
-            try
+        if (e.Rule?.Guild is null) return;
+
+        await pipeline.Execute(e, "AutoModRuleUpdated", nameof(AutoModEventHandler),
+            e.Rule.Guild.Id, null, e.Rule.Creator?.Id, async ctx =>
             {
-                if (e.Rule?.Guild is null) return;
-
-                var now = DateTime.UtcNow;
-                using var scope = scopeFactory.CreateScope();
-                var db = scope.ServiceProvider.GetRequiredService<DiscordDbContext>();
-                var rawEventService = scope.ServiceProvider.GetRequiredService<RawEventLogService>();
-
-                rawJson = await rawEventService.SerializeAndLogAsync(
-                    e, "AutoModRuleUpdated", e.Rule.Guild.Id, null, e.Rule.Creator?.Id, correlationId: correlationId);
-
-                var entity = new AutoModEventEntity
+                ctx.Db.AutoModEvents.Add(new AutoModEventEntity
                 {
                     GuildDiscordId = e.Rule.Guild.Id,
                     RuleDiscordId = e.Rule.Id,
                     EventType = AutoModEventType.RuleUpdated,
                     RuleName = e.Rule.Name,
                     TriggerType = (int)e.Rule.TriggerType,
-                    EventTimestampUtc = now,
-                    ReceivedAtUtc = now,
-                    RawEventJson = rawJson
-                };
+                    EventTimestampUtc = ctx.ReceivedAtUtc,
+                    ReceivedAtUtc = ctx.ReceivedAtUtc,
+                    RawEventJson = ctx.RawJson
+                });
 
-                db.AutoModEvents.Add(entity);
-                await db.SaveChangesAsync();
-            }
-            catch (Exception ex)
-            {
-                logger.LogError(ex, "Error handling automod rule updated");
-                using var failureScope = scopeFactory.CreateScope();
-                var failedEventService = failureScope.ServiceProvider.GetRequiredService<FailedEventService>();
-                await failedEventService.RecordFailureAsync(
-                    "AutoModRuleUpdated", nameof(AutoModEventHandler), ex,
-                    e.Rule?.Guild?.Id, null, e.Rule?.Creator?.Id, rawJson, correlationId: correlationId);
-            }
-        }
+                await ctx.Db.SaveChangesAsync();
+            });
     }
 
     public async Task HandleEventAsync(DiscordClient sender, AutoModerationRuleDeletedEventArgs e)
     {
-        var correlationId = Guid.NewGuid();
-        using (logger.BeginScope(new Dictionary<string, object> { ["CorrelationId"] = correlationId }))
-        {
-            string? rawJson = null;
-            try
+        if (e.Rule?.Guild is null) return;
+
+        await pipeline.Execute(e, "AutoModRuleDeleted", nameof(AutoModEventHandler),
+            e.Rule.Guild.Id, null, e.Rule.Creator?.Id, async ctx =>
             {
-                if (e.Rule?.Guild is null) return;
-
-                var now = DateTime.UtcNow;
-                using var scope = scopeFactory.CreateScope();
-                var db = scope.ServiceProvider.GetRequiredService<DiscordDbContext>();
-                var rawEventService = scope.ServiceProvider.GetRequiredService<RawEventLogService>();
-
-                rawJson = await rawEventService.SerializeAndLogAsync(
-                    e, "AutoModRuleDeleted", e.Rule.Guild.Id, null, e.Rule.Creator?.Id, correlationId: correlationId);
-
-                var entity = new AutoModEventEntity
+                ctx.Db.AutoModEvents.Add(new AutoModEventEntity
                 {
                     GuildDiscordId = e.Rule.Guild.Id,
                     RuleDiscordId = e.Rule.Id,
                     EventType = AutoModEventType.RuleDeleted,
                     RuleName = e.Rule.Name,
                     TriggerType = (int)e.Rule.TriggerType,
-                    EventTimestampUtc = now,
-                    ReceivedAtUtc = now,
-                    RawEventJson = rawJson
-                };
+                    EventTimestampUtc = ctx.ReceivedAtUtc,
+                    ReceivedAtUtc = ctx.ReceivedAtUtc,
+                    RawEventJson = ctx.RawJson
+                });
 
-                db.AutoModEvents.Add(entity);
-                await db.SaveChangesAsync();
-            }
-            catch (Exception ex)
-            {
-                logger.LogError(ex, "Error handling automod rule deleted");
-                using var failureScope = scopeFactory.CreateScope();
-                var failedEventService = failureScope.ServiceProvider.GetRequiredService<FailedEventService>();
-                await failedEventService.RecordFailureAsync(
-                    "AutoModRuleDeleted", nameof(AutoModEventHandler), ex,
-                    e.Rule?.Guild?.Id, null, e.Rule?.Creator?.Id, rawJson, correlationId: correlationId);
-            }
-        }
+                await ctx.Db.SaveChangesAsync();
+            });
     }
 
     public async Task HandleEventAsync(DiscordClient sender, AutoModerationRuleExecutedEventArgs e)
     {
-        var correlationId = Guid.NewGuid();
-        using (logger.BeginScope(new Dictionary<string, object> { ["CorrelationId"] = correlationId }))
-        {
-            string? rawJson = null;
-            try
+        await pipeline.Execute(e, "AutoModActionExecuted", nameof(AutoModEventHandler),
+            e.Rule.GuildId, e.Rule.ChannelId, e.Rule.UserId, async ctx =>
             {
-                var now = DateTime.UtcNow;
-                using var scope = scopeFactory.CreateScope();
-                var db = scope.ServiceProvider.GetRequiredService<DiscordDbContext>();
-                var rawEventService = scope.ServiceProvider.GetRequiredService<RawEventLogService>();
-
-                rawJson = await rawEventService.SerializeAndLogAsync(
-                    e, "AutoModActionExecuted", e.Rule.GuildId, e.Rule.ChannelId, e.Rule.UserId, correlationId: correlationId);
-
-                // Note: e.Rule is actually DiscordAutoModerationActionExecution
-                var entity = new AutoModEventEntity
+                // e.Rule is a DiscordAutoModerationActionExecution, not a rule definition.
+                ctx.Db.AutoModEvents.Add(new AutoModEventEntity
                 {
                     GuildDiscordId = e.Rule.GuildId,
                     RuleDiscordId = e.Rule.RuleId,
@@ -176,23 +99,12 @@ public class AutoModEventHandler(IServiceScopeFactory scopeFactory, ILogger<Auto
                     Content = e.Rule.Content,
                     MatchedKeyword = e.Rule.MatchedKeyword,
                     MatchedContent = e.Rule.MatchedContent,
-                    EventTimestampUtc = now,
-                    ReceivedAtUtc = now,
-                    RawEventJson = rawJson
-                };
+                    EventTimestampUtc = ctx.ReceivedAtUtc,
+                    ReceivedAtUtc = ctx.ReceivedAtUtc,
+                    RawEventJson = ctx.RawJson
+                });
 
-                db.AutoModEvents.Add(entity);
-                await db.SaveChangesAsync();
-            }
-            catch (Exception ex)
-            {
-                logger.LogError(ex, "Error handling automod action executed");
-                using var failureScope = scopeFactory.CreateScope();
-                var failedEventService = failureScope.ServiceProvider.GetRequiredService<FailedEventService>();
-                await failedEventService.RecordFailureAsync(
-                    "AutoModActionExecuted", nameof(AutoModEventHandler), ex,
-                    e.Rule?.GuildId, e.Rule?.ChannelId, e.Rule?.UserId, rawJson, correlationId: correlationId);
-            }
-        }
+                await ctx.Db.SaveChangesAsync();
+            });
     }
 }

--- a/src/DiscordEventService/Services/EventHandlers/ScheduledEventHandler.cs
+++ b/src/DiscordEventService/Services/EventHandlers/ScheduledEventHandler.cs
@@ -1,6 +1,7 @@
 using DiscordEventService.Data;
 using DiscordEventService.Data.Entities.Core;
 using DiscordEventService.Data.Entities.Events;
+using DiscordEventService.Services.Pipeline;
 using DSharpPlus;
 using DSharpPlus.Entities;
 using DSharpPlus.EventArgs;
@@ -8,7 +9,7 @@ using Microsoft.EntityFrameworkCore;
 
 namespace DiscordEventService.Services.EventHandlers;
 
-public class ScheduledEventHandler(IServiceScopeFactory scopeFactory, ILogger<ScheduledEventHandler> logger) :
+public sealed class ScheduledEventHandler(EventPipeline pipeline) :
     IEventHandler<ScheduledGuildEventCreatedEventArgs>,
     IEventHandler<ScheduledGuildEventUpdatedEventArgs>,
     IEventHandler<ScheduledGuildEventDeletedEventArgs>,
@@ -18,23 +19,12 @@ public class ScheduledEventHandler(IServiceScopeFactory scopeFactory, ILogger<Sc
 {
     public async Task HandleEventAsync(DiscordClient sender, ScheduledGuildEventCreatedEventArgs e)
     {
-        var correlationId = Guid.NewGuid();
-        using (logger.BeginScope(new Dictionary<string, object> { ["CorrelationId"] = correlationId }))
-        {
-            string? rawJson = null;
-            try
+        await pipeline.Execute(e, "ScheduledGuildEventCreated", nameof(ScheduledEventHandler),
+            e.Guild.Id, e.Channel?.Id, e.Creator?.Id, async ctx =>
             {
-                var now = DateTime.UtcNow;
-                using var scope = scopeFactory.CreateScope();
-                var db = scope.ServiceProvider.GetRequiredService<DiscordDbContext>();
-                var rawEventService = scope.ServiceProvider.GetRequiredService<RawEventLogService>();
+                await UpsertScheduledEventAsync(ctx.Db, e.Event, e.Creator?.Id);
 
-                rawJson = await rawEventService.SerializeAndLogAsync(
-                    e, "ScheduledGuildEventCreated", e.Guild.Id, e.Channel?.Id, e.Creator?.Id, correlationId: correlationId);
-
-                await UpsertScheduledEventAsync(db, e.Event, e.Creator?.Id);
-
-                var entity = new ScheduledEventEntity
+                ctx.Db.ScheduledEvents.Add(new ScheduledEventEntity
                 {
                     EventDiscordId = e.Event.Id,
                     GuildDiscordId = e.Guild.Id,
@@ -47,45 +37,23 @@ public class ScheduledEventHandler(IServiceScopeFactory scopeFactory, ILogger<Sc
                     EntityType = (int)e.Event.Type,
                     ScheduledStartTime = e.Event.StartTime.UtcDateTime,
                     ScheduledEndTime = e.Event.EndTime?.UtcDateTime,
-                    EventTimestampUtc = now,
-                    ReceivedAtUtc = now,
-                    RawEventJson = rawJson
-                };
+                    EventTimestampUtc = ctx.ReceivedAtUtc,
+                    ReceivedAtUtc = ctx.ReceivedAtUtc,
+                    RawEventJson = ctx.RawJson
+                });
 
-                db.ScheduledEvents.Add(entity);
-                await db.SaveChangesAsync();
-            }
-            catch (Exception ex)
-            {
-                logger.LogError(ex, "Error handling scheduled event created");
-                using var failureScope = scopeFactory.CreateScope();
-                var failedEventService = failureScope.ServiceProvider.GetRequiredService<FailedEventService>();
-                await failedEventService.RecordFailureAsync(
-                    "ScheduledGuildEventCreated", nameof(ScheduledEventHandler), ex,
-                    e.Guild?.Id, e.Channel?.Id, e.Creator?.Id, rawJson, correlationId: correlationId);
-            }
-        }
+                await ctx.Db.SaveChangesAsync();
+            });
     }
 
     public async Task HandleEventAsync(DiscordClient sender, ScheduledGuildEventUpdatedEventArgs e)
     {
-        var correlationId = Guid.NewGuid();
-        using (logger.BeginScope(new Dictionary<string, object> { ["CorrelationId"] = correlationId }))
-        {
-            string? rawJson = null;
-            try
+        await pipeline.Execute(e, "ScheduledGuildEventUpdated", nameof(ScheduledEventHandler),
+            e.EventAfter.GuildId, e.EventAfter.ChannelId, e.EventAfter.Creator?.Id, async ctx =>
             {
-                var now = DateTime.UtcNow;
-                using var scope = scopeFactory.CreateScope();
-                var db = scope.ServiceProvider.GetRequiredService<DiscordDbContext>();
-                var rawEventService = scope.ServiceProvider.GetRequiredService<RawEventLogService>();
+                await UpsertScheduledEventAsync(ctx.Db, e.EventAfter, e.EventAfter.Creator?.Id);
 
-                rawJson = await rawEventService.SerializeAndLogAsync(
-                    e, "ScheduledGuildEventUpdated", e.EventAfter.GuildId, e.EventAfter.ChannelId, e.EventAfter.Creator?.Id, correlationId: correlationId);
-
-                await UpsertScheduledEventAsync(db, e.EventAfter, e.EventAfter.Creator?.Id);
-
-                var entity = new ScheduledEventEntity
+                ctx.Db.ScheduledEvents.Add(new ScheduledEventEntity
                 {
                     EventDiscordId = e.EventAfter.Id,
                     GuildDiscordId = e.EventAfter.GuildId,
@@ -98,95 +66,50 @@ public class ScheduledEventHandler(IServiceScopeFactory scopeFactory, ILogger<Sc
                     EntityType = (int)e.EventAfter.Type,
                     ScheduledStartTime = e.EventAfter.StartTime.UtcDateTime,
                     ScheduledEndTime = e.EventAfter.EndTime?.UtcDateTime,
-                    EventTimestampUtc = now,
-                    ReceivedAtUtc = now,
-                    RawEventJson = rawJson
-                };
+                    EventTimestampUtc = ctx.ReceivedAtUtc,
+                    ReceivedAtUtc = ctx.ReceivedAtUtc,
+                    RawEventJson = ctx.RawJson
+                });
 
-                db.ScheduledEvents.Add(entity);
-                await db.SaveChangesAsync();
-            }
-            catch (Exception ex)
-            {
-                logger.LogError(ex, "Error handling scheduled event updated");
-                using var failureScope = scopeFactory.CreateScope();
-                var failedEventService = failureScope.ServiceProvider.GetRequiredService<FailedEventService>();
-                await failedEventService.RecordFailureAsync(
-                    "ScheduledGuildEventUpdated", nameof(ScheduledEventHandler), ex,
-                    e.EventAfter?.GuildId, e.EventAfter?.ChannelId, e.EventAfter?.Creator?.Id, rawJson, correlationId: correlationId);
-            }
-        }
+                await ctx.Db.SaveChangesAsync();
+            });
     }
 
     public async Task HandleEventAsync(DiscordClient sender, ScheduledGuildEventDeletedEventArgs e)
     {
-        var correlationId = Guid.NewGuid();
-        using (logger.BeginScope(new Dictionary<string, object> { ["CorrelationId"] = correlationId }))
-        {
-            string? rawJson = null;
-            try
+        await pipeline.Execute(e, "ScheduledGuildEventDeleted", nameof(ScheduledEventHandler),
+            e.Event.GuildId, e.Event.ChannelId, null, async ctx =>
             {
-                var now = DateTime.UtcNow;
-                using var scope = scopeFactory.CreateScope();
-                var db = scope.ServiceProvider.GetRequiredService<DiscordDbContext>();
-                var rawEventService = scope.ServiceProvider.GetRequiredService<RawEventLogService>();
-
-                rawJson = await rawEventService.SerializeAndLogAsync(
-                    e, "ScheduledGuildEventDeleted", e.Event.GuildId, e.Event.ChannelId, null, correlationId: correlationId);
-
-                // Mark as deleted
-                await db.GuildScheduledEvents
+                await ctx.Db.GuildScheduledEvents
                     .Where(s => s.DiscordId == e.Event.Id)
                     .ExecuteUpdateAsync(s => s
                         .SetProperty(x => x.IsDeleted, true)
-                        .SetProperty(x => x.DeletedAtUtc, (DateTime?)now));
+                        .SetProperty(x => x.DeletedAtUtc, (DateTime?)ctx.ReceivedAtUtc));
 
-                var entity = new ScheduledEventEntity
+                ctx.Db.ScheduledEvents.Add(new ScheduledEventEntity
                 {
                     EventDiscordId = e.Event.Id,
                     GuildDiscordId = e.Event.GuildId,
                     ChannelDiscordId = e.Event.ChannelId,
                     EventType = ScheduledEventEventType.Deleted,
                     Name = e.Event.Name,
-                    EventTimestampUtc = now,
-                    ReceivedAtUtc = now,
-                    RawEventJson = rawJson
-                };
+                    EventTimestampUtc = ctx.ReceivedAtUtc,
+                    ReceivedAtUtc = ctx.ReceivedAtUtc,
+                    RawEventJson = ctx.RawJson
+                });
 
-                db.ScheduledEvents.Add(entity);
-                await db.SaveChangesAsync();
-            }
-            catch (Exception ex)
-            {
-                logger.LogError(ex, "Error handling scheduled event deleted");
-                using var failureScope = scopeFactory.CreateScope();
-                var failedEventService = failureScope.ServiceProvider.GetRequiredService<FailedEventService>();
-                await failedEventService.RecordFailureAsync(
-                    "ScheduledGuildEventDeleted", nameof(ScheduledEventHandler), ex,
-                    e.Event?.GuildId, e.Event?.ChannelId, null, rawJson, correlationId: correlationId);
-            }
-        }
+                await ctx.Db.SaveChangesAsync();
+            });
     }
 
     public async Task HandleEventAsync(DiscordClient sender, ScheduledGuildEventCompletedEventArgs e)
     {
-        var correlationId = Guid.NewGuid();
-        using (logger.BeginScope(new Dictionary<string, object> { ["CorrelationId"] = correlationId }))
-        {
-            string? rawJson = null;
-            try
+        await pipeline.Execute(e, "ScheduledGuildEventCompleted", nameof(ScheduledEventHandler),
+            e.Event.GuildId, e.Event.ChannelId, null, async ctx =>
             {
-                var now = DateTime.UtcNow;
-                using var scope = scopeFactory.CreateScope();
-                var db = scope.ServiceProvider.GetRequiredService<DiscordDbContext>();
-                var rawEventService = scope.ServiceProvider.GetRequiredService<RawEventLogService>();
+                await UpsertScheduledEventAsync(ctx.Db, e.Event, e.Event.Creator?.Id);
 
-                rawJson = await rawEventService.SerializeAndLogAsync(
-                    e, "ScheduledGuildEventCompleted", e.Event.GuildId, e.Event.ChannelId, null, correlationId: correlationId);
-
-                await UpsertScheduledEventAsync(db, e.Event, e.Event.Creator?.Id);
-
-                var entity = new ScheduledEventEntity
+                ctx.Db.ScheduledEvents.Add(new ScheduledEventEntity
                 {
                     EventDiscordId = e.Event.Id,
                     GuildDiscordId = e.Event.GuildId,
@@ -194,118 +117,61 @@ public class ScheduledEventHandler(IServiceScopeFactory scopeFactory, ILogger<Sc
                     EventType = ScheduledEventEventType.Completed,
                     Name = e.Event.Name,
                     Status = (int)e.Event.Status,
-                    EventTimestampUtc = now,
-                    ReceivedAtUtc = now,
-                    RawEventJson = rawJson
-                };
+                    EventTimestampUtc = ctx.ReceivedAtUtc,
+                    ReceivedAtUtc = ctx.ReceivedAtUtc,
+                    RawEventJson = ctx.RawJson
+                });
 
-                db.ScheduledEvents.Add(entity);
-                await db.SaveChangesAsync();
-            }
-            catch (Exception ex)
-            {
-                logger.LogError(ex, "Error handling scheduled event completed");
-                using var failureScope = scopeFactory.CreateScope();
-                var failedEventService = failureScope.ServiceProvider.GetRequiredService<FailedEventService>();
-                await failedEventService.RecordFailureAsync(
-                    "ScheduledGuildEventCompleted", nameof(ScheduledEventHandler), ex,
-                    e.Event?.GuildId, e.Event?.ChannelId, null, rawJson, correlationId: correlationId);
-            }
-        }
+                await ctx.Db.SaveChangesAsync();
+            });
     }
 
     public async Task HandleEventAsync(DiscordClient sender, ScheduledGuildEventUserAddedEventArgs e)
     {
-        var correlationId = Guid.NewGuid();
-        using (logger.BeginScope(new Dictionary<string, object> { ["CorrelationId"] = correlationId }))
-        {
-            string? rawJson = null;
-            try
+        await pipeline.Execute(e, "ScheduledGuildEventUserAdded", nameof(ScheduledEventHandler),
+            e.Guild.Id, null, e.User.Id, async ctx =>
             {
-                var now = DateTime.UtcNow;
-                using var scope = scopeFactory.CreateScope();
-                var db = scope.ServiceProvider.GetRequiredService<DiscordDbContext>();
-                var rawEventService = scope.ServiceProvider.GetRequiredService<RawEventLogService>();
-
-                rawJson = await rawEventService.SerializeAndLogAsync(
-                    e, "ScheduledGuildEventUserAdded", e.Guild.Id, null, e.User.Id, correlationId: correlationId);
-
-                // Increment user count
-                await db.GuildScheduledEvents
+                await ctx.Db.GuildScheduledEvents
                     .Where(s => s.DiscordId == e.Event.Id)
                     .ExecuteUpdateAsync(s => s.SetProperty(x => x.UserCount, x => x.UserCount + 1));
 
-                var entity = new ScheduledEventEntity
+                ctx.Db.ScheduledEvents.Add(new ScheduledEventEntity
                 {
                     EventDiscordId = e.Event.Id,
                     GuildDiscordId = e.Guild.Id,
                     EventType = ScheduledEventEventType.UserAdded,
                     UserDiscordId = e.User.Id,
-                    EventTimestampUtc = now,
-                    ReceivedAtUtc = now,
-                    RawEventJson = rawJson
-                };
+                    EventTimestampUtc = ctx.ReceivedAtUtc,
+                    ReceivedAtUtc = ctx.ReceivedAtUtc,
+                    RawEventJson = ctx.RawJson
+                });
 
-                db.ScheduledEvents.Add(entity);
-                await db.SaveChangesAsync();
-            }
-            catch (Exception ex)
-            {
-                logger.LogError(ex, "Error handling scheduled event user added");
-                using var failureScope = scopeFactory.CreateScope();
-                var failedEventService = failureScope.ServiceProvider.GetRequiredService<FailedEventService>();
-                await failedEventService.RecordFailureAsync(
-                    "ScheduledGuildEventUserAdded", nameof(ScheduledEventHandler), ex,
-                    e.Guild?.Id, null, e.User?.Id, rawJson, correlationId: correlationId);
-            }
-        }
+                await ctx.Db.SaveChangesAsync();
+            });
     }
 
     public async Task HandleEventAsync(DiscordClient sender, ScheduledGuildEventUserRemovedEventArgs e)
     {
-        var correlationId = Guid.NewGuid();
-        using (logger.BeginScope(new Dictionary<string, object> { ["CorrelationId"] = correlationId }))
-        {
-            string? rawJson = null;
-            try
+        await pipeline.Execute(e, "ScheduledGuildEventUserRemoved", nameof(ScheduledEventHandler),
+            e.Guild.Id, null, e.User.Id, async ctx =>
             {
-                var now = DateTime.UtcNow;
-                using var scope = scopeFactory.CreateScope();
-                var db = scope.ServiceProvider.GetRequiredService<DiscordDbContext>();
-                var rawEventService = scope.ServiceProvider.GetRequiredService<RawEventLogService>();
-
-                rawJson = await rawEventService.SerializeAndLogAsync(
-                    e, "ScheduledGuildEventUserRemoved", e.Guild.Id, null, e.User.Id, correlationId: correlationId);
-
-                // Decrement user count
-                await db.GuildScheduledEvents
+                await ctx.Db.GuildScheduledEvents
                     .Where(s => s.DiscordId == e.Event.Id)
                     .ExecuteUpdateAsync(s => s.SetProperty(x => x.UserCount, x => x.UserCount - 1));
 
-                var entity = new ScheduledEventEntity
+                ctx.Db.ScheduledEvents.Add(new ScheduledEventEntity
                 {
                     EventDiscordId = e.Event.Id,
                     GuildDiscordId = e.Guild.Id,
                     EventType = ScheduledEventEventType.UserRemoved,
                     UserDiscordId = e.User.Id,
-                    EventTimestampUtc = now,
-                    ReceivedAtUtc = now,
-                    RawEventJson = rawJson
-                };
+                    EventTimestampUtc = ctx.ReceivedAtUtc,
+                    ReceivedAtUtc = ctx.ReceivedAtUtc,
+                    RawEventJson = ctx.RawJson
+                });
 
-                db.ScheduledEvents.Add(entity);
-                await db.SaveChangesAsync();
-            }
-            catch (Exception ex)
-            {
-                logger.LogError(ex, "Error handling scheduled event user removed");
-                using var failureScope = scopeFactory.CreateScope();
-                var failedEventService = failureScope.ServiceProvider.GetRequiredService<FailedEventService>();
-                await failedEventService.RecordFailureAsync(
-                    "ScheduledGuildEventUserRemoved", nameof(ScheduledEventHandler), ex,
-                    e.Guild?.Id, null, e.User?.Id, rawJson, correlationId: correlationId);
-            }
-        }
+                await ctx.Db.SaveChangesAsync();
+            });
     }
 
     private static async Task UpsertScheduledEventAsync(DiscordDbContext db, DiscordScheduledGuildEvent evt, ulong? creatorDiscordId)

--- a/src/DiscordEventService/Services/EventHandlers/StageInstanceEventHandler.cs
+++ b/src/DiscordEventService/Services/EventHandlers/StageInstanceEventHandler.cs
@@ -1,45 +1,32 @@
-using DiscordEventService.Data;
 using DiscordEventService.Data.Entities.Core;
 using DiscordEventService.Data.Entities.Events;
+using DiscordEventService.Services.Pipeline;
 using DSharpPlus;
 using DSharpPlus.EventArgs;
 using Microsoft.EntityFrameworkCore;
 
 namespace DiscordEventService.Services.EventHandlers;
 
-public class StageInstanceEventHandler(IServiceScopeFactory scopeFactory, ILogger<StageInstanceEventHandler> logger) :
+public sealed class StageInstanceEventHandler(EventPipeline pipeline) :
     IEventHandler<StageInstanceCreatedEventArgs>,
     IEventHandler<StageInstanceUpdatedEventArgs>,
     IEventHandler<StageInstanceDeletedEventArgs>
 {
     public async Task HandleEventAsync(DiscordClient sender, StageInstanceCreatedEventArgs e)
     {
-        var correlationId = Guid.NewGuid();
-        using (logger.BeginScope(new Dictionary<string, object> { ["CorrelationId"] = correlationId }))
-        {
-            string? rawJson = null;
-            try
+        await pipeline.Execute(e, "StageInstanceCreated", nameof(StageInstanceEventHandler),
+            e.StageInstance.GuildId, e.StageInstance.ChannelId, null, async ctx =>
             {
-                var now = DateTime.UtcNow;
-                using var scope = scopeFactory.CreateScope();
-                var db = scope.ServiceProvider.GetRequiredService<DiscordDbContext>();
-                var rawEventService = scope.ServiceProvider.GetRequiredService<RawEventLogService>();
-
-                rawJson = await rawEventService.SerializeAndLogAsync(
-                    e, "StageInstanceCreated", e.StageInstance.GuildId, e.StageInstance.ChannelId, null, correlationId: correlationId);
-
-                await db.SaveChangesAsync();
-
-                var guildGuid = await db.Guilds
+                var guildGuid = await ctx.Db.Guilds
                     .Where(g => g.DiscordId == e.StageInstance.GuildId)
                     .Select(g => g.Id)
                     .FirstOrDefaultAsync();
-                var channelGuid = await db.Channels
+                var channelGuid = await ctx.Db.Channels
                     .Where(c => c.DiscordId == e.StageInstance.ChannelId)
                     .Select(c => c.Id)
                     .FirstOrDefaultAsync();
 
-                db.StageInstances.Add(new StageInstanceEntity
+                ctx.Db.StageInstances.Add(new StageInstanceEntity
                 {
                     DiscordId = e.StageInstance.Id,
                     GuildId = guildGuid,
@@ -48,7 +35,7 @@ public class StageInstanceEventHandler(IServiceScopeFactory scopeFactory, ILogge
                     PrivacyLevel = (int)e.StageInstance.PrivacyLevel
                 });
 
-                db.StageInstanceEvents.Add(new StageInstanceEventEntity
+                ctx.Db.StageInstanceEvents.Add(new StageInstanceEventEntity
                 {
                     StageInstanceDiscordId = e.StageInstance.Id,
                     GuildDiscordId = e.StageInstance.GuildId,
@@ -56,48 +43,27 @@ public class StageInstanceEventHandler(IServiceScopeFactory scopeFactory, ILogge
                     EventType = StageInstanceEventType.Created,
                     TopicAfter = e.StageInstance.Topic,
                     PrivacyLevelAfter = (int)e.StageInstance.PrivacyLevel,
-                    EventTimestampUtc = now,
-                    ReceivedAtUtc = now,
-                    RawEventJson = rawJson
+                    EventTimestampUtc = ctx.ReceivedAtUtc,
+                    ReceivedAtUtc = ctx.ReceivedAtUtc,
+                    RawEventJson = ctx.RawJson
                 });
 
-                await db.SaveChangesAsync();
-            }
-            catch (Exception ex)
-            {
-                logger.LogError(ex, "Error handling stage instance created");
-                using var failureScope = scopeFactory.CreateScope();
-                var failedEventService = failureScope.ServiceProvider.GetRequiredService<FailedEventService>();
-                await failedEventService.RecordFailureAsync(
-                    "StageInstanceCreated", nameof(StageInstanceEventHandler), ex,
-                    e.StageInstance?.GuildId, e.StageInstance?.ChannelId, null, rawJson, correlationId: correlationId);
-            }
-        }
+                await ctx.Db.SaveChangesAsync();
+            });
     }
 
     public async Task HandleEventAsync(DiscordClient sender, StageInstanceUpdatedEventArgs e)
     {
-        var correlationId = Guid.NewGuid();
-        using (logger.BeginScope(new Dictionary<string, object> { ["CorrelationId"] = correlationId }))
-        {
-            string? rawJson = null;
-            try
+        await pipeline.Execute(e, "StageInstanceUpdated", nameof(StageInstanceEventHandler),
+            e.StageInstanceAfter.GuildId, e.StageInstanceAfter.ChannelId, null, async ctx =>
             {
-                var now = DateTime.UtcNow;
-                using var scope = scopeFactory.CreateScope();
-                var db = scope.ServiceProvider.GetRequiredService<DiscordDbContext>();
-                var rawEventService = scope.ServiceProvider.GetRequiredService<RawEventLogService>();
-
-                rawJson = await rawEventService.SerializeAndLogAsync(
-                    e, "StageInstanceUpdated", e.StageInstanceAfter.GuildId, e.StageInstanceAfter.ChannelId, null, correlationId: correlationId);
-
-                await db.StageInstances
+                await ctx.Db.StageInstances
                     .Where(s => s.DiscordId == e.StageInstanceAfter.Id)
                     .ExecuteUpdateAsync(s => s
                         .SetProperty(st => st.Topic, e.StageInstanceAfter.Topic)
                         .SetProperty(st => st.PrivacyLevel, (int)e.StageInstanceAfter.PrivacyLevel));
 
-                db.StageInstanceEvents.Add(new StageInstanceEventEntity
+                ctx.Db.StageInstanceEvents.Add(new StageInstanceEventEntity
                 {
                     StageInstanceDiscordId = e.StageInstanceAfter.Id,
                     GuildDiscordId = e.StageInstanceAfter.GuildId,
@@ -107,48 +73,27 @@ public class StageInstanceEventHandler(IServiceScopeFactory scopeFactory, ILogge
                     TopicAfter = e.StageInstanceAfter.Topic,
                     PrivacyLevelBefore = e.StageInstanceBefore != null ? (int)e.StageInstanceBefore.PrivacyLevel : null,
                     PrivacyLevelAfter = (int)e.StageInstanceAfter.PrivacyLevel,
-                    EventTimestampUtc = now,
-                    ReceivedAtUtc = now,
-                    RawEventJson = rawJson
+                    EventTimestampUtc = ctx.ReceivedAtUtc,
+                    ReceivedAtUtc = ctx.ReceivedAtUtc,
+                    RawEventJson = ctx.RawJson
                 });
 
-                await db.SaveChangesAsync();
-            }
-            catch (Exception ex)
-            {
-                logger.LogError(ex, "Error handling stage instance updated");
-                using var failureScope = scopeFactory.CreateScope();
-                var failedEventService = failureScope.ServiceProvider.GetRequiredService<FailedEventService>();
-                await failedEventService.RecordFailureAsync(
-                    "StageInstanceUpdated", nameof(StageInstanceEventHandler), ex,
-                    e.StageInstanceAfter?.GuildId, e.StageInstanceAfter?.ChannelId, null, rawJson, correlationId: correlationId);
-            }
-        }
+                await ctx.Db.SaveChangesAsync();
+            });
     }
 
     public async Task HandleEventAsync(DiscordClient sender, StageInstanceDeletedEventArgs e)
     {
-        var correlationId = Guid.NewGuid();
-        using (logger.BeginScope(new Dictionary<string, object> { ["CorrelationId"] = correlationId }))
-        {
-            string? rawJson = null;
-            try
+        await pipeline.Execute(e, "StageInstanceDeleted", nameof(StageInstanceEventHandler),
+            e.StageInstance.GuildId, e.StageInstance.ChannelId, null, async ctx =>
             {
-                var now = DateTime.UtcNow;
-                using var scope = scopeFactory.CreateScope();
-                var db = scope.ServiceProvider.GetRequiredService<DiscordDbContext>();
-                var rawEventService = scope.ServiceProvider.GetRequiredService<RawEventLogService>();
-
-                rawJson = await rawEventService.SerializeAndLogAsync(
-                    e, "StageInstanceDeleted", e.StageInstance.GuildId, e.StageInstance.ChannelId, null, correlationId: correlationId);
-
-                await db.StageInstances
+                await ctx.Db.StageInstances
                     .Where(s => s.DiscordId == e.StageInstance.Id)
                     .ExecuteUpdateAsync(s => s
                         .SetProperty(st => st.IsDeleted, true)
-                        .SetProperty(st => st.DeletedAtUtc, (DateTime?)now));
+                        .SetProperty(st => st.DeletedAtUtc, (DateTime?)ctx.ReceivedAtUtc));
 
-                db.StageInstanceEvents.Add(new StageInstanceEventEntity
+                ctx.Db.StageInstanceEvents.Add(new StageInstanceEventEntity
                 {
                     StageInstanceDiscordId = e.StageInstance.Id,
                     GuildDiscordId = e.StageInstance.GuildId,
@@ -156,22 +101,12 @@ public class StageInstanceEventHandler(IServiceScopeFactory scopeFactory, ILogge
                     EventType = StageInstanceEventType.Deleted,
                     TopicBefore = e.StageInstance.Topic,
                     PrivacyLevelBefore = (int)e.StageInstance.PrivacyLevel,
-                    EventTimestampUtc = now,
-                    ReceivedAtUtc = now,
-                    RawEventJson = rawJson
+                    EventTimestampUtc = ctx.ReceivedAtUtc,
+                    ReceivedAtUtc = ctx.ReceivedAtUtc,
+                    RawEventJson = ctx.RawJson
                 });
 
-                await db.SaveChangesAsync();
-            }
-            catch (Exception ex)
-            {
-                logger.LogError(ex, "Error handling stage instance deleted");
-                using var failureScope = scopeFactory.CreateScope();
-                var failedEventService = failureScope.ServiceProvider.GetRequiredService<FailedEventService>();
-                await failedEventService.RecordFailureAsync(
-                    "StageInstanceDeleted", nameof(StageInstanceEventHandler), ex,
-                    e.StageInstance?.GuildId, e.StageInstance?.ChannelId, null, rawJson, correlationId: correlationId);
-            }
-        }
+                await ctx.Db.SaveChangesAsync();
+            });
     }
 }


### PR DESCRIPTION
## Summary
Part 2 of §A1.3 (#157) — migrates the **3 multi-method handlers** (each subscribes to several event types) onto `EventPipeline`.

- `AutoModEventHandler` (4 events), `StageInstanceEventHandler` (3 events), `ScheduledEventHandler` (6 events)
- Each event type calls `pipeline.Execute(...)` with its own `eventType`/`guildId`/`channelId`/`userId`; handler body writes its rows via `ctx.Db` / `ctx.RawJson` / `ctx.ReceivedAtUtc`
- Net **-287 lines** (140 insertions, 427 deletions)

Behavior preserved:
- **AutoMod** guild-null guards (`if (e.Rule?.Guild is null) return;`) moved ahead of `Execute` — same early-return semantics, no raw_event_log/failure row when guild is absent
- **StageInstance Created** dropped its manual raw-flush `SaveChanges` (the pipeline now flushes raw_event_log first); entity resolution + soft-delete unchanged
- **ScheduledEvent** `UpsertScheduledEventAsync` helper preserved verbatim (kept its name to keep the diff migration-only)

## Test plan
- [x] `dotnet build` — 0 errors (pre-existing warnings only; none in changed files)
- [x] `VALIDATE_AND_EXIT=1 dotnet run` — DI validation passed
- [ ] Local live test — AutoMod rule create/trigger, Stage instance create/update/delete, Scheduled event create/RSVP/complete (coordinating with maintainer; some require a community-enabled server / stage channel)
- [ ] Post-deploy Loki verification

🤖 Generated with [Claude Code](https://claude.com/claude-code)