### PR TITLE
feat: extract generic UpsertPrimitive for 23505 retry (#159)

### DIFF
--- a/WojtusDiscord.slnx
+++ b/WojtusDiscord.slnx
@@ -1,3 +1,4 @@
 <Solution>
   <Project Path="src/DiscordEventService/DiscordEventService.csproj" />
+  <Project Path="tests/DiscordEventService.Tests/DiscordEventService.Tests.csproj" />
 </Solution>

--- a/src/DiscordEventService/Data/DbSetUpsertExtensions.cs
+++ b/src/DiscordEventService/Data/DbSetUpsertExtensions.cs
@@ -1,0 +1,39 @@
+using System.Linq.Expressions;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Internal;
+using Microsoft.EntityFrameworkCore.Query;
+using Npgsql;
+
+namespace DiscordEventService.Data;
+
+internal static class DbSetUpsertExtensions
+{
+    public static async Task<TResult?> UpsertAsync<TEntity, TResult>(
+        this DbSet<TEntity> set,
+        Expression<Func<TEntity, bool>> match,
+        Action<UpdateSettersBuilder<TEntity>> update,
+        Func<TEntity> create,
+        Expression<Func<TEntity, TResult>> select)
+        where TEntity : class
+    {
+        var rowsAffected = await set.Where(match).ExecuteUpdateAsync(update);
+        if (rowsAffected == 0)
+        {
+            // No public API exposes the DbContext from a DbSet; this is the standard EF accessor.
+            var db = set.GetService<ICurrentDbContext>().Context;
+            try
+            {
+                set.Add(create());
+                await db.SaveChangesAsync();
+            }
+            catch (DbUpdateException ex) when (ex.InnerException is PostgresException { SqlState: "23505" })
+            {
+                // Race: another writer inserted first — drop the failed Add and update instead.
+                db.ChangeTracker.Clear();
+                await set.Where(match).ExecuteUpdateAsync(update);
+            }
+        }
+        return await set.Where(match).Select(select).FirstOrDefaultAsync();
+    }
+}

--- a/src/DiscordEventService/DiscordEventService.csproj
+++ b/src/DiscordEventService/DiscordEventService.csproj
@@ -7,6 +7,10 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <InternalsVisibleTo Include="DiscordEventService.Tests" />
+  </ItemGroup>
+
+  <ItemGroup>
     <PackageReference Include="DotNetEnv" Version="3.1.1" />
     <PackageReference Include="DSharpPlus" Version="5.0.0-nightly-02485" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />

--- a/src/DiscordEventService/Services/GuildUpsertService.cs
+++ b/src/DiscordEventService/Services/GuildUpsertService.cs
@@ -1,7 +1,6 @@
 using DiscordEventService.Data;
 using DiscordEventService.Data.Entities.Core;
 using DSharpPlus.Entities;
-using Microsoft.EntityFrameworkCore;
 
 namespace DiscordEventService.Services;
 
@@ -9,43 +8,21 @@ public class GuildUpsertService(DiscordDbContext db, ILogger<GuildUpsertService>
 {
     public async Task<Guid> UpsertGuildAsync(DiscordGuild guild)
     {
-        var rowsAffected = await db.Guilds
-            .Where(g => g.DiscordId == guild.Id)
-            .ExecuteUpdateAsync(s => s
+        var id = await db.Guilds.UpsertAsync(
+            g => g.DiscordId == guild.Id,
+            s => s
                 .SetProperty(g => g.Name, guild.Name)
                 .SetProperty(g => g.IconHash, guild.IconHash)
-                .SetProperty(g => g.OwnerId, guild.OwnerId));
-
-        if (rowsAffected == 0)
-        {
-            try
+                .SetProperty(g => g.OwnerId, guild.OwnerId),
+            () => new GuildEntity
             {
-                db.Guilds.Add(new GuildEntity
-                {
-                    DiscordId = guild.Id,
-                    Name = guild.Name,
-                    IconHash = guild.IconHash,
-                    OwnerId = guild.OwnerId,
-                    LeftAtUtc = null
-                });
-                await db.SaveChangesAsync();
-            }
-            catch (DbUpdateException ex) when (ex.InnerException is Npgsql.PostgresException { SqlState: "23505" })
-            {
-                db.ChangeTracker.Clear();
-                await db.Guilds
-                    .Where(g => g.DiscordId == guild.Id)
-                    .ExecuteUpdateAsync(s => s
-                        .SetProperty(g => g.Name, guild.Name)
-                        .SetProperty(g => g.IconHash, guild.IconHash)
-                        .SetProperty(g => g.OwnerId, guild.OwnerId));
-            }
-        }
-
-        var id = await db.Guilds
-            .Where(g => g.DiscordId == guild.Id)
-            .Select(g => g.Id)
-            .FirstOrDefaultAsync();
+                DiscordId = guild.Id,
+                Name = guild.Name,
+                IconHash = guild.IconHash,
+                OwnerId = guild.OwnerId,
+                LeftAtUtc = null
+            },
+            g => g.Id);
 
         if (id == Guid.Empty)
         {

--- a/tests/DiscordEventService.Tests/DiscordEventService.Tests.csproj
+++ b/tests/DiscordEventService.Tests/DiscordEventService.Tests.csproj
@@ -1,0 +1,22 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <IsPackable>false</IsPackable>
+    <IsTestProject>true</IsTestProject>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
+    <PackageReference Include="xunit" Version="2.9.3" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" />
+    <PackageReference Include="Testcontainers.PostgreSql" Version="4.1.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\DiscordEventService\DiscordEventService.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/tests/DiscordEventService.Tests/GuildUpsertTests.cs
+++ b/tests/DiscordEventService.Tests/GuildUpsertTests.cs
@@ -1,0 +1,123 @@
+using DiscordEventService.Data;
+using DiscordEventService.Data.Entities.Core;
+using Microsoft.EntityFrameworkCore;
+using Testcontainers.PostgreSql;
+using Xunit;
+
+namespace DiscordEventService.Tests;
+
+public sealed class PostgresFixture : IAsyncLifetime
+{
+    // uuidv7() default value SQL in the migrations requires PostgreSQL 18.
+    public PostgreSqlContainer Container { get; } = new PostgreSqlBuilder()
+        .WithImage("postgres:18")
+        .Build();
+
+    public Task InitializeAsync() => Container.StartAsync();
+
+    public Task DisposeAsync() => Container.DisposeAsync().AsTask();
+}
+
+public sealed class GuildUpsertTests(PostgresFixture fixture) : IClassFixture<PostgresFixture>, IAsyncLifetime
+{
+    private DiscordDbContext _db = null!;
+
+    public async Task InitializeAsync()
+    {
+        _db = NewContext();
+        await _db.Database.MigrateAsync();
+        await _db.Guilds.ExecuteDeleteAsync();
+    }
+
+    public Task DisposeAsync() => _db.DisposeAsync().AsTask();
+
+    [Fact]
+    public async Task UpsertAsync_WhenNew_InsertsRowAndReturnsId()
+    {
+        var id = await _db.Guilds.UpsertAsync(
+            g => g.DiscordId == 100UL,
+            s => s.SetProperty(g => g.Name, "Alpha"),
+            () => new GuildEntity { DiscordId = 100UL, Name = "Alpha" },
+            g => g.Id);
+
+        Assert.NotEqual(Guid.Empty, id);
+        await using var verify = NewContext();
+        var row = await verify.Guilds.SingleAsync(g => g.DiscordId == 100UL);
+        Assert.Equal("Alpha", row.Name);
+    }
+
+    [Fact]
+    public async Task UpsertAsync_WhenExists_UpdatesRowKeepingId()
+    {
+        _db.Guilds.Add(new GuildEntity { DiscordId = 200UL, Name = "Before" });
+        await _db.SaveChangesAsync();
+        var originalId = await _db.Guilds.Where(g => g.DiscordId == 200UL).Select(g => g.Id).SingleAsync();
+        _db.ChangeTracker.Clear();
+
+        var id = await _db.Guilds.UpsertAsync(
+            g => g.DiscordId == 200UL,
+            s => s.SetProperty(g => g.Name, "After"),
+            () => new GuildEntity { DiscordId = 200UL, Name = "SHOULD_NOT_BE_USED" },
+            g => g.Id);
+
+        Assert.Equal(originalId, id);
+        await using var verify = NewContext();
+        var rows = await verify.Guilds.Where(g => g.DiscordId == 200UL).ToListAsync();
+        Assert.Single(rows);
+        Assert.Equal("After", rows[0].Name);
+    }
+
+    [Fact]
+    public async Task UpsertAsync_WhenInsertConflicts_SwallowsViolationAndReturnsDefault()
+    {
+        _db.Guilds.Add(new GuildEntity { DiscordId = 300UL, Name = "Existing" });
+        await _db.SaveChangesAsync();
+        _db.ChangeTracker.Clear();
+
+        // match never hits the existing row, so ExecuteUpdate affects 0 rows and the insert
+        // path runs; the factory inserts DiscordId=300, which collides on the unique index → 23505.
+        var id = await _db.Guilds.UpsertAsync(
+            g => g.DiscordId == 999UL,
+            s => s.SetProperty(g => g.Name, "Retry"),
+            () => new GuildEntity { DiscordId = 300UL, Name = "Conflict" },
+            g => g.Id);
+
+        Assert.Equal(Guid.Empty, id);
+        await using var verify = NewContext();
+        var rows = await verify.Guilds.ToListAsync();
+        Assert.Single(rows);
+        Assert.Equal(300UL, rows[0].DiscordId);
+        Assert.Equal("Existing", rows[0].Name);
+    }
+
+    [Fact]
+    public async Task UpsertAsync_WhenConcurrent_CreatesSingleRow()
+    {
+        const ulong discordId = 400UL;
+        var tasks = Enumerable.Range(0, 8).Select(async i =>
+        {
+            await using var ctx = NewContext();
+            return await ctx.Guilds.UpsertAsync(
+                g => g.DiscordId == discordId,
+                s => s.SetProperty(g => g.Name, $"Concurrent-{i}"),
+                () => new GuildEntity { DiscordId = discordId, Name = $"Concurrent-{i}" },
+                g => g.Id);
+        });
+
+        var ids = await Task.WhenAll(tasks);
+
+        Assert.All(ids, id => Assert.NotEqual(Guid.Empty, id));
+        Assert.Single(ids.Distinct());
+        await using var verify = NewContext();
+        Assert.Equal(1, await verify.Guilds.CountAsync(g => g.DiscordId == discordId));
+    }
+
+    private DiscordDbContext NewContext()
+    {
+        var options = new DbContextOptionsBuilder<DiscordDbContext>()
+            .UseNpgsql(fixture.Container.GetConnectionString())
+            .UseSnakeCaseNamingConvention()
+            .Options;
+        return new DiscordDbContext(options);
+    }
+}


### PR DESCRIPTION
## Summary
Implements **§A2.1** of epic #154 — extract the copy-pasted PostgreSQL **23505** (unique-violation) race-retry protocol into one generic primitive.

- New `DbSet<T>.UpsertAsync(match, update, create, select)` extension (`Data/DbSetUpsertExtensions.cs`): **update-first → insert on miss → catch 23505 → `ChangeTracker.Clear()` → ExecuteUpdate retry → re-query and return**.
- **Transaction-passive by design** — never opens its own `CreateExecutionStrategy`/transaction, so it composes inside the handler variants that wrap multiple writes in an outer transaction (the §A2.2/§A2.3 follow-ups).
- Refactored `GuildUpsertService.UpsertGuildAsync` onto it: **57 → 35 lines**, behavior preserved (including the existing `Guid.Empty`-as-error-signal log that §A3.2/#163 will remove). Public signature unchanged (14 callers).

## Tests
First test project in the repo: **xUnit + Testcontainers (Postgres 18, real EF migrations)**. `InternalsVisibleTo` lets tests call the internal primitive directly.
- `UpsertAsync_WhenNew_InsertsRowAndReturnsId`
- `UpsertAsync_WhenExists_UpdatesRowKeepingId`
- `UpsertAsync_WhenInsertConflicts_SwallowsViolationAndReturnsDefault` — **deterministic artificial 23505** (mismatched `match` + colliding factory)
- `UpsertAsync_WhenConcurrent_CreatesSingleRow` — 8 parallel upserts on a new key, exercises the real race

All 4 pass locally (~370ms, shared container). Live-verified on the dev bot: a message event drove `UpsertGuildAsync`'s `UPDATE guilds … WHERE discord_id` + re-query `SELECT id` cleanly, no errors, no duplicate row.

## Notes for review
- **`Async` suffix:** the dotnet-guidelines doc says no `Async` suffix, but I kept `UpsertAsync` to match every sibling in this repo (`UpsertGuildAsync`, `UpsertChannelAsync`, `UpsertUserAsync`) and the chained EF async methods. Flagging the intentional deviation.
- **DbContext from `DbSet<T>`:** obtained via `set.GetService<ICurrentDbContext>().Context` (the standard EF accessor — no public API exposes it). Commented in-code.
- **CI:** `build.yml` builds only the main csproj via a reusable workflow with no test step, so this test project does **not** run in CI yet and won't break the existing build/deploy. Wiring `dotnet test` into CI (and confirming the self-hosted runner has Docker for Testcontainers) is deferred — happy to follow up.

## Test plan
- [x] `dotnet build` clean (8 baseline warnings, none new)
- [x] 4 integration tests pass against local Postgres
- [x] Live dev-bot: update path + re-query confirmed, no errors
- [ ] GitHub Claude review