### PR TITLE
feat: add EventContext.RecordFailureAsync + migrate Message handler (#158)

### DIFF
--- a/src/DiscordEventService/Services/EventHandlers/MessageEventHandler.cs
+++ b/src/DiscordEventService/Services/EventHandlers/MessageEventHandler.cs
@@ -1,7 +1,7 @@
 using DiscordEventService.Data;
 using DiscordEventService.Data.Entities.Core;
 using DiscordEventService.Data.Entities.Events;
-using DiscordEventService.Services;
+using DiscordEventService.Services.Pipeline;
 using DSharpPlus;
 using DSharpPlus.Entities;
 using DSharpPlus.EventArgs;
@@ -11,7 +11,7 @@ using System.Text.Json.Nodes;
 
 namespace DiscordEventService.Services.EventHandlers;
 
-public class MessageEventHandler(IServiceScopeFactory scopeFactory, ILogger<MessageEventHandler> logger) :
+public sealed class MessageEventHandler(EventPipeline pipeline) :
     IEventHandler<MessageCreatedEventArgs>,
     IEventHandler<MessageUpdatedEventArgs>,
     IEventHandler<MessageDeletedEventArgs>,
@@ -21,26 +21,12 @@ public class MessageEventHandler(IServiceScopeFactory scopeFactory, ILogger<Mess
     {
         if (e.Guild is null) return;
 
-        var correlationId = Guid.NewGuid();
-        using (logger.BeginScope(new Dictionary<string, object> { ["CorrelationId"] = correlationId }))
-        {
-            string? rawJson = null;
-            try
+        await pipeline.Execute(e, "MessageCreated", nameof(MessageEventHandler),
+            e.Guild.Id, e.Channel.Id, e.Author.Id, async ctx =>
             {
-                using var scope = scopeFactory.CreateScope();
-                var db = scope.ServiceProvider.GetRequiredService<DiscordDbContext>();
-                var userService = scope.ServiceProvider.GetRequiredService<UserService>();
-                var guildUpsert = scope.ServiceProvider.GetRequiredService<GuildUpsertService>();
-                var channelUpsert = scope.ServiceProvider.GetRequiredService<ChannelUpsertService>();
-                var rawEventService = scope.ServiceProvider.GetRequiredService<RawEventLogService>();
-
-                rawJson = await rawEventService.SerializeAndLogAsync(
-                    e, "MessageCreated", e.Guild.Id, e.Channel.Id, e.Author.Id, correlationId: correlationId);
-
-                // Persist the raw event row immediately. Otherwise any 23505 race inside one of the
-                // upsert services below clears the change tracker on its catch path and the staged
-                // raw_event_logs row is silently dropped along with the rolled-back insert.
-                await db.SaveChangesAsync();
+                var userService = ctx.Services.GetRequiredService<UserService>();
+                var guildUpsert = ctx.Services.GetRequiredService<GuildUpsertService>();
+                var channelUpsert = ctx.Services.GetRequiredService<ChannelUpsertService>();
 
                 await userService.UpsertUserAsync(e.Author);
 
@@ -58,23 +44,18 @@ public class MessageEventHandler(IServiceScopeFactory scopeFactory, ILogger<Mess
                 // skip + FailedEvent instead of a silent NULL FK row.
                 var guildId = await guildUpsert.UpsertGuildAsync(e.Guild);
                 var channelId = await channelUpsert.UpsertChannelAsync(e.Channel, guildId);
-                var authorId = await db.Users
+                var authorId = await ctx.Db.Users
                     .Where(u => u.DiscordId == e.Author.Id)
                     .Select(u => u.Id)
                     .FirstOrDefaultAsync();
 
                 if (guildId == Guid.Empty || channelId == Guid.Empty || authorId == Guid.Empty)
                 {
-                    logger.LogError(
+                    ctx.Logger.LogError(
                         "MessageCreated: could not resolve required FKs for MessageId={MessageId} (guildId={GuildId} channelId={ChannelId} authorId={AuthorId}); skipping insert",
                         e.Message.Id, guildId, channelId, authorId);
-                    using var fkFailScope = scopeFactory.CreateScope();
-                    var failedEventService = fkFailScope.ServiceProvider.GetRequiredService<FailedEventService>();
-                    await failedEventService.RecordFailureAsync(
-                        "MessageCreated", nameof(MessageEventHandler),
-                        new InvalidOperationException(
-                            $"Required FK not resolved: guild={guildId} channel={channelId} author={authorId}"),
-                        e.Guild?.Id, e.Channel.Id, e.Author.Id, rawJson, correlationId: correlationId);
+                    await ctx.RecordFailureAsync(new InvalidOperationException(
+                        $"Required FK not resolved: guild={guildId} channel={channelId} author={authorId}"));
                     return;
                 }
 
@@ -92,18 +73,18 @@ public class MessageEventHandler(IServiceScopeFactory scopeFactory, ILogger<Mess
                     AttachmentsJson = attachmentsJson,
                     EmbedsJson = embedsJson,
                     EventTimestampUtc = e.Message.Timestamp.UtcDateTime,
-                    ReceivedAtUtc = DateTime.UtcNow,
-                    RawEventJson = rawJson
+                    ReceivedAtUtc = ctx.ReceivedAtUtc,
+                    RawEventJson = ctx.RawJson
                 };
 
                 // Wrap multi-row writes in a transaction so the 23505 retry path
                 // (ExecuteUpdate + insert) is atomic. ExecutionStrategy is required
                 // because EnableRetryOnFailure is configured on the DbContext.
-                var strategy = db.Database.CreateExecutionStrategy();
+                var strategy = ctx.Db.Database.CreateExecutionStrategy();
                 await strategy.ExecuteAsync(async () =>
                 {
-                    db.ChangeTracker.Clear();
-                    await using var tx = await db.Database.BeginTransactionAsync();
+                    ctx.Db.ChangeTracker.Clear();
+                    await using var tx = await ctx.Db.Database.BeginTransactionAsync();
 
                     var messageEntity = new MessageEntity
                     {
@@ -120,20 +101,20 @@ public class MessageEventHandler(IServiceScopeFactory scopeFactory, ILogger<Mess
                         Flags = (int)(e.Message.Flags ?? 0),
                         CreatedAtUtc = e.Message.Timestamp.UtcDateTime
                     };
-                    db.Messages.Add(messageEntity);
-                    db.MessageEvents.Add(NewMessageEvent());
+                    ctx.Db.Messages.Add(messageEntity);
+                    ctx.Db.MessageEvents.Add(NewMessageEvent());
 
                     Guid messageId;
                     try
                     {
-                        await db.SaveChangesAsync();
+                        await ctx.Db.SaveChangesAsync();
                         messageId = messageEntity.Id;
                     }
                     catch (DbUpdateException dbEx) when (dbEx.InnerException is Npgsql.PostgresException { SqlState: "23505" })
                     {
-                        db.ChangeTracker.Clear();
+                        ctx.Db.ChangeTracker.Clear();
                         var normalizedContent = NormalizeContent(e.Message.Content);
-                        await db.Messages
+                        await ctx.Db.Messages
                             .Where(m => m.DiscordId == e.Message.Id)
                             .ExecuteUpdateAsync(s => s
                                 .SetProperty(m => m.Content, normalizedContent)
@@ -143,60 +124,39 @@ public class MessageEventHandler(IServiceScopeFactory scopeFactory, ILogger<Mess
                                 .SetProperty(m => m.EmbedsJson, embedsJson)
                                 .SetProperty(m => m.Flags, (int)(e.Message.Flags ?? 0))
                                 .SetProperty(m => m.ReplyToDiscordId, e.Message.ReferencedMessage?.Id));
-                        db.MessageEvents.Add(NewMessageEvent());
-                        await db.SaveChangesAsync();
-                        messageId = await db.Messages
+                        ctx.Db.MessageEvents.Add(NewMessageEvent());
+                        await ctx.Db.SaveChangesAsync();
+                        messageId = await ctx.Db.Messages
                             .Where(m => m.DiscordId == e.Message.Id)
                             .Select(m => m.Id)
                             .FirstAsync();
                     }
 
-                    await ExtractAndSaveMentionsAsync(db, messageId, e.Message);
+                    await ExtractAndSaveMentionsAsync(ctx.Db, messageId, e.Message);
                     await tx.CommitAsync();
                 });
-            }
-            catch (Exception ex)
-            {
-                logger.LogError(ex, "Error handling message created for MessageId={MessageId}", e.Message.Id);
-                using var failureScope = scopeFactory.CreateScope();
-                var failedEventService = failureScope.ServiceProvider.GetRequiredService<FailedEventService>();
-                await failedEventService.RecordFailureAsync(
-                    "MessageCreated", nameof(MessageEventHandler), ex,
-                    e.Guild?.Id, e.Channel.Id, e.Author.Id, rawJson, correlationId: correlationId);
-            }
-        }
+            });
     }
 
     public async Task HandleEventAsync(DiscordClient sender, MessageUpdatedEventArgs e)
     {
         if (e.Guild is null) return;
 
-        var correlationId = Guid.NewGuid();
-        using (logger.BeginScope(new Dictionary<string, object> { ["CorrelationId"] = correlationId }))
-        {
-            string? rawJson = null;
-            try
+        await pipeline.Execute(e, "MessageUpdated", nameof(MessageEventHandler),
+            e.Guild.Id, e.Channel.Id, e.Author?.Id, async ctx =>
             {
-                var receivedAt = DateTime.UtcNow;
-                using var scope = scopeFactory.CreateScope();
-                var db = scope.ServiceProvider.GetRequiredService<DiscordDbContext>();
-                var rawEventService = scope.ServiceProvider.GetRequiredService<RawEventLogService>();
-
-                rawJson = await rawEventService.SerializeAndLogAsync(
-                    e, "MessageUpdated", e.Guild.Id, e.Channel.Id, e.Author?.Id, correlationId: correlationId);
-
                 var attachmentsJson = e.Message.Attachments.Count > 0
                     ? JsonSerializer.Serialize(e.Message.Attachments.Select(a => new { a.Id, a.Url, a.FileName, a.FileSize }))
                     : null;
                 var embedsJson = e.Message.Embeds.Count > 0
                     ? JsonSerializer.Serialize(e.Message.Embeds)
                     : null;
-                var editedAt = e.Message.EditedTimestamp?.UtcDateTime ?? receivedAt;
+                var editedAt = e.Message.EditedTimestamp?.UtcDateTime ?? ctx.ReceivedAtUtc;
                 var flagsAfter = (int)(e.Message.Flags ?? 0);
 
                 // Get the message entity for FK reference + before-state fallback when DSharpPlus
                 // didn't deliver e.MessageBefore (uncached message edit).
-                var message = await db.Messages.FirstOrDefaultAsync(m => m.DiscordId == e.Message.Id);
+                var message = await ctx.Db.Messages.FirstOrDefaultAsync(m => m.DiscordId == e.Message.Id);
                 var messageGuid = message?.Id;
 
                 var contentBefore = NormalizeContent(e.MessageBefore is { } beforeForContent
@@ -216,20 +176,16 @@ public class MessageEventHandler(IServiceScopeFactory scopeFactory, ILogger<Mess
                     ? (int)(before.Flags ?? 0)
                     : message?.Flags;
 
-                // SerializeAndLogAsync staged a RawEventLog row but did NOT save it; flush it
-                // before the strategy lambda's ChangeTracker.Clear() detaches it.
-                await db.SaveChangesAsync();
-
                 // Wrap the ExecuteUpdate (auto-commits without a tx) and the event-log inserts
                 // in one transaction so a failure between them rolls back atomically.
-                var strategy = db.Database.CreateExecutionStrategy();
+                var strategy = ctx.Db.Database.CreateExecutionStrategy();
                 await strategy.ExecuteAsync(async () =>
                 {
-                    db.ChangeTracker.Clear();
-                    await using var tx = await db.Database.BeginTransactionAsync();
+                    ctx.Db.ChangeTracker.Clear();
+                    await using var tx = await ctx.Db.Database.BeginTransactionAsync();
 
                     var normalizedContent = NormalizeContent(e.Message.Content);
-                    await db.Messages
+                    await ctx.Db.Messages
                         .Where(m => m.DiscordId == e.Message.Id)
                         .ExecuteUpdateAsync(s => s
                             .SetProperty(m => m.Content, normalizedContent)
@@ -240,7 +196,7 @@ public class MessageEventHandler(IServiceScopeFactory scopeFactory, ILogger<Mess
                             .SetProperty(m => m.Flags, flagsAfter)
                             .SetProperty(m => m.EditedAtUtc, editedAt));
 
-                    db.MessageEvents.Add(new MessageEventEntity
+                    ctx.Db.MessageEvents.Add(new MessageEventEntity
                     {
                         MessageDiscordId = e.Message.Id,
                         ChannelDiscordId = e.Channel.Id,
@@ -255,8 +211,8 @@ public class MessageEventHandler(IServiceScopeFactory scopeFactory, ILogger<Mess
                         AttachmentsJson = attachmentsJson,
                         EmbedsJson = embedsJson,
                         EventTimestampUtc = editedAt,
-                        ReceivedAtUtc = receivedAt,
-                        RawEventJson = rawJson
+                        ReceivedAtUtc = ctx.ReceivedAtUtc,
+                        RawEventJson = ctx.RawJson
                     });
 
                     var contentChanged = contentBefore != normalizedContent;
@@ -270,7 +226,7 @@ public class MessageEventHandler(IServiceScopeFactory scopeFactory, ILogger<Mess
                     if (messageGuid is Guid mid &&
                         (contentChanged || attachmentsChanged || embedsChanged || flagsChanged))
                     {
-                        db.MessageEditHistory.Add(new MessageEditHistoryEntity
+                        ctx.Db.MessageEditHistory.Add(new MessageEditHistoryEntity
                         {
                             MessageId = mid,
                             MessageDiscordId = e.Message.Id,
@@ -283,58 +239,36 @@ public class MessageEventHandler(IServiceScopeFactory scopeFactory, ILogger<Mess
                             FlagsBefore = flagsBefore,
                             FlagsAfter = flagsAfter,
                             EditedAtUtc = editedAt,
-                            RecordedAtUtc = receivedAt
+                            RecordedAtUtc = ctx.ReceivedAtUtc
                         });
                     }
 
-                    await db.SaveChangesAsync();
+                    await ctx.Db.SaveChangesAsync();
 
                     if (messageGuid is Guid mentionMid)
                     {
-                        await ExtractAndSaveMentionsAsync(db, mentionMid, e.Message);
+                        await ExtractAndSaveMentionsAsync(ctx.Db, mentionMid, e.Message);
                     }
 
                     await tx.CommitAsync();
                 });
-            }
-            catch (Exception ex)
-            {
-                logger.LogError(ex, "Error handling message updated for MessageId={MessageId}", e.Message.Id);
-                using var failureScope = scopeFactory.CreateScope();
-                var failedEventService = failureScope.ServiceProvider.GetRequiredService<FailedEventService>();
-                await failedEventService.RecordFailureAsync(
-                    "MessageUpdated", nameof(MessageEventHandler), ex,
-                    e.Guild?.Id, e.Channel.Id, e.Author?.Id, eventJson: rawJson, correlationId: correlationId);
-            }
-        }
+            });
     }
 
     public async Task HandleEventAsync(DiscordClient sender, MessageDeletedEventArgs e)
     {
         if (e.Guild is null) return;
 
-        var correlationId = Guid.NewGuid();
-        using (logger.BeginScope(new Dictionary<string, object> { ["CorrelationId"] = correlationId }))
-        {
-            string? rawJson = null;
-            try
+        await pipeline.Execute(e, "MessageDeleted", nameof(MessageEventHandler),
+            e.Guild.Id, e.Channel.Id, e.Message.Author?.Id, async ctx =>
             {
-                var receivedAt = DateTime.UtcNow;
-                using var scope = scopeFactory.CreateScope();
-                var db = scope.ServiceProvider.GetRequiredService<DiscordDbContext>();
-                var rawEventService = scope.ServiceProvider.GetRequiredService<RawEventLogService>();
-
-                rawJson = await rawEventService.SerializeAndLogAsync(
-                    e, "MessageDeleted", e.Guild.Id, e.Channel.Id, e.Message.Author?.Id, correlationId: correlationId);
-
-                // Mark message as deleted
-                await db.Messages
+                await ctx.Db.Messages
                     .Where(m => m.DiscordId == e.Message.Id)
                     .ExecuteUpdateAsync(s => s
                         .SetProperty(m => m.IsDeleted, true)
-                        .SetProperty(m => m.DeletedAtUtc, receivedAt));
+                        .SetProperty(m => m.DeletedAtUtc, ctx.ReceivedAtUtc));
 
-                db.MessageEvents.Add(new MessageEventEntity
+                ctx.Db.MessageEvents.Add(new MessageEventEntity
                 {
                     MessageDiscordId = e.Message.Id,
                     ChannelDiscordId = e.Channel.Id,
@@ -342,23 +276,45 @@ public class MessageEventHandler(IServiceScopeFactory scopeFactory, ILogger<Mess
                     GuildDiscordId = e.Guild.Id,
                     EventType = MessageEventType.Deleted,
                     Content = NormalizeContent(e.Message.Content),
-                    EventTimestampUtc = receivedAt,
-                    ReceivedAtUtc = receivedAt,
-                    RawEventJson = rawJson
+                    EventTimestampUtc = ctx.ReceivedAtUtc,
+                    ReceivedAtUtc = ctx.ReceivedAtUtc,
+                    RawEventJson = ctx.RawJson
                 });
 
-                await db.SaveChangesAsync();
-            }
-            catch (Exception ex)
+                await ctx.Db.SaveChangesAsync();
+            });
+    }
+
+    public async Task HandleEventAsync(DiscordClient sender, MessagesBulkDeletedEventArgs e)
+    {
+        if (e.Guild is null) return;
+
+        await pipeline.Execute(e, "MessagesBulkDeleted", nameof(MessageEventHandler),
+            e.Guild.Id, e.Channel.Id, null, async ctx =>
             {
-                logger.LogError(ex, "Error handling message deleted for MessageId={MessageId}", e.Message.Id);
-                using var failureScope = scopeFactory.CreateScope();
-                var failedEventService = failureScope.ServiceProvider.GetRequiredService<FailedEventService>();
-                await failedEventService.RecordFailureAsync(
-                    "MessageDeleted", nameof(MessageEventHandler), ex,
-                    e.Guild?.Id, e.Channel.Id, e.Message.Author?.Id, eventJson: rawJson, correlationId: correlationId);
-            }
-        }
+                var messageIds = e.Messages.Select(m => m.Id).ToList();
+                await ctx.Db.Messages
+                    .Where(m => messageIds.Contains(m.DiscordId))
+                    .ExecuteUpdateAsync(s => s
+                        .SetProperty(m => m.IsDeleted, true)
+                        .SetProperty(m => m.DeletedAtUtc, ctx.ReceivedAtUtc));
+
+                var events = e.Messages.Select(msg => new MessageEventEntity
+                {
+                    MessageDiscordId = msg.Id,
+                    ChannelDiscordId = e.Channel.Id,
+                    AuthorDiscordId = msg.Author?.Id,
+                    GuildDiscordId = e.Guild.Id,
+                    EventType = MessageEventType.BulkDeleted,
+                    Content = NormalizeContent(msg.Content),
+                    EventTimestampUtc = ctx.ReceivedAtUtc,
+                    ReceivedAtUtc = ctx.ReceivedAtUtc,
+                    RawEventJson = ctx.RawJson
+                });
+
+                ctx.Db.MessageEvents.AddRange(events);
+                await ctx.Db.SaveChangesAsync();
+            });
     }
 
     private static async Task ExtractAndSaveMentionsAsync(DiscordDbContext db, Guid messageId, DiscordMessage message)
@@ -432,59 +388,5 @@ public class MessageEventHandler(IServiceScopeFactory scopeFactory, ILogger<Mess
         if (a == b) return true;
         if (string.IsNullOrEmpty(a) || string.IsNullOrEmpty(b)) return false;
         return JsonNode.DeepEquals(JsonNode.Parse(a), JsonNode.Parse(b));
-    }
-
-    public async Task HandleEventAsync(DiscordClient sender, MessagesBulkDeletedEventArgs e)
-    {
-        if (e.Guild is null) return;
-
-        var correlationId = Guid.NewGuid();
-        using (logger.BeginScope(new Dictionary<string, object> { ["CorrelationId"] = correlationId }))
-        {
-            string? rawJson = null;
-            try
-            {
-                var receivedAt = DateTime.UtcNow;
-                using var scope = scopeFactory.CreateScope();
-                var db = scope.ServiceProvider.GetRequiredService<DiscordDbContext>();
-                var rawEventService = scope.ServiceProvider.GetRequiredService<RawEventLogService>();
-
-                rawJson = await rawEventService.SerializeAndLogAsync(
-                    e, "MessagesBulkDeleted", e.Guild.Id, e.Channel.Id, null, correlationId: correlationId);
-
-                // Mark all messages as deleted
-                var messageIds = e.Messages.Select(m => m.Id).ToList();
-                await db.Messages
-                    .Where(m => messageIds.Contains(m.DiscordId))
-                    .ExecuteUpdateAsync(s => s
-                        .SetProperty(m => m.IsDeleted, true)
-                        .SetProperty(m => m.DeletedAtUtc, receivedAt));
-
-                var events = e.Messages.Select(msg => new MessageEventEntity
-                {
-                    MessageDiscordId = msg.Id,
-                    ChannelDiscordId = e.Channel.Id,
-                    AuthorDiscordId = msg.Author?.Id,
-                    GuildDiscordId = e.Guild.Id,
-                    EventType = MessageEventType.BulkDeleted,
-                    Content = NormalizeContent(msg.Content),
-                    EventTimestampUtc = receivedAt,
-                    ReceivedAtUtc = receivedAt,
-                    RawEventJson = rawJson
-                });
-
-                db.MessageEvents.AddRange(events);
-                await db.SaveChangesAsync();
-            }
-            catch (Exception ex)
-            {
-                logger.LogError(ex, "Error handling bulk message delete in ChannelId={ChannelId}", e.Channel.Id);
-                using var failureScope = scopeFactory.CreateScope();
-                var failedEventService = failureScope.ServiceProvider.GetRequiredService<FailedEventService>();
-                await failedEventService.RecordFailureAsync(
-                    "MessagesBulkDeleted", nameof(MessageEventHandler), ex,
-                    e.Guild?.Id, e.Channel.Id, null, eventJson: rawJson, correlationId: correlationId);
-            }
-        }
     }
 }

--- a/src/DiscordEventService/Services/Pipeline/EventContext.cs
+++ b/src/DiscordEventService/Services/Pipeline/EventContext.cs
@@ -8,4 +8,5 @@ public record EventContext(
     Guid CorrelationId,
     string? RawJson,
     DateTime ReceivedAtUtc,
-    ILogger Logger);
+    ILogger Logger,
+    Func<Exception, Task> RecordFailureAsync);

--- a/src/DiscordEventService/Services/Pipeline/EventPipeline.cs
+++ b/src/DiscordEventService/Services/Pipeline/EventPipeline.cs
@@ -18,6 +18,19 @@ public sealed class EventPipeline(IServiceScopeFactory scopeFactory, ILoggerFact
         using (logger.BeginScope(new Dictionary<string, object> { ["CorrelationId"] = correlationId }))
         {
             string? rawJson = null;
+
+            // Records a FailedEvent in an isolated scope using this event's metadata. Used both
+            // by the pipeline's own exception path and by handlers that want to record a soft
+            // failure (e.g. an unresolved FK) and return without throwing.
+            async Task RecordFailureAsync(Exception ex)
+            {
+                using var failureScope = scopeFactory.CreateScope();
+                var failedEventService = failureScope.ServiceProvider.GetRequiredService<FailedEventService>();
+                await failedEventService.RecordFailureAsync(
+                    eventType, handlerName, ex,
+                    guildId, channelId, userId, rawJson, correlationId: correlationId);
+            }
+
             try
             {
                 var receivedAt = DateTime.UtcNow;
@@ -32,17 +45,13 @@ public sealed class EventPipeline(IServiceScopeFactory scopeFactory, ILoggerFact
                 // in upsert services would silently drop staged raw_event_logs rows otherwise.
                 await db.SaveChangesAsync();
 
-                var context = new EventContext(db, scope.ServiceProvider, correlationId, rawJson, receivedAt, logger);
+                var context = new EventContext(db, scope.ServiceProvider, correlationId, rawJson, receivedAt, logger, RecordFailureAsync);
                 await handler(context);
             }
             catch (Exception ex)
             {
                 logger.LogError(ex, "Error handling {EventType} in {HandlerName}", eventType, handlerName);
-                using var failureScope = scopeFactory.CreateScope();
-                var failedEventService = failureScope.ServiceProvider.GetRequiredService<FailedEventService>();
-                await failedEventService.RecordFailureAsync(
-                    eventType, handlerName, ex,
-                    guildId, channelId, userId, rawJson, correlationId: correlationId);
+                await RecordFailureAsync(ex);
             }
         }
     }


### PR DESCRIPTION
## Summary
Part 1 of §A1.4 (#158) — the first **deep** handler, plus the one pipeline extension the deep handlers need.

**Pipeline extension:** `EventContext` now carries a `Func<Exception,Task> RecordFailureAsync` built by the pipeline from its own event metadata (eventType/handler/guild/channel/user/rawJson/correlationId) + an isolated scope. A handler can record a soft failure and `return` without re-supplying metadata. The pipeline reuses the same delegate for its own exception path, so the change is net-neutral on the catch block.

**MessageEventHandler** (Created/Updated/Deleted/BulkDeleted) migrated:
- The FK-resolution-skip path (the 2026-05-03 NULL-FK guard) now calls `ctx.RecordFailureAsync(...)` + `return` instead of hand-rolling an isolated `FailedEventService` scope
- Transaction / `ExecutionStrategy` / `ChangeTracker.Clear` / 23505-retry / edit-history / mention-extraction all stay in the handler lambda via `ctx.Db` (handler business logic, not ceremony)
- Net **-88 lines**

## Test plan
- [x] `dotnet build` — 0 errors; 0 warnings in changed files
- [x] `VALIDATE_AND_EXIT=1 dotnet run` — DI validation passed
- [ ] Local live test — send a message (FK upsert + mentions), edit it (edit-history + structural JSON compare), delete it, bulk-delete; verify messages/message_events/message_edit_history/message_mentions rows
- [ ] Post-deploy Loki verification

🤖 Generated with [Claude Code](https://claude.com/claude-code)