### PR TITLE
feat: migrate entity-upsert event handlers to EventPipeline (#157)

### DIFF
--- a/src/DiscordEventService/Services/EventHandlers/ChannelEventHandler.cs
+++ b/src/DiscordEventService/Services/EventHandlers/ChannelEventHandler.cs
@@ -1,6 +1,6 @@
-using DiscordEventService.Data;
 using DiscordEventService.Data.Entities.Core;
 using DiscordEventService.Data.Entities.Events;
+using DiscordEventService.Services.Pipeline;
 using DSharpPlus;
 using DSharpPlus.Entities;
 using DSharpPlus.EventArgs;
@@ -8,7 +8,7 @@ using Microsoft.EntityFrameworkCore;
 
 namespace DiscordEventService.Services.EventHandlers;
 
-public class ChannelEventHandler(IServiceScopeFactory scopeFactory, ILogger<ChannelEventHandler> logger) :
+public sealed class ChannelEventHandler(EventPipeline pipeline) :
     IEventHandler<ChannelCreatedEventArgs>,
     IEventHandler<ChannelUpdatedEventArgs>,
     IEventHandler<ChannelDeletedEventArgs>,
@@ -16,23 +16,10 @@ public class ChannelEventHandler(IServiceScopeFactory scopeFactory, ILogger<Chan
 {
     public async Task HandleEventAsync(DiscordClient sender, ChannelCreatedEventArgs e)
     {
-        var correlationId = Guid.NewGuid();
-        using (logger.BeginScope(new Dictionary<string, object> { ["CorrelationId"] = correlationId }))
-        {
-            string? rawJson = null;
-            try
+        await pipeline.Execute(e, "ChannelCreated", nameof(ChannelEventHandler),
+            e.Guild.Id, e.Channel.Id, null, async ctx =>
             {
-                var receivedAt = DateTime.UtcNow;
-                using var scope = scopeFactory.CreateScope();
-                var db = scope.ServiceProvider.GetRequiredService<DiscordDbContext>();
-                var rawEventService = scope.ServiceProvider.GetRequiredService<RawEventLogService>();
-                var guildUpsert = scope.ServiceProvider.GetRequiredService<GuildUpsertService>();
-
-                rawJson = await rawEventService.SerializeAndLogAsync(
-                    e, "ChannelCreated", e.Guild.Id, e.Channel.Id, null, correlationId: correlationId);
-
-                await db.SaveChangesAsync();
-
+                var guildUpsert = ctx.Services.GetRequiredService<GuildUpsertService>();
                 var guildGuid = await guildUpsert.UpsertGuildAsync(e.Guild);
 
                 ChannelEventEntity NewChannelEvent() => new()
@@ -44,12 +31,12 @@ public class ChannelEventHandler(IServiceScopeFactory scopeFactory, ILogger<Chan
                     NameAfter = e.Channel.Name,
                     TopicAfter = e.Channel.Topic,
                     PositionAfter = e.Channel.Position,
-                    EventTimestampUtc = receivedAt,
-                    ReceivedAtUtc = receivedAt,
-                    RawEventJson = rawJson
+                    EventTimestampUtc = ctx.ReceivedAtUtc,
+                    ReceivedAtUtc = ctx.ReceivedAtUtc,
+                    RawEventJson = ctx.RawJson
                 };
 
-                var channelEntity = await db.Channels
+                var channelEntity = await ctx.Db.Channels
                     .FirstOrDefaultAsync(c => c.DiscordId == e.Channel.Id);
 
                 if (channelEntity == null)
@@ -59,57 +46,37 @@ public class ChannelEventHandler(IServiceScopeFactory scopeFactory, ILogger<Chan
                         DiscordId = e.Channel.Id,
                         GuildId = guildGuid
                     };
-                    db.Channels.Add(channelEntity);
+                    ctx.Db.Channels.Add(channelEntity);
                 }
 
                 UpdateChannelEntity(channelEntity, e.Channel);
-                db.ChannelEvents.Add(NewChannelEvent());
+                ctx.Db.ChannelEvents.Add(NewChannelEvent());
 
                 try
                 {
-                    await db.SaveChangesAsync();
+                    await ctx.Db.SaveChangesAsync();
                 }
                 catch (DbUpdateException dbEx) when (dbEx.InnerException is Npgsql.PostgresException { SqlState: "23505" })
                 {
                     // Concurrent insert won the race. Re-fetch the now-existing row, update it, re-add the event.
-                    db.ChangeTracker.Clear();
-                    var existing = await db.Channels.FirstOrDefaultAsync(c => c.DiscordId == e.Channel.Id);
+                    ctx.Db.ChangeTracker.Clear();
+                    var existing = await ctx.Db.Channels.FirstOrDefaultAsync(c => c.DiscordId == e.Channel.Id);
                     if (existing != null)
                     {
                         UpdateChannelEntity(existing, e.Channel);
                     }
-                    db.ChannelEvents.Add(NewChannelEvent());
-                    await db.SaveChangesAsync();
+                    ctx.Db.ChannelEvents.Add(NewChannelEvent());
+                    await ctx.Db.SaveChangesAsync();
                 }
-            }
-            catch (Exception ex)
-            {
-                logger.LogError(ex, "Error handling channel created for ChannelId={ChannelId}", e.Channel.Id);
-                using var failureScope = scopeFactory.CreateScope();
-                var failedEventService = failureScope.ServiceProvider.GetRequiredService<FailedEventService>();
-                await failedEventService.RecordFailureAsync(
-                    "ChannelCreated", nameof(ChannelEventHandler), ex,
-                    e.Guild?.Id, e.Channel.Id, null, rawJson, correlationId: correlationId);
-            }
-        }
+            });
     }
 
     public async Task HandleEventAsync(DiscordClient sender, ChannelUpdatedEventArgs e)
     {
-        var correlationId = Guid.NewGuid();
-        using (logger.BeginScope(new Dictionary<string, object> { ["CorrelationId"] = correlationId }))
-        {
-            string? rawJson = null;
-            try
+        await pipeline.Execute(e, "ChannelUpdated", nameof(ChannelEventHandler),
+            e.ChannelAfter.Guild.Id, e.ChannelAfter.Id, null, async ctx =>
             {
-                using var scope = scopeFactory.CreateScope();
-                var db = scope.ServiceProvider.GetRequiredService<DiscordDbContext>();
-                var rawEventService = scope.ServiceProvider.GetRequiredService<RawEventLogService>();
-
-                rawJson = await rawEventService.SerializeAndLogAsync(
-                    e, "ChannelUpdated", e.ChannelAfter.Guild.Id, e.ChannelAfter.Id, null, correlationId: correlationId);
-
-                var channelEntity = await db.Channels
+                var channelEntity = await ctx.Db.Channels
                     .FirstOrDefaultAsync(c => c.DiscordId == e.ChannelAfter.Id);
 
                 if (channelEntity != null)
@@ -123,9 +90,9 @@ public class ChannelEventHandler(IServiceScopeFactory scopeFactory, ILogger<Chan
                     GuildDiscordId = e.ChannelAfter.Guild.Id,
                     ChannelType = (int)e.ChannelAfter.Type,
                     EventType = ChannelEventType.Updated,
-                    EventTimestampUtc = DateTime.UtcNow,
-                    ReceivedAtUtc = DateTime.UtcNow,
-                    RawEventJson = rawJson
+                    EventTimestampUtc = ctx.ReceivedAtUtc,
+                    ReceivedAtUtc = ctx.ReceivedAtUtc,
+                    RawEventJson = ctx.RawJson
                 };
 
                 if (e.ChannelBefore.Name != e.ChannelAfter.Name)
@@ -146,46 +113,26 @@ public class ChannelEventHandler(IServiceScopeFactory scopeFactory, ILogger<Chan
                     channelEvent.PositionAfter = e.ChannelAfter.Position;
                 }
 
-                db.ChannelEvents.Add(channelEvent);
-                await db.SaveChangesAsync();
-            }
-            catch (Exception ex)
-            {
-                logger.LogError(ex, "Error handling channel updated for ChannelId={ChannelId}", e.ChannelAfter.Id);
-                using var failureScope = scopeFactory.CreateScope();
-                var failedEventService = failureScope.ServiceProvider.GetRequiredService<FailedEventService>();
-                await failedEventService.RecordFailureAsync(
-                    "ChannelUpdated", nameof(ChannelEventHandler), ex,
-                    e.ChannelAfter.Guild?.Id, e.ChannelAfter.Id, null, rawJson, correlationId: correlationId);
-            }
-        }
+                ctx.Db.ChannelEvents.Add(channelEvent);
+                await ctx.Db.SaveChangesAsync();
+            });
     }
 
     public async Task HandleEventAsync(DiscordClient sender, ChannelDeletedEventArgs e)
     {
-        var correlationId = Guid.NewGuid();
-        using (logger.BeginScope(new Dictionary<string, object> { ["CorrelationId"] = correlationId }))
-        {
-            string? rawJson = null;
-            try
+        await pipeline.Execute(e, "ChannelDeleted", nameof(ChannelEventHandler),
+            e.Guild.Id, e.Channel.Id, null, async ctx =>
             {
-                using var scope = scopeFactory.CreateScope();
-                var db = scope.ServiceProvider.GetRequiredService<DiscordDbContext>();
-                var rawEventService = scope.ServiceProvider.GetRequiredService<RawEventLogService>();
-
-                rawJson = await rawEventService.SerializeAndLogAsync(
-                    e, "ChannelDeleted", e.Guild.Id, e.Channel.Id, null, correlationId: correlationId);
-
-                var channelEntity = await db.Channels
+                var channelEntity = await ctx.Db.Channels
                     .FirstOrDefaultAsync(c => c.DiscordId == e.Channel.Id);
 
                 if (channelEntity != null)
                 {
                     channelEntity.IsDeleted = true;
-                    channelEntity.DeletedAtUtc = DateTime.UtcNow;
+                    channelEntity.DeletedAtUtc = ctx.ReceivedAtUtc;
                 }
 
-                var channelEvent = new ChannelEventEntity
+                ctx.Db.ChannelEvents.Add(new ChannelEventEntity
                 {
                     ChannelDiscordId = e.Channel.Id,
                     GuildDiscordId = e.Guild.Id,
@@ -194,65 +141,33 @@ public class ChannelEventHandler(IServiceScopeFactory scopeFactory, ILogger<Chan
                     NameBefore = e.Channel.Name,
                     TopicBefore = e.Channel.Topic,
                     PositionBefore = e.Channel.Position,
-                    EventTimestampUtc = DateTime.UtcNow,
-                    ReceivedAtUtc = DateTime.UtcNow,
-                    RawEventJson = rawJson
-                };
+                    EventTimestampUtc = ctx.ReceivedAtUtc,
+                    ReceivedAtUtc = ctx.ReceivedAtUtc,
+                    RawEventJson = ctx.RawJson
+                });
 
-                db.ChannelEvents.Add(channelEvent);
-                await db.SaveChangesAsync();
-            }
-            catch (Exception ex)
-            {
-                logger.LogError(ex, "Error handling channel deleted for ChannelId={ChannelId}", e.Channel.Id);
-                using var failureScope = scopeFactory.CreateScope();
-                var failedEventService = failureScope.ServiceProvider.GetRequiredService<FailedEventService>();
-                await failedEventService.RecordFailureAsync(
-                    "ChannelDeleted", nameof(ChannelEventHandler), ex,
-                    e.Guild?.Id, e.Channel.Id, null, rawJson, correlationId: correlationId);
-            }
-        }
+                await ctx.Db.SaveChangesAsync();
+            });
     }
 
     public async Task HandleEventAsync(DiscordClient sender, ChannelPinsUpdatedEventArgs e)
     {
-        var correlationId = Guid.NewGuid();
-        using (logger.BeginScope(new Dictionary<string, object> { ["CorrelationId"] = correlationId }))
-        {
-            string? rawJson = null;
-            try
+        await pipeline.Execute(e, "ChannelPinsUpdatedChannel", nameof(ChannelEventHandler),
+            e.Guild?.Id ?? 0, e.Channel.Id, null, async ctx =>
             {
-                using var scope = scopeFactory.CreateScope();
-                var db = scope.ServiceProvider.GetRequiredService<DiscordDbContext>();
-                var rawEventService = scope.ServiceProvider.GetRequiredService<RawEventLogService>();
-
-                rawJson = await rawEventService.SerializeAndLogAsync(
-                    e, "ChannelPinsUpdatedChannel", e.Guild?.Id ?? 0, e.Channel.Id, null, correlationId: correlationId);
-
-                var channelEvent = new ChannelEventEntity
+                ctx.Db.ChannelEvents.Add(new ChannelEventEntity
                 {
                     ChannelDiscordId = e.Channel.Id,
                     GuildDiscordId = e.Guild?.Id ?? 0,
                     ChannelType = (int)e.Channel.Type,
                     EventType = ChannelEventType.PinsUpdated,
-                    EventTimestampUtc = e.LastPinTimestamp?.UtcDateTime ?? DateTime.UtcNow,
-                    ReceivedAtUtc = DateTime.UtcNow,
-                    RawEventJson = rawJson
-                };
+                    EventTimestampUtc = e.LastPinTimestamp?.UtcDateTime ?? ctx.ReceivedAtUtc,
+                    ReceivedAtUtc = ctx.ReceivedAtUtc,
+                    RawEventJson = ctx.RawJson
+                });
 
-                db.ChannelEvents.Add(channelEvent);
-                await db.SaveChangesAsync();
-            }
-            catch (Exception ex)
-            {
-                logger.LogError(ex, "Error handling channel pins updated for ChannelId={ChannelId}", e.Channel.Id);
-                using var failureScope = scopeFactory.CreateScope();
-                var failedEventService = failureScope.ServiceProvider.GetRequiredService<FailedEventService>();
-                await failedEventService.RecordFailureAsync(
-                    "ChannelPinsUpdatedChannel", nameof(ChannelEventHandler), ex,
-                    e.Guild?.Id, e.Channel.Id, null, rawJson, correlationId: correlationId);
-            }
-        }
+                await ctx.Db.SaveChangesAsync();
+            });
     }
 
     private static void UpdateChannelEntity(ChannelEntity entity, DiscordChannel channel)

