### PR TITLE
feat: migrate upsert event handlers to EventPipeline (#157)

### DIFF
--- a/src/DiscordEventService/Services/EventHandlers/AutoModRuleEventHandler.cs
+++ b/src/DiscordEventService/Services/EventHandlers/AutoModRuleEventHandler.cs
@@ -1,6 +1,6 @@
-using DiscordEventService.Data;
 using DiscordEventService.Data.Entities.Core;
 using DiscordEventService.Data.Entities.Events;
+using DiscordEventService.Services.Pipeline;
 using DSharpPlus;
 using DSharpPlus.EventArgs;
 using Microsoft.EntityFrameworkCore;
@@ -8,37 +8,23 @@ using System.Text.Json;
 
 namespace DiscordEventService.Services.EventHandlers;
 
-public class AutoModRuleEventHandler(IServiceScopeFactory scopeFactory, ILogger<AutoModRuleEventHandler> logger) :
+public sealed class AutoModRuleEventHandler(EventPipeline pipeline) :
     IEventHandler<AutoModerationRuleCreatedEventArgs>,
     IEventHandler<AutoModerationRuleUpdatedEventArgs>,
     IEventHandler<AutoModerationRuleDeletedEventArgs>
 {
     public async Task HandleEventAsync(DiscordClient sender, AutoModerationRuleCreatedEventArgs e)
     {
-        var correlationId = Guid.NewGuid();
-        using (logger.BeginScope(new Dictionary<string, object> { ["CorrelationId"] = correlationId }))
-        {
-            string? rawJson = null;
-            try
+        var guildDiscordId = e.Rule.Guild?.Id ?? 0UL;
+        var creatorDiscordId = e.Rule.Creator?.Id ?? 0UL;
+
+        await pipeline.Execute(e, "AutoModRuleCreatedRule", nameof(AutoModRuleEventHandler),
+            guildDiscordId, null, creatorDiscordId, async ctx =>
             {
-                var now = DateTime.UtcNow;
-                using var scope = scopeFactory.CreateScope();
-                var db = scope.ServiceProvider.GetRequiredService<DiscordDbContext>();
-                var rawEventService = scope.ServiceProvider.GetRequiredService<RawEventLogService>();
-                var userService = scope.ServiceProvider.GetRequiredService<UserService>();
-
-                var guildDiscordId = e.Rule.Guild?.Id ?? 0UL;
-                var creatorDiscordId = e.Rule.Creator?.Id ?? 0UL;
-
-                rawJson = await rawEventService.SerializeAndLogAsync(
-                    e, "AutoModRuleCreatedRule", guildDiscordId, null, creatorDiscordId, correlationId: correlationId);
-
-                await db.SaveChangesAsync();
-
                 Guid? guildGuid = null;
                 if (e.Rule.Guild != null)
                 {
-                    var guildUpsert = scope.ServiceProvider.GetRequiredService<GuildUpsertService>();
+                    var guildUpsert = ctx.Services.GetRequiredService<GuildUpsertService>();
                     var id = await guildUpsert.UpsertGuildAsync(e.Rule.Guild);
                     guildGuid = id != Guid.Empty ? id : null;
                 }
@@ -46,14 +32,15 @@ public class AutoModRuleEventHandler(IServiceScopeFactory scopeFactory, ILogger<
                 Guid? creatorGuid = null;
                 if (e.Rule.Creator != null)
                 {
+                    var userService = ctx.Services.GetRequiredService<UserService>();
                     await userService.UpsertUserAsync(e.Rule.Creator);
-                    creatorGuid = await db.Users
+                    creatorGuid = await ctx.Db.Users
                         .Where(u => u.DiscordId == e.Rule.Creator.Id)
                         .Select(u => (Guid?)u.Id)
                         .FirstOrDefaultAsync();
                 }
 
-                db.AutoModRules.Add(new AutoModRuleEntity
+                ctx.Db.AutoModRules.Add(new AutoModRuleEntity
                 {
                     DiscordId = e.Rule.Id,
                     GuildId = guildGuid,
@@ -65,7 +52,7 @@ public class AutoModRuleEventHandler(IServiceScopeFactory scopeFactory, ILogger<
                     ActionsJson = e.Rule.Actions != null ? JsonSerializer.Serialize(e.Rule.Actions) : null
                 });
 
-                db.AutoModRuleEvents.Add(new AutoModRuleEventEntity
+                ctx.Db.AutoModRuleEvents.Add(new AutoModRuleEventEntity
                 {
                     RuleDiscordId = e.Rule.Id,
                     GuildDiscordId = guildDiscordId,
@@ -74,53 +61,30 @@ public class AutoModRuleEventHandler(IServiceScopeFactory scopeFactory, ILogger<
                     Name = e.Rule.Name ?? string.Empty,
                     TriggerType = (int)e.Rule.TriggerType,
                     IsEnabled = e.Rule.IsEnabled,
-                    EventTimestampUtc = now,
-                    ReceivedAtUtc = now,
-                    RawEventJson = rawJson
+                    EventTimestampUtc = ctx.ReceivedAtUtc,
+                    ReceivedAtUtc = ctx.ReceivedAtUtc,
+                    RawEventJson = ctx.RawJson
                 });
 
-                await db.SaveChangesAsync();
-            }
-            catch (Exception ex)
-            {
-                logger.LogError(ex, "Error handling automod rule created");
-                using var failureScope = scopeFactory.CreateScope();
-                var failedEventService = failureScope.ServiceProvider.GetRequiredService<FailedEventService>();
-                await failedEventService.RecordFailureAsync(
-                    "AutoModRuleCreated", nameof(AutoModRuleEventHandler), ex,
-                    e.Rule.Guild?.Id, null, e.Rule.Creator?.Id, rawJson, correlationId: correlationId);
-            }
-        }
+                await ctx.Db.SaveChangesAsync();
+            });
     }
 
     public async Task HandleEventAsync(DiscordClient sender, AutoModerationRuleUpdatedEventArgs e)
     {
-        var correlationId = Guid.NewGuid();
-        using (logger.BeginScope(new Dictionary<string, object> { ["CorrelationId"] = correlationId }))
-        {
-            string? rawJson = null;
-            try
+        var guildDiscordId = e.Rule.Guild?.Id ?? 0UL;
+
+        await pipeline.Execute(e, "AutoModRuleUpdatedRule", nameof(AutoModRuleEventHandler),
+            guildDiscordId, null, e.Rule.Creator?.Id, async ctx =>
             {
-                var now = DateTime.UtcNow;
-                using var scope = scopeFactory.CreateScope();
-                var db = scope.ServiceProvider.GetRequiredService<DiscordDbContext>();
-                var rawEventService = scope.ServiceProvider.GetRequiredService<RawEventLogService>();
-
-                var guildDiscordId = e.Rule.Guild?.Id ?? 0UL;
-
-                rawJson = await rawEventService.SerializeAndLogAsync(
-                    e, "AutoModRuleUpdatedRule", guildDiscordId, null, e.Rule.Creator?.Id, correlationId: correlationId);
-
-                await db.SaveChangesAsync();
-
-                await db.AutoModRules
+                await ctx.Db.AutoModRules
                     .Where(r => r.DiscordId == e.Rule.Id)
                     .ExecuteUpdateAsync(s => s
                         .SetProperty(r => r.Name, e.Rule.Name ?? string.Empty)
                         .SetProperty(r => r.IsEnabled, e.Rule.IsEnabled)
                         .SetProperty(r => r.ActionsJson, e.Rule.Actions != null ? JsonSerializer.Serialize(e.Rule.Actions) : null));
 
-                db.AutoModRuleEvents.Add(new AutoModRuleEventEntity
+                ctx.Db.AutoModRuleEvents.Add(new AutoModRuleEventEntity
                 {
                     RuleDiscordId = e.Rule.Id,
                     GuildDiscordId = guildDiscordId,
@@ -129,74 +93,41 @@ public class AutoModRuleEventHandler(IServiceScopeFactory scopeFactory, ILogger<
                     Name = e.Rule.Name ?? string.Empty,
                     TriggerType = (int)e.Rule.TriggerType,
                     IsEnabled = e.Rule.IsEnabled,
-                    EventTimestampUtc = now,
-                    ReceivedAtUtc = now,
-                    RawEventJson = rawJson
+                    EventTimestampUtc = ctx.ReceivedAtUtc,
+                    ReceivedAtUtc = ctx.ReceivedAtUtc,
+                    RawEventJson = ctx.RawJson
                 });
 
-                await db.SaveChangesAsync();
-            }
-            catch (Exception ex)
-            {
-                logger.LogError(ex, "Error handling automod rule updated");
-                using var failureScope = scopeFactory.CreateScope();
-                var failedEventService = failureScope.ServiceProvider.GetRequiredService<FailedEventService>();
-                await failedEventService.RecordFailureAsync(
-                    "AutoModRuleUpdated", nameof(AutoModRuleEventHandler), ex,
-                    e.Rule.Guild?.Id, null, e.Rule.Creator?.Id, rawJson, correlationId: correlationId);
-            }
-        }
+                await ctx.Db.SaveChangesAsync();
+            });
     }
 
     public async Task HandleEventAsync(DiscordClient sender, AutoModerationRuleDeletedEventArgs e)
     {
-        var correlationId = Guid.NewGuid();
-        using (logger.BeginScope(new Dictionary<string, object> { ["CorrelationId"] = correlationId }))
-        {
-            string? rawJson = null;
-            try
+        var guildDiscordId = e.Rule.Guild?.Id ?? 0UL;
+
+        await pipeline.Execute(e, "AutoModRuleDeletedRule", nameof(AutoModRuleEventHandler),
+            guildDiscordId, null, e.Rule.Creator?.Id, async ctx =>
             {
-                var now = DateTime.UtcNow;
-                using var scope = scopeFactory.CreateScope();
-                var db = scope.ServiceProvider.GetRequiredService<DiscordDbContext>();
-                var rawEventService = scope.ServiceProvider.GetRequiredService<RawEventLogService>();
-
-                var guildDiscordId = e.Rule.Guild?.Id ?? 0;
-
-                rawJson = await rawEventService.SerializeAndLogAsync(
-                    e, "AutoModRuleDeletedRule", guildDiscordId, null, e.Rule.Creator?.Id, correlationId: correlationId);
-
-                await db.SaveChangesAsync();
-
-                await db.AutoModRules
+                await ctx.Db.AutoModRules
                     .Where(r => r.DiscordId == e.Rule.Id)
                     .ExecuteUpdateAsync(s => s
                         .SetProperty(r => r.IsDeleted, true)
-                        .SetProperty(r => r.DeletedAtUtc, (DateTime?)now));
+                        .SetProperty(r => r.DeletedAtUtc, (DateTime?)ctx.ReceivedAtUtc));
 
-                db.AutoModRuleEvents.Add(new AutoModRuleEventEntity
+                ctx.Db.AutoModRuleEvents.Add(new AutoModRuleEventEntity
                 {
                     RuleDiscordId = e.Rule.Id,
                     GuildDiscordId = guildDiscordId,
                     CreatorDiscordId = e.Rule.Creator?.Id ?? 0,
                     EventType = AutoModRuleEventType.Deleted,
                     Name = e.Rule.Name ?? string.Empty,
-                    EventTimestampUtc = now,
-                    ReceivedAtUtc = now,
-                    RawEventJson = rawJson
+                    EventTimestampUtc = ctx.ReceivedAtUtc,
+                    ReceivedAtUtc = ctx.ReceivedAtUtc,
+                    RawEventJson = ctx.RawJson
                 });
 
-                await db.SaveChangesAsync();
-            }
-            catch (Exception ex)
-            {
-                logger.LogError(ex, "Error handling automod rule deleted");
-                using var failureScope = scopeFactory.CreateScope();
-                var failedEventService = failureScope.ServiceProvider.GetRequiredService<FailedEventService>();
-                await failedEventService.RecordFailureAsync(
-                    "AutoModRuleDeleted", nameof(AutoModRuleEventHandler), ex,
-                    e.Rule.Guild?.Id, null, e.Rule.Creator?.Id, rawJson, correlationId: correlationId);
-            }
-        }
+                await ctx.Db.SaveChangesAsync();
+            });
     }
 }

--- a/src/DiscordEventService/Services/EventHandlers/BanEventHandler.cs
+++ b/src/DiscordEventService/Services/EventHandlers/BanEventHandler.cs
@@ -1,143 +1,97 @@
-using DiscordEventService.Data;
 using DiscordEventService.Data.Entities.Core;
 using DiscordEventService.Data.Entities.Events;
+using DiscordEventService.Services.Pipeline;
 using DSharpPlus;
 using DSharpPlus.EventArgs;
 using Microsoft.EntityFrameworkCore;
 
 namespace DiscordEventService.Services.EventHandlers;
 
-public class BanEventHandler(IServiceScopeFactory scopeFactory, ILogger<BanEventHandler> logger) :
+public sealed class BanEventHandler(EventPipeline pipeline) :
     IEventHandler<GuildBanAddedEventArgs>,
     IEventHandler<GuildBanRemovedEventArgs>
 {
     public async Task HandleEventAsync(DiscordClient sender, GuildBanAddedEventArgs e)
     {
-        var correlationId = Guid.NewGuid();
-        using (logger.BeginScope(new Dictionary<string, object> { ["CorrelationId"] = correlationId }))
-        {
-            string? rawJson = null;
-            try
+        await pipeline.Execute(e, "GuildBanAdded", nameof(BanEventHandler),
+            e.Guild.Id, null, e.Member.Id, async ctx =>
             {
-                var now = DateTime.UtcNow;
-                using var scope = scopeFactory.CreateScope();
-                var db = scope.ServiceProvider.GetRequiredService<DiscordDbContext>();
-                var userService = scope.ServiceProvider.GetRequiredService<UserService>();
-                var rawEventService = scope.ServiceProvider.GetRequiredService<RawEventLogService>();
+                var guildUpsert = ctx.Services.GetRequiredService<GuildUpsertService>();
+                var userService = ctx.Services.GetRequiredService<UserService>();
 
-                rawJson = await rawEventService.SerializeAndLogAsync(
-                    e, "GuildBanAdded", e.Guild.Id, null, e.Member.Id, correlationId: correlationId);
-
-                await db.SaveChangesAsync();
-
-                var guildUpsert = scope.ServiceProvider.GetRequiredService<GuildUpsertService>();
                 var guildGuid = await guildUpsert.UpsertGuildAsync(e.Guild);
                 await userService.UpsertUserAsync(e.Member);
-                var userGuid = await db.Users
+                var userGuid = await ctx.Db.Users
                     .Where(u => u.DiscordId == e.Member.Id)
                     .Select(u => u.Id)
                     .FirstOrDefaultAsync();
 
                 if (guildGuid != Guid.Empty && userGuid != Guid.Empty)
                 {
-                    // Add or update ban entity
-                    var existingBan = await db.Bans
+                    var existingBan = await ctx.Db.Bans
                         .FirstOrDefaultAsync(b => b.GuildId == guildGuid && b.UserId == userGuid && b.IsActive);
 
                     if (existingBan == null)
                     {
-                        db.Bans.Add(new BanEntity
+                        ctx.Db.Bans.Add(new BanEntity
                         {
                             GuildId = guildGuid,
                             UserId = userGuid,
                             IsActive = true,
-                            BannedAtUtc = now
+                            BannedAtUtc = ctx.ReceivedAtUtc
                         });
                     }
                 }
 
-                db.BanEvents.Add(new BanEventEntity
+                ctx.Db.BanEvents.Add(new BanEventEntity
                 {
                     GuildDiscordId = e.Guild.Id,
                     UserDiscordId = e.Member.Id,
                     EventType = BanEventType.Added,
-                    EventTimestampUtc = now,
-                    ReceivedAtUtc = now,
-                    RawEventJson = rawJson
+                    EventTimestampUtc = ctx.ReceivedAtUtc,
+                    ReceivedAtUtc = ctx.ReceivedAtUtc,
+                    RawEventJson = ctx.RawJson
                 });
 
-                await db.SaveChangesAsync();
-            }
-            catch (Exception ex)
-            {
-                logger.LogError(ex, "Error handling ban added for UserId={UserId}", e.Member.Id);
-                using var failureScope = scopeFactory.CreateScope();
-                var failedEventService = failureScope.ServiceProvider.GetRequiredService<FailedEventService>();
-                await failedEventService.RecordFailureAsync(
-                    "GuildBanAdded", nameof(BanEventHandler), ex,
-                    e.Guild?.Id, null, e.Member?.Id, rawJson, correlationId: correlationId);
-            }
-        }
+                await ctx.Db.SaveChangesAsync();
+            });
     }
 
     public async Task HandleEventAsync(DiscordClient sender, GuildBanRemovedEventArgs e)
     {
-        var correlationId = Guid.NewGuid();
-        using (logger.BeginScope(new Dictionary<string, object> { ["CorrelationId"] = correlationId }))
-        {
-            string? rawJson = null;
-            try
+        await pipeline.Execute(e, "GuildBanRemoved", nameof(BanEventHandler),
+            e.Guild.Id, null, e.Member.Id, async ctx =>
             {
-                var now = DateTime.UtcNow;
-                using var scope = scopeFactory.CreateScope();
-                var db = scope.ServiceProvider.GetRequiredService<DiscordDbContext>();
-                var rawEventService = scope.ServiceProvider.GetRequiredService<RawEventLogService>();
-                var guildUpsert = scope.ServiceProvider.GetRequiredService<GuildUpsertService>();
-                var userService = scope.ServiceProvider.GetRequiredService<UserService>();
-
-                rawJson = await rawEventService.SerializeAndLogAsync(
-                    e, "GuildBanRemoved", e.Guild.Id, null, e.Member.Id, correlationId: correlationId);
-
-                await db.SaveChangesAsync();
+                var guildUpsert = ctx.Services.GetRequiredService<GuildUpsertService>();
+                var userService = ctx.Services.GetRequiredService<UserService>();
 
                 var guildGuid = await guildUpsert.UpsertGuildAsync(e.Guild);
                 await userService.UpsertUserAsync(e.Member);
-                var userGuid = await db.Users
+                var userGuid = await ctx.Db.Users
                     .Where(u => u.DiscordId == e.Member.Id)
                     .Select(u => u.Id)
                     .FirstOrDefaultAsync();
 
                 if (guildGuid != Guid.Empty && userGuid != Guid.Empty)
                 {
-                    // Mark ban as inactive
-                    await db.Bans
+                    await ctx.Db.Bans
                         .Where(b => b.GuildId == guildGuid && b.UserId == userGuid && b.IsActive)
                         .ExecuteUpdateAsync(s => s
                             .SetProperty(b => b.IsActive, false)
-                            .SetProperty(b => b.UnbannedAtUtc, now));
+                            .SetProperty(b => b.UnbannedAtUtc, ctx.ReceivedAtUtc));
                 }
 
-                db.BanEvents.Add(new BanEventEntity
+                ctx.Db.BanEvents.Add(new BanEventEntity
                 {
                     GuildDiscordId = e.Guild.Id,
                     UserDiscordId = e.Member.Id,
                     EventType = BanEventType.Removed,
-                    EventTimestampUtc = now,
-                    ReceivedAtUtc = now,
-                    RawEventJson = rawJson
+                    EventTimestampUtc = ctx.ReceivedAtUtc,
+                    ReceivedAtUtc = ctx.ReceivedAtUtc,
+                    RawEventJson = ctx.RawJson
                 });
 
-                await db.SaveChangesAsync();
-            }
-            catch (Exception ex)
-            {
-                logger.LogError(ex, "Error handling ban removed for UserId={UserId}", e.Member.Id);
-                using var failureScope = scopeFactory.CreateScope();
-                var failedEventService = failureScope.ServiceProvider.GetRequiredService<FailedEventService>();
-                await failedEventService.RecordFailureAsync(
-                    "GuildBanRemoved", nameof(BanEventHandler), ex,
-                    e.Guild?.Id, null, e.Member?.Id, rawJson, correlationId: correlationId);
-            }
-        }
+                await ctx.Db.SaveChangesAsync();
+            });
     }
 }

--- a/src/DiscordEventService/Services/EventHandlers/EmojiEventHandler.cs
+++ b/src/DiscordEventService/Services/EventHandlers/EmojiEventHandler.cs
@@ -1,6 +1,6 @@
-using DiscordEventService.Data;
 using DiscordEventService.Data.Entities.Core;
 using DiscordEventService.Data.Entities.Events;
+using DiscordEventService.Services.Pipeline;
 using DSharpPlus;
 using DSharpPlus.EventArgs;
 using Microsoft.EntityFrameworkCore;
@@ -8,28 +8,15 @@ using System.Text.Json;
 
 namespace DiscordEventService.Services.EventHandlers;
 
-public class EmojiEventHandler(IServiceScopeFactory scopeFactory, ILogger<EmojiEventHandler> logger) :
+public sealed class EmojiEventHandler(EventPipeline pipeline) :
     IEventHandler<GuildEmojisUpdatedEventArgs>
 {
     public async Task HandleEventAsync(DiscordClient sender, GuildEmojisUpdatedEventArgs e)
     {
-        var correlationId = Guid.NewGuid();
-        using (logger.BeginScope(new Dictionary<string, object> { ["CorrelationId"] = correlationId }))
-        {
-            string? rawJson = null;
-            try
+        await pipeline.Execute(e, "GuildEmojisUpdated", nameof(EmojiEventHandler),
+            e.Guild.Id, null, null, async ctx =>
             {
-                var now = DateTime.UtcNow;
-                using var scope = scopeFactory.CreateScope();
-                var db = scope.ServiceProvider.GetRequiredService<DiscordDbContext>();
-                var rawEventService = scope.ServiceProvider.GetRequiredService<RawEventLogService>();
-
-                rawJson = await rawEventService.SerializeAndLogAsync(
-                    e, "GuildEmojisUpdated", e.Guild.Id, null, null, correlationId: correlationId);
-
-                await db.SaveChangesAsync();
-
-                var guildUpsert = scope.ServiceProvider.GetRequiredService<GuildUpsertService>();
+                var guildUpsert = ctx.Services.GetRequiredService<GuildUpsertService>();
                 var guildGuid = await guildUpsert.UpsertGuildAsync(e.Guild);
 
                 var beforeIds = e.EmojisBefore.Keys.ToHashSet();
@@ -41,15 +28,14 @@ public class EmojiEventHandler(IServiceScopeFactory scopeFactory, ILogger<EmojiE
                     .Where(id => e.EmojisBefore[id].Name != e.EmojisAfter[id].Name)
                     .ToList();
 
-                // Upsert emotes
                 foreach (var emoji in e.EmojisAfter.Values)
                 {
-                    var existing = await db.Emotes
+                    var existing = await ctx.Db.Emotes
                         .Where(em => em.DiscordId == emoji.Id)
                         .FirstOrDefaultAsync();
                     if (existing == null)
                     {
-                        db.Emotes.Add(new EmoteEntity
+                        ctx.Db.Emotes.Add(new EmoteEntity
                         {
                             DiscordId = emoji.Id,
                             GuildId = guildGuid != Guid.Empty ? guildGuid : null,
@@ -68,16 +54,15 @@ public class EmojiEventHandler(IServiceScopeFactory scopeFactory, ILogger<EmojiE
                     }
                 }
 
-                // Mark removed as deleted
                 foreach (var id in removedIds)
                 {
-                    await db.Emotes.Where(em => em.DiscordId == id)
+                    await ctx.Db.Emotes.Where(em => em.DiscordId == id)
                         .ExecuteUpdateAsync(s => s
                             .SetProperty(em => em.IsDeleted, true)
-                            .SetProperty(em => em.DeletedAtUtc, (DateTime?)now));
+                            .SetProperty(em => em.DeletedAtUtc, (DateTime?)ctx.ReceivedAtUtc));
                 }
 
-                var emojiEvent = new EmojiEventEntity
+                ctx.Db.EmojiEvents.Add(new EmojiEventEntity
                 {
                     GuildDiscordId = e.Guild.Id,
                     EmojisAddedJson = addedIds.Count > 0
@@ -89,23 +74,12 @@ public class EmojiEventHandler(IServiceScopeFactory scopeFactory, ILogger<EmojiE
                     EmojisUpdatedJson = updatedIds.Count > 0
                         ? JsonSerializer.Serialize(updatedIds.Select(id => new { Id = id, NameBefore = e.EmojisBefore[id].Name, NameAfter = e.EmojisAfter[id].Name }))
                         : null,
-                    EventTimestampUtc = now,
-                    ReceivedAtUtc = now,
-                    RawEventJson = rawJson
-                };
+                    EventTimestampUtc = ctx.ReceivedAtUtc,
+                    ReceivedAtUtc = ctx.ReceivedAtUtc,
+                    RawEventJson = ctx.RawJson
+                });
 
-                db.EmojiEvents.Add(emojiEvent);
-                await db.SaveChangesAsync();
-            }
-            catch (Exception ex)
-            {
-                logger.LogError(ex, "Error handling emojis updated for GuildId={GuildId}", e.Guild.Id);
-                using var failureScope = scopeFactory.CreateScope();
-                var failedEventService = failureScope.ServiceProvider.GetRequiredService<FailedEventService>();
-                await failedEventService.RecordFailureAsync(
-                    "GuildEmojisUpdated", nameof(EmojiEventHandler), ex,
-                    e.Guild?.Id, null, null, rawJson, correlationId: correlationId);
-            }
-        }
+                await ctx.Db.SaveChangesAsync();
+            });
     }
 }

--- a/src/DiscordEventService/Services/EventHandlers/IntegrationEventHandler.cs
+++ b/src/DiscordEventService/Services/EventHandlers/IntegrationEventHandler.cs
@@ -1,39 +1,26 @@
-using DiscordEventService.Data;
 using DiscordEventService.Data.Entities.Core;
 using DiscordEventService.Data.Entities.Events;
+using DiscordEventService.Services.Pipeline;
 using DSharpPlus;
 using DSharpPlus.EventArgs;
 using Microsoft.EntityFrameworkCore;
 
 namespace DiscordEventService.Services.EventHandlers;
 
-public class IntegrationEventHandler(IServiceScopeFactory scopeFactory, ILogger<IntegrationEventHandler> logger) :
+public sealed class IntegrationEventHandler(EventPipeline pipeline) :
     IEventHandler<IntegrationCreatedEventArgs>,
     IEventHandler<IntegrationUpdatedEventArgs>,
     IEventHandler<IntegrationDeletedEventArgs>
 {
     public async Task HandleEventAsync(DiscordClient sender, IntegrationCreatedEventArgs e)
     {
-        var correlationId = Guid.NewGuid();
-        using (logger.BeginScope(new Dictionary<string, object> { ["CorrelationId"] = correlationId }))
-        {
-            string? rawJson = null;
-            try
+        await pipeline.Execute(e, "IntegrationCreated", nameof(IntegrationEventHandler),
+            e.Guild.Id, null, null, async ctx =>
             {
-                var now = DateTime.UtcNow;
-                using var scope = scopeFactory.CreateScope();
-                var db = scope.ServiceProvider.GetRequiredService<DiscordDbContext>();
-                var rawEventService = scope.ServiceProvider.GetRequiredService<RawEventLogService>();
-
-                rawJson = await rawEventService.SerializeAndLogAsync(
-                    e, "IntegrationCreated", e.Guild.Id, null, null, correlationId: correlationId);
-
-                await db.SaveChangesAsync();
-
-                var guildUpsert = scope.ServiceProvider.GetRequiredService<GuildUpsertService>();
+                var guildUpsert = ctx.Services.GetRequiredService<GuildUpsertService>();
                 var guildGuid = await guildUpsert.UpsertGuildAsync(e.Guild);
 
-                db.Integrations.Add(new IntegrationEntity
+                ctx.Db.Integrations.Add(new IntegrationEntity
                 {
                     DiscordId = e.Integration.Id,
                     GuildId = guildGuid,
@@ -42,7 +29,7 @@ public class IntegrationEventHandler(IServiceScopeFactory scopeFactory, ILogger<
                     IsEnabled = e.Integration.IsEnabled
                 });
 
-                db.IntegrationEvents.Add(new IntegrationEventEntity
+                ctx.Db.IntegrationEvents.Add(new IntegrationEventEntity
                 {
                     IntegrationDiscordId = e.Integration.Id,
                     GuildDiscordId = e.Guild.Id,
@@ -50,48 +37,27 @@ public class IntegrationEventHandler(IServiceScopeFactory scopeFactory, ILogger<
                     Name = e.Integration.Name,
                     Type = e.Integration.Type,
                     IsEnabled = e.Integration.IsEnabled,
-                    EventTimestampUtc = now,
-                    ReceivedAtUtc = now,
-                    RawEventJson = rawJson
+                    EventTimestampUtc = ctx.ReceivedAtUtc,
+                    ReceivedAtUtc = ctx.ReceivedAtUtc,
+                    RawEventJson = ctx.RawJson
                 });
 
-                await db.SaveChangesAsync();
-            }
-            catch (Exception ex)
-            {
-                logger.LogError(ex, "Error handling integration created");
-                using var failureScope = scopeFactory.CreateScope();
-                var failedEventService = failureScope.ServiceProvider.GetRequiredService<FailedEventService>();
-                await failedEventService.RecordFailureAsync(
-                    "IntegrationCreated", nameof(IntegrationEventHandler), ex,
-                    e.Guild?.Id, null, null, rawJson, correlationId: correlationId);
-            }
-        }
+                await ctx.Db.SaveChangesAsync();
+            });
     }
 
     public async Task HandleEventAsync(DiscordClient sender, IntegrationUpdatedEventArgs e)
     {
-        var correlationId = Guid.NewGuid();
-        using (logger.BeginScope(new Dictionary<string, object> { ["CorrelationId"] = correlationId }))
-        {
-            string? rawJson = null;
-            try
+        await pipeline.Execute(e, "IntegrationUpdated", nameof(IntegrationEventHandler),
+            e.Guild.Id, null, null, async ctx =>
             {
-                var now = DateTime.UtcNow;
-                using var scope = scopeFactory.CreateScope();
-                var db = scope.ServiceProvider.GetRequiredService<DiscordDbContext>();
-                var rawEventService = scope.ServiceProvider.GetRequiredService<RawEventLogService>();
-
-                rawJson = await rawEventService.SerializeAndLogAsync(
-                    e, "IntegrationUpdated", e.Guild.Id, null, null, correlationId: correlationId);
-
-                await db.Integrations
+                await ctx.Db.Integrations
                     .Where(i => i.DiscordId == e.Integration.Id)
                     .ExecuteUpdateAsync(s => s
                         .SetProperty(i => i.Name, e.Integration.Name)
                         .SetProperty(i => i.IsEnabled, e.Integration.IsEnabled));
 
-                db.IntegrationEvents.Add(new IntegrationEventEntity
+                ctx.Db.IntegrationEvents.Add(new IntegrationEventEntity
                 {
                     IntegrationDiscordId = e.Integration.Id,
                     GuildDiscordId = e.Guild.Id,
@@ -99,68 +65,37 @@ public class IntegrationEventHandler(IServiceScopeFactory scopeFactory, ILogger<
                     Name = e.Integration.Name,
                     Type = e.Integration.Type,
                     IsEnabled = e.Integration.IsEnabled,
-                    EventTimestampUtc = now,
-                    ReceivedAtUtc = now,
-                    RawEventJson = rawJson
+                    EventTimestampUtc = ctx.ReceivedAtUtc,
+                    ReceivedAtUtc = ctx.ReceivedAtUtc,
+                    RawEventJson = ctx.RawJson
                 });
 
-                await db.SaveChangesAsync();
-            }
-            catch (Exception ex)
-            {
-                logger.LogError(ex, "Error handling integration updated");
-                using var failureScope = scopeFactory.CreateScope();
-                var failedEventService = failureScope.ServiceProvider.GetRequiredService<FailedEventService>();
-                await failedEventService.RecordFailureAsync(
-                    "IntegrationUpdated", nameof(IntegrationEventHandler), ex,
-                    e.Guild?.Id, null, null, rawJson, correlationId: correlationId);
-            }
-        }
+                await ctx.Db.SaveChangesAsync();
+            });
     }
 
     public async Task HandleEventAsync(DiscordClient sender, IntegrationDeletedEventArgs e)
     {
-        var correlationId = Guid.NewGuid();
-        using (logger.BeginScope(new Dictionary<string, object> { ["CorrelationId"] = correlationId }))
-        {
-            string? rawJson = null;
-            try
+        await pipeline.Execute(e, "IntegrationDeleted", nameof(IntegrationEventHandler),
+            e.Guild.Id, null, null, async ctx =>
             {
-                var now = DateTime.UtcNow;
-                using var scope = scopeFactory.CreateScope();
-                var db = scope.ServiceProvider.GetRequiredService<DiscordDbContext>();
-                var rawEventService = scope.ServiceProvider.GetRequiredService<RawEventLogService>();
-
-                rawJson = await rawEventService.SerializeAndLogAsync(
-                    e, "IntegrationDeleted", e.Guild.Id, null, null, correlationId: correlationId);
-
-                await db.Integrations
+                await ctx.Db.Integrations
                     .Where(i => i.DiscordId == e.IntegrationId)
                     .ExecuteUpdateAsync(s => s
                         .SetProperty(i => i.IsDeleted, true)
-                        .SetProperty(i => i.DeletedAtUtc, (DateTime?)now));
+                        .SetProperty(i => i.DeletedAtUtc, (DateTime?)ctx.ReceivedAtUtc));
 
-                db.IntegrationEvents.Add(new IntegrationEventEntity
+                ctx.Db.IntegrationEvents.Add(new IntegrationEventEntity
                 {
                     IntegrationDiscordId = e.IntegrationId,
                     GuildDiscordId = e.Guild.Id,
                     EventType = IntegrationEventType.Deleted,
-                    EventTimestampUtc = now,
-                    ReceivedAtUtc = now,
-                    RawEventJson = rawJson
+                    EventTimestampUtc = ctx.ReceivedAtUtc,
+                    ReceivedAtUtc = ctx.ReceivedAtUtc,
+                    RawEventJson = ctx.RawJson
                 });
 
-                await db.SaveChangesAsync();
-            }
-            catch (Exception ex)
-            {
-                logger.LogError(ex, "Error handling integration deleted");
-                using var failureScope = scopeFactory.CreateScope();
-                var failedEventService = failureScope.ServiceProvider.GetRequiredService<FailedEventService>();
-                await failedEventService.RecordFailureAsync(
-                    "IntegrationDeleted", nameof(IntegrationEventHandler), ex,
-                    e.Guild?.Id, null, null, rawJson, correlationId: correlationId);
-            }
-        }
+                await ctx.Db.SaveChangesAsync();
+            });
     }
 }

--- a/src/DiscordEventService/Services/EventHandlers/InviteEventHandler.cs
+++ b/src/DiscordEventService/Services/EventHandlers/InviteEventHandler.cs
@@ -1,36 +1,24 @@
-using DiscordEventService.Data;
 using DiscordEventService.Data.Entities.Core;
 using DiscordEventService.Data.Entities.Events;
+using DiscordEventService.Services.Pipeline;
 using DSharpPlus;
 using DSharpPlus.EventArgs;
 using Microsoft.EntityFrameworkCore;
 
 namespace DiscordEventService.Services.EventHandlers;
 
-public class InviteEventHandler(IServiceScopeFactory scopeFactory, ILogger<InviteEventHandler> logger) :
+public sealed class InviteEventHandler(EventPipeline pipeline) :
     IEventHandler<InviteCreatedEventArgs>,
     IEventHandler<InviteDeletedEventArgs>
 {
     public async Task HandleEventAsync(DiscordClient sender, InviteCreatedEventArgs e)
     {
-        var correlationId = Guid.NewGuid();
-        using (logger.BeginScope(new Dictionary<string, object> { ["CorrelationId"] = correlationId }))
-        {
-            string? rawJson = null;
-            try
+        await pipeline.Execute(e, "InviteCreated", nameof(InviteEventHandler),
+            e.Guild.Id, e.Channel.Id, e.Invite.Inviter?.Id, async ctx =>
             {
-                var now = DateTime.UtcNow;
-                using var scope = scopeFactory.CreateScope();
-                var db = scope.ServiceProvider.GetRequiredService<DiscordDbContext>();
-                var rawEventService = scope.ServiceProvider.GetRequiredService<RawEventLogService>();
-                var guildUpsert = scope.ServiceProvider.GetRequiredService<GuildUpsertService>();
-                var channelUpsert = scope.ServiceProvider.GetRequiredService<ChannelUpsertService>();
-                var userService = scope.ServiceProvider.GetRequiredService<UserService>();
-
-                rawJson = await rawEventService.SerializeAndLogAsync(
-                    e, "InviteCreated", e.Guild.Id, e.Channel.Id, e.Invite.Inviter?.Id, correlationId: correlationId);
-
-                await db.SaveChangesAsync();
+                var guildUpsert = ctx.Services.GetRequiredService<GuildUpsertService>();
+                var channelUpsert = ctx.Services.GetRequiredService<ChannelUpsertService>();
+                var userService = ctx.Services.GetRequiredService<UserService>();
 
                 var guildGuid = await guildUpsert.UpsertGuildAsync(e.Guild);
                 var channelGuid = await channelUpsert.UpsertChannelAsync(e.Channel, guildGuid);
@@ -38,19 +26,18 @@ public class InviteEventHandler(IServiceScopeFactory scopeFactory, ILogger<Invit
                 if (e.Invite.Inviter != null)
                 {
                     await userService.UpsertUserAsync(e.Invite.Inviter);
-                    inviterGuid = await db.Users
+                    inviterGuid = await ctx.Db.Users
                         .Where(u => u.DiscordId == e.Invite.Inviter.Id)
                         .Select(u => u.Id)
                         .FirstOrDefaultAsync();
                 }
 
-                // Upsert InviteEntity
                 var invite = e.Invite;
-                var inviteEntity = await db.Invites.FirstOrDefaultAsync(i => i.Code == invite.Code);
+                var inviteEntity = await ctx.Db.Invites.FirstOrDefaultAsync(i => i.Code == invite.Code);
                 if (inviteEntity == null)
                 {
                     inviteEntity = new InviteEntity { Code = invite.Code };
-                    db.Invites.Add(inviteEntity);
+                    ctx.Db.Invites.Add(inviteEntity);
                 }
 
                 if (guildGuid != Guid.Empty) inviteEntity.GuildId = guildGuid;
@@ -65,7 +52,7 @@ public class InviteEventHandler(IServiceScopeFactory scopeFactory, ILogger<Invit
                 inviteEntity.IsDeleted = false;
                 inviteEntity.DeletedAtUtc = null;
 
-                var eventEntity = new InviteEventEntity
+                ctx.Db.InviteEvents.Add(new InviteEventEntity
                 {
                     GuildDiscordId = e.Guild.Id,
                     ChannelDiscordId = e.Channel.Id,
@@ -76,72 +63,38 @@ public class InviteEventHandler(IServiceScopeFactory scopeFactory, ILogger<Invit
                     MaxUses = invite.MaxUses,
                     IsTemporary = invite.IsTemporary,
                     Uses = invite.Uses,
-                    EventTimestampUtc = now,
-                    ReceivedAtUtc = now,
-                    RawEventJson = rawJson
-                };
+                    EventTimestampUtc = ctx.ReceivedAtUtc,
+                    ReceivedAtUtc = ctx.ReceivedAtUtc,
+                    RawEventJson = ctx.RawJson
+                });
 
-                db.InviteEvents.Add(eventEntity);
-                await db.SaveChangesAsync();
-            }
-            catch (Exception ex)
-            {
-                logger.LogError(ex, "Error handling invite created");
-                using var failureScope = scopeFactory.CreateScope();
-                var failedEventService = failureScope.ServiceProvider.GetRequiredService<FailedEventService>();
-                await failedEventService.RecordFailureAsync(
-                    "InviteCreated", nameof(InviteEventHandler), ex,
-                    e.Guild?.Id, e.Channel?.Id, e.Invite?.Inviter?.Id, rawJson, correlationId: correlationId);
-            }
-        }
+                await ctx.Db.SaveChangesAsync();
+            });
     }
 
     public async Task HandleEventAsync(DiscordClient sender, InviteDeletedEventArgs e)
     {
-        var correlationId = Guid.NewGuid();
-        using (logger.BeginScope(new Dictionary<string, object> { ["CorrelationId"] = correlationId }))
-        {
-            string? rawJson = null;
-            try
+        await pipeline.Execute(e, "InviteDeleted", nameof(InviteEventHandler),
+            e.Guild.Id, e.Channel.Id, null, async ctx =>
             {
-                var now = DateTime.UtcNow;
-                using var scope = scopeFactory.CreateScope();
-                var db = scope.ServiceProvider.GetRequiredService<DiscordDbContext>();
-                var rawEventService = scope.ServiceProvider.GetRequiredService<RawEventLogService>();
-
-                rawJson = await rawEventService.SerializeAndLogAsync(
-                    e, "InviteDeleted", e.Guild.Id, e.Channel.Id, null, correlationId: correlationId);
-
-                // Mark invite as deleted
-                await db.Invites
+                await ctx.Db.Invites
                     .Where(i => i.Code == e.Invite.Code)
                     .ExecuteUpdateAsync(s => s
                         .SetProperty(i => i.IsDeleted, true)
-                        .SetProperty(i => i.DeletedAtUtc, (DateTime?)now));
+                        .SetProperty(i => i.DeletedAtUtc, (DateTime?)ctx.ReceivedAtUtc));
 
-                var eventEntity = new InviteEventEntity
+                ctx.Db.InviteEvents.Add(new InviteEventEntity
                 {
                     GuildDiscordId = e.Guild.Id,
                     ChannelDiscordId = e.Channel.Id,
                     EventType = InviteEventType.Deleted,
                     Code = e.Invite.Code,
-                    EventTimestampUtc = now,
-                    ReceivedAtUtc = now,
-                    RawEventJson = rawJson
-                };
+                    EventTimestampUtc = ctx.ReceivedAtUtc,
+                    ReceivedAtUtc = ctx.ReceivedAtUtc,
+                    RawEventJson = ctx.RawJson
+                });
 
-                db.InviteEvents.Add(eventEntity);
-                await db.SaveChangesAsync();
-            }
-            catch (Exception ex)
-            {
-                logger.LogError(ex, "Error handling invite deleted");
-                using var failureScope = scopeFactory.CreateScope();
-                var failedEventService = failureScope.ServiceProvider.GetRequiredService<FailedEventService>();
-                await failedEventService.RecordFailureAsync(
-                    "InviteDeleted", nameof(InviteEventHandler), ex,
-                    e.Guild?.Id, e.Channel?.Id, null, rawJson, correlationId: correlationId);
-            }
-        }
+                await ctx.Db.SaveChangesAsync();
+            });
     }
 }

--- a/src/DiscordEventService/Services/EventHandlers/StickerEventHandler.cs
+++ b/src/DiscordEventService/Services/EventHandlers/StickerEventHandler.cs
@@ -1,6 +1,6 @@
-using DiscordEventService.Data;
 using DiscordEventService.Data.Entities.Core;
 using DiscordEventService.Data.Entities.Events;
+using DiscordEventService.Services.Pipeline;
 using DSharpPlus;
 using DSharpPlus.EventArgs;
 using Microsoft.EntityFrameworkCore;
@@ -8,28 +8,15 @@ using System.Text.Json;
 
 namespace DiscordEventService.Services.EventHandlers;
 
-public class StickerEventHandler(IServiceScopeFactory scopeFactory, ILogger<StickerEventHandler> logger) :
+public sealed class StickerEventHandler(EventPipeline pipeline) :
     IEventHandler<GuildStickersUpdatedEventArgs>
 {
     public async Task HandleEventAsync(DiscordClient sender, GuildStickersUpdatedEventArgs e)
     {
-        var correlationId = Guid.NewGuid();
-        using (logger.BeginScope(new Dictionary<string, object> { ["CorrelationId"] = correlationId }))
-        {
-            string? rawJson = null;
-            try
+        await pipeline.Execute(e, "GuildStickersUpdated", nameof(StickerEventHandler),
+            e.Guild.Id, null, null, async ctx =>
             {
-                var now = DateTime.UtcNow;
-                using var scope = scopeFactory.CreateScope();
-                var db = scope.ServiceProvider.GetRequiredService<DiscordDbContext>();
-                var rawEventService = scope.ServiceProvider.GetRequiredService<RawEventLogService>();
-
-                rawJson = await rawEventService.SerializeAndLogAsync(
-                    e, "GuildStickersUpdated", e.Guild.Id, null, null, correlationId: correlationId);
-
-                await db.SaveChangesAsync();
-
-                var guildUpsert = scope.ServiceProvider.GetRequiredService<GuildUpsertService>();
+                var guildUpsert = ctx.Services.GetRequiredService<GuildUpsertService>();
                 var guildGuid = await guildUpsert.UpsertGuildAsync(e.Guild);
 
                 var beforeIds = e.StickersBefore.Keys.ToHashSet();
@@ -42,13 +29,12 @@ public class StickerEventHandler(IServiceScopeFactory scopeFactory, ILogger<Stic
                                  e.StickersBefore[id].Description != e.StickersAfter[id].Description)
                     .ToList();
 
-                // Upsert stickers
                 foreach (var sticker in e.StickersAfter.Values)
                 {
-                    var existing = await db.Stickers.FirstOrDefaultAsync(s => s.DiscordId == sticker.Id);
+                    var existing = await ctx.Db.Stickers.FirstOrDefaultAsync(s => s.DiscordId == sticker.Id);
                     if (existing == null)
                     {
-                        db.Stickers.Add(new StickerEntity
+                        ctx.Db.Stickers.Add(new StickerEntity
                         {
                             DiscordId = sticker.Id,
                             GuildId = guildGuid != Guid.Empty ? guildGuid : null,
@@ -70,16 +56,15 @@ public class StickerEventHandler(IServiceScopeFactory scopeFactory, ILogger<Stic
                     }
                 }
 
-                // Mark removed as deleted
                 foreach (var id in removedIds)
                 {
-                    await db.Stickers.Where(s => s.DiscordId == id)
+                    await ctx.Db.Stickers.Where(s => s.DiscordId == id)
                         .ExecuteUpdateAsync(s => s
                             .SetProperty(st => st.IsDeleted, true)
-                            .SetProperty(st => st.DeletedAtUtc, (DateTime?)now));
+                            .SetProperty(st => st.DeletedAtUtc, (DateTime?)ctx.ReceivedAtUtc));
                 }
 
-                var stickerEvent = new StickerEventEntity
+                ctx.Db.StickerEvents.Add(new StickerEventEntity
                 {
                     GuildDiscordId = e.Guild.Id,
                     StickersAddedJson = addedIds.Count > 0
@@ -91,23 +76,12 @@ public class StickerEventHandler(IServiceScopeFactory scopeFactory, ILogger<Stic
                     StickersUpdatedJson = updatedIds.Count > 0
                         ? JsonSerializer.Serialize(updatedIds.Select(id => new { Id = id, NameBefore = e.StickersBefore[id].Name, NameAfter = e.StickersAfter[id].Name }))
                         : null,
-                    EventTimestampUtc = now,
-                    ReceivedAtUtc = now,
-                    RawEventJson = rawJson
-                };
+                    EventTimestampUtc = ctx.ReceivedAtUtc,
+                    ReceivedAtUtc = ctx.ReceivedAtUtc,
+                    RawEventJson = ctx.RawJson
+                });
 
-                db.StickerEvents.Add(stickerEvent);
-                await db.SaveChangesAsync();
-            }
-            catch (Exception ex)
-            {
-                logger.LogError(ex, "Error handling stickers updated for GuildId={GuildId}", e.Guild.Id);
-                using var failureScope = scopeFactory.CreateScope();
-                var failedEventService = failureScope.ServiceProvider.GetRequiredService<FailedEventService>();
-                await failedEventService.RecordFailureAsync(
-                    "GuildStickersUpdated", nameof(StickerEventHandler), ex,
-                    e.Guild?.Id, null, null, rawJson, correlationId: correlationId);
-            }
-        }
+                await ctx.Db.SaveChangesAsync();
+            });
     }
 }


### PR DESCRIPTION
## Summary
Part 3 of §A1.3 (#157) — migrates the **6 upsert handlers** (those calling `GuildUpsertService` / `UserService` / `ChannelUpsertService`) onto `EventPipeline`.

- `BanEventHandler`, `EmojiEventHandler`, `StickerEventHandler`, `IntegrationEventHandler`, `InviteEventHandler`, `AutoModRuleEventHandler`
- Upsert services are now resolved via `ctx.Services.GetRequiredService<…>()` inside the handler lambda
- The manual raw-flush `SaveChanges` (after `SerializeAndLogAsync`) is dropped — the pipeline flushes raw_event_log before the handler runs
- Net **-279 lines** (160 insertions, 439 deletions)

Behavior preserved:
- **Emoji/Sticker** add/update/soft-delete diffing + `JsonSerializer` payloads unchanged
- **Invite Created** still resolves guild + channel + inviter upserts before upserting the `InviteEntity`
- **Ban** add/remove keeps the active-ban dedup / `ExecuteUpdate` unban
- **AutoModRule** retains its null-guild tolerance (records with `guildId 0`, no early-return). Removing the manual catch blocks cleared the prior failure-path CS8602 null-deref warnings on `e.Rule.Guild?.Id`.

## Test plan
- [x] `dotnet build` — 0 errors; 0 warnings in changed files (down from 6 pre-existing in AutoModRule)
- [x] `VALIDATE_AND_EXIT=1 dotnet run` — DI validation passed
- [ ] Local live test (optional) — emoji add/remove, invite create/delete, ban/unban exercise the upsert paths
- [ ] Post-deploy Loki verification

🤖 Generated with [Claude Code](https://claude.com/claude-code)