### PR TITLE
feat: migrate Socket, GuildUpdate, GuildMembersChunk handlers (#158)

### DIFF
--- a/src/DiscordEventService/Services/EventHandlers/GuildMembersChunkHandler.cs
+++ b/src/DiscordEventService/Services/EventHandlers/GuildMembersChunkHandler.cs
@@ -1,12 +1,12 @@
-using DiscordEventService.Data;
 using DiscordEventService.Data.Entities.Events;
+using DiscordEventService.Services.Pipeline;
 using DSharpPlus;
 using DSharpPlus.EventArgs;
 using System.Text.Json;
 
 namespace DiscordEventService.Services.EventHandlers;
 
-public class GuildMembersChunkHandler(IServiceScopeFactory scopeFactory, ILogger<GuildMembersChunkHandler> logger) :
+public sealed class GuildMembersChunkHandler(EventPipeline pipeline) :
     IEventHandler<GuildMembersChunkedEventArgs>
 {
     private static readonly JsonSerializerOptions JsonOptions = new()
@@ -17,29 +17,17 @@ public class GuildMembersChunkHandler(IServiceScopeFactory scopeFactory, ILogger
 
     public async Task HandleEventAsync(DiscordClient sender, GuildMembersChunkedEventArgs args)
     {
-        var correlationId = Guid.NewGuid();
-        using (logger.BeginScope(new Dictionary<string, object> { ["CorrelationId"] = correlationId }))
-        {
-            string? rawJson = null;
-            try
+        await pipeline.Execute(args, "GuildMembersChunked", nameof(GuildMembersChunkHandler),
+            args.Guild.Id, null, null, async ctx =>
             {
-                var now = DateTime.UtcNow;
+                var userService = ctx.Services.GetRequiredService<UserService>();
 
-                using var scope = scopeFactory.CreateScope();
-                var db = scope.ServiceProvider.GetRequiredService<DiscordDbContext>();
-                var userService = scope.ServiceProvider.GetRequiredService<UserService>();
-                var rawEventService = scope.ServiceProvider.GetRequiredService<RawEventLogService>();
-
-                rawJson = await rawEventService.SerializeAndLogAsync(
-                    args, "GuildMembersChunked", args.Guild.Id, null, null, correlationId: correlationId);
-
-                // Upsert all members received in this chunk
                 foreach (var member in args.Members)
                 {
                     await userService.UpsertUserAsync(member);
                 }
 
-                var chunkEvent = new GuildMembersChunkEventEntity
+                ctx.Db.GuildMembersChunkEvents.Add(new GuildMembersChunkEventEntity
                 {
                     GuildDiscordId = args.Guild.Id,
                     ChunkIndex = args.ChunkIndex,
@@ -58,26 +46,15 @@ public class GuildMembersChunkHandler(IServiceScopeFactory scopeFactory, ILogger
                     NotFoundIdsJson = args.NotFound?.Count > 0
                         ? JsonSerializer.Serialize(args.NotFound.Select(id => id.ToString()), JsonOptions)
                         : null,
-                    EventTimestampUtc = now,
-                    ReceivedAtUtc = now,
-                    RawEventJson = rawJson
-                };
+                    EventTimestampUtc = ctx.ReceivedAtUtc,
+                    ReceivedAtUtc = ctx.ReceivedAtUtc,
+                    RawEventJson = ctx.RawJson
+                });
 
-                await db.GuildMembersChunkEvents.AddAsync(chunkEvent);
-                await db.SaveChangesAsync();
+                await ctx.Db.SaveChangesAsync();
 
-                logger.LogDebug("Recorded guild members chunk {ChunkIndex}/{ChunkCount} for guild {GuildId} with {MemberCount} members",
+                ctx.Logger.LogDebug("Recorded guild members chunk {ChunkIndex}/{ChunkCount} for guild {GuildId} with {MemberCount} members",
                     args.ChunkIndex, args.ChunkCount, args.Guild.Id, args.Members.Count);
-            }
-            catch (Exception ex)
-            {
-                logger.LogError(ex, "Error handling guild members chunk for guild {GuildId}", args.Guild.Id);
-                using var failureScope = scopeFactory.CreateScope();
-                var failedEventService = failureScope.ServiceProvider.GetRequiredService<FailedEventService>();
-                await failedEventService.RecordFailureAsync(
-                    "GuildMembersChunked", nameof(GuildMembersChunkHandler), ex,
-                    args.Guild?.Id, null, null, rawJson, correlationId: correlationId);
-            }
-        }
+            });
     }
 }

--- a/src/DiscordEventService/Services/EventHandlers/GuildUpdateEventHandler.cs
+++ b/src/DiscordEventService/Services/EventHandlers/GuildUpdateEventHandler.cs
@@ -1,36 +1,25 @@
-using DiscordEventService.Data;
 using DiscordEventService.Data.Entities.Events;
+using DiscordEventService.Services.Pipeline;
 using DSharpPlus;
 using DSharpPlus.EventArgs;
 
 namespace DiscordEventService.Services.EventHandlers;
 
-public class GuildUpdateEventHandler(IServiceScopeFactory scopeFactory, ILogger<GuildUpdateEventHandler> logger) :
+public sealed class GuildUpdateEventHandler(EventPipeline pipeline) :
     IEventHandler<GuildUpdatedEventArgs>
 {
     public async Task HandleEventAsync(DiscordClient sender, GuildUpdatedEventArgs e)
     {
-        var correlationId = Guid.NewGuid();
-        using (logger.BeginScope(new Dictionary<string, object> { ["CorrelationId"] = correlationId }))
-        {
-            string? rawJson = null;
-            try
+        await pipeline.Execute(e, "GuildUpdatedEvent", nameof(GuildUpdateEventHandler),
+            e.GuildAfter.Id, null, null, async ctx =>
             {
-                var now = DateTime.UtcNow;
-                using var scope = scopeFactory.CreateScope();
-                var db = scope.ServiceProvider.GetRequiredService<DiscordDbContext>();
-                var rawEventService = scope.ServiceProvider.GetRequiredService<RawEventLogService>();
-
-                rawJson = await rawEventService.SerializeAndLogAsync(
-                    e, "GuildUpdatedEvent", e.GuildAfter.Id, null, null, correlationId: correlationId);
-
                 var guildEvent = new GuildEventEntity
                 {
                     GuildDiscordId = e.GuildAfter.Id,
                     EventType = GuildEventType.Updated,
-                    EventTimestampUtc = now,
-                    ReceivedAtUtc = now,
-                    RawEventJson = rawJson
+                    EventTimestampUtc = ctx.ReceivedAtUtc,
+                    ReceivedAtUtc = ctx.ReceivedAtUtc,
+                    RawEventJson = ctx.RawJson
                 };
 
                 if (e.GuildBefore.Name != e.GuildAfter.Name)
@@ -51,18 +40,8 @@ public class GuildUpdateEventHandler(IServiceScopeFactory scopeFactory, ILogger<
                     guildEvent.OwnerDiscordIdAfter = e.GuildAfter.OwnerId;
                 }
 
-                db.GuildEvents.Add(guildEvent);
-                await db.SaveChangesAsync();
-            }
-            catch (Exception ex)
-            {
-                logger.LogError(ex, "Error handling guild updated for GuildId={GuildId}", e.GuildAfter.Id);
-                using var failureScope = scopeFactory.CreateScope();
-                var failedEventService = failureScope.ServiceProvider.GetRequiredService<FailedEventService>();
-                await failedEventService.RecordFailureAsync(
-                    "GuildUpdatedEvent", nameof(GuildUpdateEventHandler), ex,
-                    e.GuildAfter?.Id, null, null, rawJson, correlationId: correlationId);
-            }
-        }
+                ctx.Db.GuildEvents.Add(guildEvent);
+                await ctx.Db.SaveChangesAsync();
+            });
     }
 }

--- a/src/DiscordEventService/Services/EventHandlers/SocketLifecycleHandler.cs
+++ b/src/DiscordEventService/Services/EventHandlers/SocketLifecycleHandler.cs
@@ -7,8 +7,10 @@ using Microsoft.EntityFrameworkCore;
 
 namespace DiscordEventService.Services.EventHandlers;
 
-public class SocketLifecycleHandler(
-    IServiceScopeFactory scopeFactory,
+public sealed class SocketLifecycleHandler(
+    DiscordDbContext db,
+    DowntimeTrackerService tracker,
+    GuildBackfillOrchestrator orchestrator,
     BootQuickSyncService quickSyncService,
     ILogger<SocketLifecycleHandler> logger) :
     IEventHandler<SocketClosedEventArgs>,
@@ -29,8 +31,6 @@ public class SocketLifecycleHandler(
         {
             try
             {
-                using var scope = scopeFactory.CreateScope();
-                var tracker = scope.ServiceProvider.GetRequiredService<DowntimeTrackerService>();
                 await tracker.OpenDowntimeAsync(
                     BotDowntimeType.GatewayDisconnect,
                     BotDowntimeDetectionMethod.GatewayEvent,
@@ -50,8 +50,6 @@ public class SocketLifecycleHandler(
         {
             try
             {
-                using var scope = scopeFactory.CreateScope();
-                var tracker = scope.ServiceProvider.GetRequiredService<DowntimeTrackerService>();
                 // Scope to GatewayDisconnect so a routine resume doesn't clobber a
                 // manually-opened Deploy/HostDown row from the ops endpoint.
                 await tracker.CloseOpenDowntimeAsync(DateTime.UtcNow, onlyType: BotDowntimeType.GatewayDisconnect);
@@ -74,11 +72,6 @@ public class SocketLifecycleHandler(
             // reconnect) hit SessionResumed instead and don't reach here.
             try
             {
-                using var scope = scopeFactory.CreateScope();
-                var db = scope.ServiceProvider.GetRequiredService<DiscordDbContext>();
-                var orchestrator = scope.ServiceProvider.GetRequiredService<GuildBackfillOrchestrator>();
-                var tracker = scope.ServiceProvider.GetRequiredService<DowntimeTrackerService>();
-
                 // Ready can fire without a preceding Resumed (session invalidated).
                 await tracker.CloseOpenDowntimeAsync(DateTime.UtcNow, onlyType: BotDowntimeType.GatewayDisconnect);
 


### PR DESCRIPTION
## Summary
Completes #158 (§A1.4 — deep handlers). Migrates the final three handlers that still created their own DI scopes off the centralized ceremony:

- **SocketLifecycleHandler** — now **direct-injects** its scoped deps (`DiscordDbContext`, `DowntimeTrackerService`, `GuildBackfillOrchestrator`, `BootQuickSyncService`) instead of `scopeFactory.CreateScope()` per event, relying on DSharpPlus's per-event scope. Removes all manual scope ceremony from the three socket lifecycle events (`SocketClosed`, `SessionResumed`, `GuildDownloadCompleted`).
- **GuildUpdateEventHandler** — migrated onto `EventPipeline` (eventType `GuildUpdatedEvent`), conditional before/after diffs written into `GuildEventEntity`.
- **GuildMembersChunkHandler** — migrated onto `EventPipeline`; user upserts run via `ctx.Services`.

## Acceptance
`grep -rln "CreateScope" Services/EventHandlers/` returns **nothing** — zero handlers create their own DI scopes; all event-handler ceremony now flows through `EventPipeline` (or, for socket lifecycle, DSharpPlus's per-event scope).

## Live test (local dev bot, dev guild)
- **Cold connect** `GuildDownloadCompleted` fired clean: exercised the injected `db` (queried `BotDowntimeIntervals` + `BackfillCheckpoints`), injected `tracker` (`CloseOpenDowntimeAsync`), reached the orchestrator backfill-enqueue path, and injected `logger`. **0 errors** — confirms the directly-injected scoped `DbContext` resolves correctly through DSharpPlus's per-event scope.
- **Graceful shutdown** wrote a new downtime row via `DowntimeTrackerService.OpenDowntimeAsync` (same write path `SocketClosed` delegates to); row count 23→24, no disposal/captive-dependency exceptions, clean host stop.

🤖 Generated with [Claude Code](https://claude.com/claude-code)