--- a/src/DiscordEventService/Services/EventHandlers/RoleEventHandler.cs
+++ b/src/DiscordEventService/Services/EventHandlers/RoleEventHandler.cs
@@ -1,6 +1,6 @@
-using DiscordEventService.Data;
 using DiscordEventService.Data.Entities.Core;
 using DiscordEventService.Data.Entities.Events;
+using DiscordEventService.Services.Pipeline;
 using DSharpPlus;
 using DSharpPlus.Entities;
 using DSharpPlus.EventArgs;
@@ -8,30 +8,17 @@ using Microsoft.EntityFrameworkCore;
 
 namespace DiscordEventService.Services.EventHandlers;
 
-public class RoleEventHandler(IServiceScopeFactory scopeFactory, ILogger<RoleEventHandler> logger) :
+public sealed class RoleEventHandler(EventPipeline pipeline) :
     IEventHandler<GuildRoleCreatedEventArgs>,
     IEventHandler<GuildRoleUpdatedEventArgs>,
     IEventHandler<GuildRoleDeletedEventArgs>
 {
     public async Task HandleEventAsync(DiscordClient sender, GuildRoleCreatedEventArgs e)
     {
-        var correlationId = Guid.NewGuid();
-        using (logger.BeginScope(new Dictionary<string, object> { ["CorrelationId"] = correlationId }))
-        {
-            string? rawJson = null;
-            try
+        await pipeline.Execute(e, "GuildRoleCreated", nameof(RoleEventHandler),
+            e.Guild.Id, null, null, async ctx =>
             {
-                var receivedAt = DateTime.UtcNow;
-                using var scope = scopeFactory.CreateScope();
-                var db = scope.ServiceProvider.GetRequiredService<DiscordDbContext>();
-                var rawEventService = scope.ServiceProvider.GetRequiredService<RawEventLogService>();
-                var guildUpsert = scope.ServiceProvider.GetRequiredService<GuildUpsertService>();
-
-                rawJson = await rawEventService.SerializeAndLogAsync(
-                    e, "GuildRoleCreated", e.Guild.Id, null, null, correlationId: correlationId);
-
-                await db.SaveChangesAsync();
-
+                var guildUpsert = ctx.Services.GetRequiredService<GuildUpsertService>();
                 var guildGuid = await guildUpsert.UpsertGuildAsync(e.Guild);
 
                 RoleEventEntity NewRoleEvent() => new()
@@ -41,12 +28,12 @@ public class RoleEventHandler(IServiceScopeFactory scopeFactory, ILogger<RoleEve
                     EventType = RoleEventType.Created,
                     NameAfter = e.Role.Name,
                     ColorAfter = e.Role.Color.Value,
-                    EventTimestampUtc = receivedAt,
-                    ReceivedAtUtc = receivedAt,
-                    RawEventJson = rawJson
+                    EventTimestampUtc = ctx.ReceivedAtUtc,
+                    ReceivedAtUtc = ctx.ReceivedAtUtc,
+                    RawEventJson = ctx.RawJson
                 };
 
-                var roleEntity = await db.Roles
+                var roleEntity = await ctx.Db.Roles
                     .FirstOrDefaultAsync(r => r.DiscordId == e.Role.Id);
 
                 if (roleEntity == null)
@@ -56,58 +43,37 @@ public class RoleEventHandler(IServiceScopeFactory scopeFactory, ILogger<RoleEve
                         DiscordId = e.Role.Id,
                         GuildId = guildGuid
                     };
-                    db.Roles.Add(roleEntity);
+                    ctx.Db.Roles.Add(roleEntity);
                 }
 
                 UpdateRoleEntity(roleEntity, e.Role);
-                db.RoleEvents.Add(NewRoleEvent());
+                ctx.Db.RoleEvents.Add(NewRoleEvent());
 
                 try
                 {
-                    await db.SaveChangesAsync();
+                    await ctx.Db.SaveChangesAsync();
                 }
                 catch (DbUpdateException dbEx) when (dbEx.InnerException is Npgsql.PostgresException { SqlState: "23505" })
                 {
                     // Concurrent insert won the race. Re-fetch, update, re-add the event.
-                    db.ChangeTracker.Clear();
-                    var existing = await db.Roles.FirstOrDefaultAsync(r => r.DiscordId == e.Role.Id);
+                    ctx.Db.ChangeTracker.Clear();
+                    var existing = await ctx.Db.Roles.FirstOrDefaultAsync(r => r.DiscordId == e.Role.Id);
                     if (existing != null)
                     {
                         UpdateRoleEntity(existing, e.Role);
                     }
-                    db.RoleEvents.Add(NewRoleEvent());
-                    await db.SaveChangesAsync();
+                    ctx.Db.RoleEvents.Add(NewRoleEvent());
+                    await ctx.Db.SaveChangesAsync();
                 }
-            }
-            catch (Exception ex)
-            {
-                logger.LogError(ex, "Error handling role created for RoleId={RoleId}", e.Role.Id);
-                using var failureScope = scopeFactory.CreateScope();
-                var failedEventService = failureScope.ServiceProvider.GetRequiredService<FailedEventService>();
-                await failedEventService.RecordFailureAsync(
-                    "GuildRoleCreated", nameof(RoleEventHandler), ex,
-                    e.Guild?.Id, null, null, rawJson, correlationId: correlationId);
-            }
-        }
+            });
     }
 
     public async Task HandleEventAsync(DiscordClient sender, GuildRoleUpdatedEventArgs e)
     {
-        var correlationId = Guid.NewGuid();
-        using (logger.BeginScope(new Dictionary<string, object> { ["CorrelationId"] = correlationId }))
-        {
-            string? rawJson = null;
-            try
+        await pipeline.Execute(e, "GuildRoleUpdated", nameof(RoleEventHandler),
+            e.Guild.Id, null, null, async ctx =>
             {
-                var receivedAt = DateTime.UtcNow;
-                using var scope = scopeFactory.CreateScope();
-                var db = scope.ServiceProvider.GetRequiredService<DiscordDbContext>();
-                var rawEventService = scope.ServiceProvider.GetRequiredService<RawEventLogService>();
-
-                rawJson = await rawEventService.SerializeAndLogAsync(
-                    e, "GuildRoleUpdated", e.Guild.Id, null, null, correlationId: correlationId);
-
-                var roleEntity = await db.Roles
+                var roleEntity = await ctx.Db.Roles
                     .FirstOrDefaultAsync(r => r.DiscordId == e.RoleAfter.Id);
 
                 if (roleEntity != null)
@@ -120,9 +86,9 @@ public class RoleEventHandler(IServiceScopeFactory scopeFactory, ILogger<RoleEve
                     RoleDiscordId = e.RoleAfter.Id,
                     GuildDiscordId = e.Guild.Id,
                     EventType = RoleEventType.Updated,
-                    EventTimestampUtc = receivedAt,
-                    ReceivedAtUtc = receivedAt,
-                    RawEventJson = rawJson
+                    EventTimestampUtc = ctx.ReceivedAtUtc,
+                    ReceivedAtUtc = ctx.ReceivedAtUtc,
+                    RawEventJson = ctx.RawJson
                 };
 
                 if (e.RoleBefore.Name != e.RoleAfter.Name)
@@ -137,71 +103,39 @@ public class RoleEventHandler(IServiceScopeFactory scopeFactory, ILogger<RoleEve
                     roleEvent.ColorAfter = e.RoleAfter.Color.Value;
                 }
 
-                db.RoleEvents.Add(roleEvent);
-                await db.SaveChangesAsync();
-            }
-            catch (Exception ex)
-            {
-                logger.LogError(ex, "Error handling role updated for RoleId={RoleId}", e.RoleAfter.Id);
-                using var failureScope = scopeFactory.CreateScope();
-                var failedEventService = failureScope.ServiceProvider.GetRequiredService<FailedEventService>();
-                await failedEventService.RecordFailureAsync(
-                    "GuildRoleUpdated", nameof(RoleEventHandler), ex,
-                    e.Guild?.Id, null, null, rawJson, correlationId: correlationId);
-            }
-        }
+                ctx.Db.RoleEvents.Add(roleEvent);
+                await ctx.Db.SaveChangesAsync();
+            });
     }
 
     public async Task HandleEventAsync(DiscordClient sender, GuildRoleDeletedEventArgs e)
     {
-        var correlationId = Guid.NewGuid();
-        using (logger.BeginScope(new Dictionary<string, object> { ["CorrelationId"] = correlationId }))
-        {
-            string? rawJson = null;
-            try
+        await pipeline.Execute(e, "GuildRoleDeleted", nameof(RoleEventHandler),
+            e.Guild.Id, null, null, async ctx =>
             {
-                var receivedAt = DateTime.UtcNow;
-                using var scope = scopeFactory.CreateScope();
-                var db = scope.ServiceProvider.GetRequiredService<DiscordDbContext>();
-                var rawEventService = scope.ServiceProvider.GetRequiredService<RawEventLogService>();
-
-                rawJson = await rawEventService.SerializeAndLogAsync(
-                    e, "GuildRoleDeleted", e.Guild.Id, null, null, correlationId: correlationId);
-
-                var roleEntity = await db.Roles
+                var roleEntity = await ctx.Db.Roles
                     .FirstOrDefaultAsync(r => r.DiscordId == e.Role.Id);
 
                 if (roleEntity != null)
                 {
                     roleEntity.IsDeleted = true;
-                    roleEntity.DeletedAtUtc = receivedAt;
+                    roleEntity.DeletedAtUtc = ctx.ReceivedAtUtc;
                 }
 
-                var roleEvent = new RoleEventEntity
+                ctx.Db.RoleEvents.Add(new RoleEventEntity
                 {
                     RoleDiscordId = e.Role.Id,
                     GuildDiscordId = e.Guild.Id,
                     EventType = RoleEventType.Deleted,
                     NameBefore = e.Role.Name,
                     ColorBefore = e.Role.Color.Value,
-                    EventTimestampUtc = receivedAt,
-                    ReceivedAtUtc = receivedAt,
-                    RawEventJson = rawJson
-                };
+                    EventTimestampUtc = ctx.ReceivedAtUtc,
+                    ReceivedAtUtc = ctx.ReceivedAtUtc,
+                    RawEventJson = ctx.RawJson
+                });
 
-                db.RoleEvents.Add(roleEvent);
-                await db.SaveChangesAsync();
-            }
-            catch (Exception ex)
-            {
-                logger.LogError(ex, "Error handling role deleted for RoleId={RoleId}", e.Role.Id);
-                using var failureScope = scopeFactory.CreateScope();
-                var failedEventService = failureScope.ServiceProvider.GetRequiredService<FailedEventService>();
-                await failedEventService.RecordFailureAsync(
-                    "GuildRoleDeleted", nameof(RoleEventHandler), ex,
-                    e.Guild?.Id, null, null, rawJson, correlationId: correlationId);
-            }
-        }
+                await ctx.Db.SaveChangesAsync();
+            });
     }
 
     private static void UpdateRoleEntity(RoleEntity entity, DiscordRole role)

--- a/src/DiscordEventService/Services/EventHandlers/ThreadEventHandler.cs
+++ b/src/DiscordEventService/Services/EventHandlers/ThreadEventHandler.cs
@@ -1,13 +1,13 @@
 using System.Text.Json;
-using DiscordEventService.Data;
 using DiscordEventService.Data.Entities.Events;
+using DiscordEventService.Services.Pipeline;
 using DSharpPlus;
 using DSharpPlus.Entities;
 using DSharpPlus.EventArgs;
 
 namespace DiscordEventService.Services.EventHandlers;
 
-public class ThreadEventHandler(IServiceScopeFactory scopeFactory, ILogger<ThreadEventHandler> logger) :
+public sealed class ThreadEventHandler(EventPipeline pipeline) :
     IEventHandler<ThreadCreatedEventArgs>,
     IEventHandler<ThreadUpdatedEventArgs>,
     IEventHandler<ThreadDeletedEventArgs>,
@@ -15,24 +15,11 @@ public class ThreadEventHandler(IServiceScopeFactory scopeFactory, ILogger<Threa
 {
     public async Task HandleEventAsync(DiscordClient sender, ThreadCreatedEventArgs e)
     {
-        var correlationId = Guid.NewGuid();
-        using (logger.BeginScope(new Dictionary<string, object> { ["CorrelationId"] = correlationId }))
-        {
-            string? rawJson = null;
-            try
+        await pipeline.Execute(e, "ThreadCreated", nameof(ThreadEventHandler),
+            e.Guild.Id, e.Thread.Id, e.Thread.CreatorId, async ctx =>
             {
-                using var scope = scopeFactory.CreateScope();
-                var db = scope.ServiceProvider.GetRequiredService<DiscordDbContext>();
-                var rawEventService = scope.ServiceProvider.GetRequiredService<RawEventLogService>();
-                var guildUpsert = scope.ServiceProvider.GetRequiredService<GuildUpsertService>();
-                var channelUpsert = scope.ServiceProvider.GetRequiredService<ChannelUpsertService>();
-
-                rawJson = await rawEventService.SerializeAndLogAsync(
-                    e, "ThreadCreated", e.Guild.Id, e.Thread.Id, e.Thread.CreatorId, correlationId: correlationId);
-
-                // Flush the raw event row before any upsert; the upsert services' 23505 catch path
-                // calls ChangeTracker.Clear() which would otherwise drop the staged raw_event_logs row.
-                await db.SaveChangesAsync();
+                var guildUpsert = ctx.Services.GetRequiredService<GuildUpsertService>();
+                var channelUpsert = ctx.Services.GetRequiredService<ChannelUpsertService>();
 
                 // Threads are channels (ADR-0003): upsert the thread into `channels` so messages
                 // sent into it have a non-null channel_id from the first event onward.
@@ -42,7 +29,7 @@ public class ThreadEventHandler(IServiceScopeFactory scopeFactory, ILogger<Threa
                 // For message threads (parent is text/news), thread ID == starter message ID
                 var isMessageThread = e.Parent?.Type is DiscordChannelType.Text or DiscordChannelType.News;
 
-                var threadEvent = new ThreadEventEntity
+                ctx.Db.ThreadEvents.Add(new ThreadEventEntity
                 {
                     ThreadDiscordId = e.Thread.Id,
                     ParentChannelDiscordId = e.Thread.ParentId ?? 0,
@@ -53,49 +40,27 @@ public class ThreadEventHandler(IServiceScopeFactory scopeFactory, ILogger<Threa
                     StarterMessageDiscordId = isMessageThread ? e.Thread.Id : null,
                     IsArchived = e.Thread.ThreadMetadata?.IsArchived ?? false,
                     IsLocked = e.Thread.ThreadMetadata?.IsLocked ?? false,
-                    EventTimestampUtc = DateTime.UtcNow,
-                    ReceivedAtUtc = DateTime.UtcNow,
-                    RawEventJson = rawJson
-                };
+                    EventTimestampUtc = ctx.ReceivedAtUtc,
+                    ReceivedAtUtc = ctx.ReceivedAtUtc,
+                    RawEventJson = ctx.RawJson
+                });
 
-                db.ThreadEvents.Add(threadEvent);
-                await db.SaveChangesAsync();
-            }
-            catch (Exception ex)
-            {
-                logger.LogError(ex, "Error handling thread created for ThreadId={ThreadId}", e.Thread.Id);
-                using var failureScope = scopeFactory.CreateScope();
-                var failedEventService = failureScope.ServiceProvider.GetRequiredService<FailedEventService>();
-                await failedEventService.RecordFailureAsync(
-                    "ThreadCreated", nameof(ThreadEventHandler), ex,
-                    e.Guild?.Id, e.Thread?.Id, e.Thread?.CreatorId, rawJson, correlationId: correlationId);
-            }
-        }
+                await ctx.Db.SaveChangesAsync();
+            });
     }
 
     public async Task HandleEventAsync(DiscordClient sender, ThreadUpdatedEventArgs e)
     {
-        var correlationId = Guid.NewGuid();
-        using (logger.BeginScope(new Dictionary<string, object> { ["CorrelationId"] = correlationId }))
-        {
-            string? rawJson = null;
-            try
+        await pipeline.Execute(e, "ThreadUpdated", nameof(ThreadEventHandler),
+            e.Guild.Id, e.ThreadAfter.Id, e.ThreadAfter.CreatorId, async ctx =>
             {
-                using var scope = scopeFactory.CreateScope();
-                var db = scope.ServiceProvider.GetRequiredService<DiscordDbContext>();
-                var rawEventService = scope.ServiceProvider.GetRequiredService<RawEventLogService>();
-                var guildUpsert = scope.ServiceProvider.GetRequiredService<GuildUpsertService>();
-                var channelUpsert = scope.ServiceProvider.GetRequiredService<ChannelUpsertService>();
-
-                rawJson = await rawEventService.SerializeAndLogAsync(
-                    e, "ThreadUpdated", e.Guild.Id, e.ThreadAfter.Id, e.ThreadAfter.CreatorId, correlationId: correlationId);
-
-                await db.SaveChangesAsync();
+                var guildUpsert = ctx.Services.GetRequiredService<GuildUpsertService>();
+                var channelUpsert = ctx.Services.GetRequiredService<ChannelUpsertService>();
 
                 var guildId = await guildUpsert.UpsertGuildAsync(e.Guild);
                 await channelUpsert.UpsertChannelAsync(e.ThreadAfter, guildId);
 
-                var threadEvent = new ThreadEventEntity
+                ctx.Db.ThreadEvents.Add(new ThreadEventEntity
                 {
                     ThreadDiscordId = e.ThreadAfter.Id,
                     ParentChannelDiscordId = e.ThreadAfter.ParentId ?? 0,
@@ -105,47 +70,24 @@ public class ThreadEventHandler(IServiceScopeFactory scopeFactory, ILogger<Threa
                     OwnerDiscordId = e.ThreadAfter.CreatorId,
                     IsArchived = e.ThreadAfter.ThreadMetadata?.IsArchived ?? false,
                     IsLocked = e.ThreadAfter.ThreadMetadata?.IsLocked ?? false,
-                    EventTimestampUtc = DateTime.UtcNow,
-                    ReceivedAtUtc = DateTime.UtcNow,
-                    RawEventJson = rawJson
-                };
+                    EventTimestampUtc = ctx.ReceivedAtUtc,
+                    ReceivedAtUtc = ctx.ReceivedAtUtc,
+                    RawEventJson = ctx.RawJson
+                });
 
-                db.ThreadEvents.Add(threadEvent);
-                await db.SaveChangesAsync();
-            }
-            catch (Exception ex)
-            {
-                logger.LogError(ex, "Error handling thread updated for ThreadId={ThreadId}", e.ThreadAfter.Id);
-                using var failureScope = scopeFactory.CreateScope();
-                var failedEventService = failureScope.ServiceProvider.GetRequiredService<FailedEventService>();
-                await failedEventService.RecordFailureAsync(
-                    "ThreadUpdated", nameof(ThreadEventHandler), ex,
-                    e.Guild?.Id, e.ThreadAfter?.Id, e.ThreadAfter?.CreatorId, rawJson, correlationId: correlationId);
-            }
-        }
+                await ctx.Db.SaveChangesAsync();
+            });
     }
 
     public async Task HandleEventAsync(DiscordClient sender, ThreadDeletedEventArgs e)
     {
-        var correlationId = Guid.NewGuid();
-        using (logger.BeginScope(new Dictionary<string, object> { ["CorrelationId"] = correlationId }))
-        {
-            string? rawJson = null;
-            try
+        await pipeline.Execute(e, "ThreadDeleted", nameof(ThreadEventHandler),
+            e.Guild.Id, e.Thread.Id, e.Thread.CreatorId, async ctx =>
             {
-                using var scope = scopeFactory.CreateScope();
-                var db = scope.ServiceProvider.GetRequiredService<DiscordDbContext>();
-                var rawEventService = scope.ServiceProvider.GetRequiredService<RawEventLogService>();
-                var channelUpsert = scope.ServiceProvider.GetRequiredService<ChannelUpsertService>();
+                var channelUpsert = ctx.Services.GetRequiredService<ChannelUpsertService>();
+                await channelUpsert.MarkDeletedAsync(e.Thread.Id, ctx.ReceivedAtUtc);
 
-                rawJson = await rawEventService.SerializeAndLogAsync(
-                    e, "ThreadDeleted", e.Guild.Id, e.Thread.Id, e.Thread.CreatorId, correlationId: correlationId);
-
-                await db.SaveChangesAsync();
-
-                await channelUpsert.MarkDeletedAsync(e.Thread.Id, DateTime.UtcNow);
-
-                var threadEvent = new ThreadEventEntity
+                ctx.Db.ThreadEvents.Add(new ThreadEventEntity
                 {
                     ThreadDiscordId = e.Thread.Id,
                     ParentChannelDiscordId = e.Thread.ParentId ?? 0,
@@ -155,41 +97,20 @@ public class ThreadEventHandler(IServiceScopeFactory scopeFactory, ILogger<Threa
                     OwnerDiscordId = e.Thread.CreatorId,
                     IsArchived = e.Thread.ThreadMetadata?.IsArchived ?? false,
                     IsLocked = e.Thread.ThreadMetadata?.IsLocked ?? false,
-                    EventTimestampUtc = DateTime.UtcNow,
-                    ReceivedAtUtc = DateTime.UtcNow,
-                    RawEventJson = rawJson
-                };
+                    EventTimestampUtc = ctx.ReceivedAtUtc,
+                    ReceivedAtUtc = ctx.ReceivedAtUtc,
+                    RawEventJson = ctx.RawJson
+                });
 
-                db.ThreadEvents.Add(threadEvent);
-                await db.SaveChangesAsync();
-            }
-            catch (Exception ex)
-            {
-                logger.LogError(ex, "Error handling thread deleted for ThreadId={ThreadId}", e.Thread.Id);
-                using var failureScope = scopeFactory.CreateScope();
-                var failedEventService = failureScope.ServiceProvider.GetRequiredService<FailedEventService>();
-                await failedEventService.RecordFailureAsync(
-                    "ThreadDeleted", nameof(ThreadEventHandler), ex,
-                    e.Guild?.Id, e.Thread?.Id, e.Thread?.CreatorId, rawJson, correlationId: correlationId);
-            }
-        }
+                await ctx.Db.SaveChangesAsync();
+            });
     }
 
     public async Task HandleEventAsync(DiscordClient sender, ThreadMembersUpdatedEventArgs e)
     {
-        var correlationId = Guid.NewGuid();
-        using (logger.BeginScope(new Dictionary<string, object> { ["CorrelationId"] = correlationId }))
-        {
-            string? rawJson = null;
-            try
+        await pipeline.Execute(e, "ThreadMembersUpdated", nameof(ThreadEventHandler),
+            e.Guild.Id, e.Thread.Id, null, async ctx =>
             {
-                using var scope = scopeFactory.CreateScope();
-                var db = scope.ServiceProvider.GetRequiredService<DiscordDbContext>();
-                var rawEventService = scope.ServiceProvider.GetRequiredService<RawEventLogService>();
-
-                rawJson = await rawEventService.SerializeAndLogAsync(
-                    e, "ThreadMembersUpdated", e.Guild.Id, e.Thread.Id, null, correlationId: correlationId);
-
                 string? membersAddedJson = null;
                 string? membersRemovedJson = null;
 
@@ -205,7 +126,7 @@ public class ThreadEventHandler(IServiceScopeFactory scopeFactory, ILogger<Threa
                     membersRemovedJson = JsonSerializer.Serialize(removedMemberIds);
                 }
 
-                var threadEvent = new ThreadEventEntity
+                ctx.Db.ThreadEvents.Add(new ThreadEventEntity
                 {
                     ThreadDiscordId = e.Thread.Id,
                     ParentChannelDiscordId = e.Thread.ParentId ?? 0,
@@ -217,23 +138,12 @@ public class ThreadEventHandler(IServiceScopeFactory scopeFactory, ILogger<Threa
                     IsLocked = e.Thread.ThreadMetadata?.IsLocked ?? false,
                     MembersAddedJson = membersAddedJson,
                     MembersRemovedJson = membersRemovedJson,
-                    EventTimestampUtc = DateTime.UtcNow,
-                    ReceivedAtUtc = DateTime.UtcNow,
-                    RawEventJson = rawJson
-                };
+                    EventTimestampUtc = ctx.ReceivedAtUtc,
+                    ReceivedAtUtc = ctx.ReceivedAtUtc,
+                    RawEventJson = ctx.RawJson
+                });
 
-                db.ThreadEvents.Add(threadEvent);
-                await db.SaveChangesAsync();
-            }
-            catch (Exception ex)
-            {
-                logger.LogError(ex, "Error handling thread members updated for ThreadId={ThreadId}", e.Thread.Id);
-                using var failureScope = scopeFactory.CreateScope();
-                var failedEventService = failureScope.ServiceProvider.GetRequiredService<FailedEventService>();
-                await failedEventService.RecordFailureAsync(
-                    "ThreadMembersUpdated", nameof(ThreadEventHandler), ex,
-                    e.Guild?.Id, e.Thread?.Id, null, rawJson, correlationId: correlationId);
-            }
-        }
+                await ctx.Db.SaveChangesAsync();
+            });
     }
 }


### PR DESCRIPTION
## Summary
Part 4 (final) of §A1.3 (#157) — migrates the **3 entity-upsert handlers** onto `EventPipeline`, completing the medium-handler migration.

- `ChannelEventHandler` (4 events), `RoleEventHandler` (3 events), `ThreadEventHandler` (4 events)
- Net **-241 lines** (131 insertions, 372 deletions)

Key behavior preserved:
- **23505 concurrent-insert retry** (Channel/Role *Created*) now runs inside the pipeline lambda on `ctx.Db`. The pipeline pre-flushes `raw_event_log` before the handler runs, so the retry's `ChangeTracker.Clear()` cannot drop the raw row (the exact case the pre-flush exists for). `NewChannelEvent()`/`NewRoleEvent()` local functions and `UpdateChannelEntity`/`UpdateRoleEntity` helpers preserved verbatim.
- **Channel pins** keeps its null-guild tolerance (`e.Guild?.Id ?? 0`, no early return), unlike `PinEventHandler`.
- **Thread** upserts (guild + channel via `ctx.Services`) and `MarkDeletedAsync` unchanged; thread-as-channel (ADR-0003) behavior intact.

⚠️ **Behavior note (consistent with PR1–3):** `ChannelUpdated`/`ChannelDeleted`/`ChannelPinsUpdated` and `RoleUpdated`/`RoleDeleted` previously wrote the raw_event_log row + entity changes in a **single** `SaveChanges`; with the pipeline they're **two** saves (raw flushed first, then entity work). Same trade-off the earlier parts made — matches `MessageEventHandler`.

## Test plan
- [x] `dotnet build` — 0 errors; 0 warnings in changed files
- [x] `VALIDATE_AND_EXIT=1 dotnet run` — DI validation passed
- [ ] Local live test — channel create/rename/delete, role create/delete (happy path; the 23505 retry is a concurrency race, not artificially triggerable)
- [ ] Post-deploy Loki verification

🤖 Generated with [Claude Code](https://claude.com/claude-code)