### PR TITLE
feat: migrate Channel/User/Member upserts onto UpsertAsync (#160)

### DIFF
--- a/src/DiscordEventService/Services/ChannelUpsertService.cs
+++ b/src/DiscordEventService/Services/ChannelUpsertService.cs
@@ -9,9 +9,9 @@ public class ChannelUpsertService(DiscordDbContext db, ILogger<ChannelUpsertServ
 {
     public async Task<Guid> UpsertChannelAsync(DiscordChannel channel, Guid guildId)
     {
-        var rowsAffected = await db.Channels
-            .Where(c => c.DiscordId == channel.Id)
-            .ExecuteUpdateAsync(s => s
+        var id = await db.Channels.UpsertAsync(
+            c => c.DiscordId == channel.Id,
+            s => s
                 .SetProperty(c => c.Name, channel.Name)
                 .SetProperty(c => c.Type, (ChannelType)channel.Type)
                 .SetProperty(c => c.Topic, channel.Topic)
@@ -20,51 +20,23 @@ public class ChannelUpsertService(DiscordDbContext db, ILogger<ChannelUpsertServ
                 .SetProperty(c => c.Bitrate, channel.Bitrate)
                 .SetProperty(c => c.UserLimit, channel.UserLimit)
                 .SetProperty(c => c.RateLimitPerUser, channel.PerUserRateLimit)
-                .SetProperty(c => c.IsNsfw, channel.IsNSFW));
-
-        if (rowsAffected == 0)
-        {
-            try
+                .SetProperty(c => c.IsNsfw, channel.IsNSFW),
+            () => new ChannelEntity
             {
-                db.Channels.Add(new ChannelEntity
-                {
-                    DiscordId = channel.Id,
-                    GuildId = guildId,
-                    Name = channel.Name,
-                    Type = (ChannelType)channel.Type,
-                    Topic = channel.Topic,
-                    Position = channel.Position,
-                    ParentDiscordId = channel.ParentId,
-                    Bitrate = channel.Bitrate,
-                    UserLimit = channel.UserLimit,
-                    RateLimitPerUser = channel.PerUserRateLimit,
-                    IsNsfw = channel.IsNSFW,
-                    IsDeleted = false
-                });
-                await db.SaveChangesAsync();
-            }
-            catch (DbUpdateException ex) when (ex.InnerException is Npgsql.PostgresException { SqlState: "23505" })
-            {
-                db.ChangeTracker.Clear();
-                await db.Channels
-                    .Where(c => c.DiscordId == channel.Id)
-                    .ExecuteUpdateAsync(s => s
-                        .SetProperty(c => c.Name, channel.Name)
-                        .SetProperty(c => c.Type, (ChannelType)channel.Type)
-                        .SetProperty(c => c.Topic, channel.Topic)
-                        .SetProperty(c => c.Position, channel.Position)
-                        .SetProperty(c => c.ParentDiscordId, channel.ParentId)
-                        .SetProperty(c => c.Bitrate, channel.Bitrate)
-                        .SetProperty(c => c.UserLimit, channel.UserLimit)
-                        .SetProperty(c => c.RateLimitPerUser, channel.PerUserRateLimit)
-                        .SetProperty(c => c.IsNsfw, channel.IsNSFW));
-            }
-        }
-
-        var id = await db.Channels
-            .Where(c => c.DiscordId == channel.Id)
-            .Select(c => c.Id)
-            .FirstOrDefaultAsync();
+                DiscordId = channel.Id,
+                GuildId = guildId,
+                Name = channel.Name,
+                Type = (ChannelType)channel.Type,
+                Topic = channel.Topic,
+                Position = channel.Position,
+                ParentDiscordId = channel.ParentId,
+                Bitrate = channel.Bitrate,
+                UserLimit = channel.UserLimit,
+                RateLimitPerUser = channel.PerUserRateLimit,
+                IsNsfw = channel.IsNSFW,
+                IsDeleted = false
+            },
+            c => c.Id);
 
         if (id == Guid.Empty)
         {

--- a/src/DiscordEventService/Services/UserService.cs
+++ b/src/DiscordEventService/Services/UserService.cs
@@ -9,76 +9,61 @@ public class UserService(DiscordDbContext db, ILogger<UserService> logger)
 {
     public async Task UpsertUserAsync(DiscordUser user)
     {
+        // Pre-query old values for name-history detection: the primitive only does the write,
+        // and on a 23505 race we have no reliable "before" to compare against (matches insert path).
         var existing = await db.Users
             .Where(u => u.DiscordId == user.Id)
             .Select(u => new { u.Id, u.Username, u.GlobalName })
             .FirstOrDefaultAsync();
 
-        if (existing is not null)
-        {
-            await db.Users
-                .Where(u => u.DiscordId == user.Id)
-                .ExecuteUpdateAsync(s => s
-                    .SetProperty(u => u.Username, user.Username)
-                    .SetProperty(u => u.GlobalName, user.GlobalName)
-                    .SetProperty(u => u.Discriminator, user.Discriminator)
-                    .SetProperty(u => u.AvatarHash, user.AvatarHash));
-
-            var usernameChanged = existing.Username != user.Username;
-            var globalNameChanged = existing.GlobalName != user.GlobalName;
-
-            if (usernameChanged || globalNameChanged)
+        await db.Users.UpsertAsync(
+            u => u.DiscordId == user.Id,
+            s => s
+                .SetProperty(u => u.Username, user.Username)
+                .SetProperty(u => u.GlobalName, user.GlobalName)
+                .SetProperty(u => u.Discriminator, user.Discriminator)
+                .SetProperty(u => u.AvatarHash, user.AvatarHash),
+            () => new UserEntity
             {
-                db.UserNameHistory.Add(new UserNameHistoryEntity
-                {
-                    UserId = existing.Id,
-                    UsernameBefore = usernameChanged ? existing.Username : null,
-                    UsernameAfter = usernameChanged ? user.Username : null,
-                    GlobalNameBefore = globalNameChanged ? existing.GlobalName : null,
-                    GlobalNameAfter = globalNameChanged ? user.GlobalName : null,
-                    ChangedAtUtc = DateTime.UtcNow
-                });
-                await db.SaveChangesAsync();
-                db.ChangeTracker.Clear();
+                DiscordId = user.Id,
+                Username = user.Username,
+                GlobalName = user.GlobalName,
+                Discriminator = user.Discriminator,
+                AvatarHash = user.AvatarHash,
+                IsBot = user.IsBot,
+                IsSystem = user.IsSystem ?? false
+            },
+            u => u.Id);
 
-                logger.LogInformation(
-                    "User name changed for {DiscordId}: username {OldUser} → {NewUser}, globalName {OldGlobal} → {NewGlobal}",
-                    user.Id,
-                    usernameChanged ? existing.Username : "(unchanged)",
-                    usernameChanged ? user.Username : "(unchanged)",
-                    globalNameChanged ? existing.GlobalName : "(unchanged)",
-                    globalNameChanged ? user.GlobalName : "(unchanged)");
-            }
+        if (existing is null)
+        {
+            return;
         }
-        else
+
+        var usernameChanged = existing.Username != user.Username;
+        var globalNameChanged = existing.GlobalName != user.GlobalName;
+
+        if (usernameChanged || globalNameChanged)
         {
-            try
+            db.UserNameHistory.Add(new UserNameHistoryEntity
             {
-                db.Users.Add(new UserEntity
-                {
-                    DiscordId = user.Id,
-                    Username = user.Username,
-                    GlobalName = user.GlobalName,
-                    Discriminator = user.Discriminator,
-                    AvatarHash = user.AvatarHash,
-                    IsBot = user.IsBot,
-                    IsSystem = user.IsSystem ?? false
-                });
-                await db.SaveChangesAsync();
-            }
-            catch (DbUpdateException ex) when (ex.InnerException is Npgsql.PostgresException { SqlState: "23505" })
-            {
-                // Race: another thread inserted first — update to latest values.
-                // No history row: we have no reliable "before" to compare against.
-                db.ChangeTracker.Clear();
-                await db.Users
-                    .Where(u => u.DiscordId == user.Id)
-                    .ExecuteUpdateAsync(s => s
-                        .SetProperty(u => u.Username, user.Username)
-                        .SetProperty(u => u.GlobalName, user.GlobalName)
-                        .SetProperty(u => u.Discriminator, user.Discriminator)
-                        .SetProperty(u => u.AvatarHash, user.AvatarHash));
-            }
+                UserId = existing.Id,
+                UsernameBefore = usernameChanged ? existing.Username : null,
+                UsernameAfter = usernameChanged ? user.Username : null,
+                GlobalNameBefore = globalNameChanged ? existing.GlobalName : null,
+                GlobalNameAfter = globalNameChanged ? user.GlobalName : null,
+                ChangedAtUtc = DateTime.UtcNow
+            });
+            await db.SaveChangesAsync();
+            db.ChangeTracker.Clear();
+
+            logger.LogInformation(
+                "User name changed for {DiscordId}: username {OldUser} → {NewUser}, globalName {OldGlobal} → {NewGlobal}",
+                user.Id,
+                usernameChanged ? existing.Username : "(unchanged)",
+                usernameChanged ? user.Username : "(unchanged)",
+                globalNameChanged ? existing.GlobalName : "(unchanged)",
+                globalNameChanged ? user.GlobalName : "(unchanged)");
         }
     }
 
@@ -97,51 +82,29 @@ public class UserService(DiscordDbContext db, ILogger<UserService> logger)
             return;
         }
 
-        var rowsAffected = await db.Members
-            .Where(m => m.UserId == userEntity.Id && m.GuildId == guildEntity.Id)
-            .ExecuteUpdateAsync(s => s
+        await db.Members.UpsertAsync(
+            m => m.UserId == userEntity.Id && m.GuildId == guildEntity.Id,
+            s => s
                 .SetProperty(m => m.Nickname, member.Nickname)
                 .SetProperty(m => m.GuildAvatarHash, member.GuildAvatarHash)
                 .SetProperty(m => m.PremiumSinceUtc, member.PremiumSince != null ? member.PremiumSince.Value.UtcDateTime : (DateTime?)null)
                 .SetProperty(m => m.IsDeafened, member.IsDeafened == true)
                 .SetProperty(m => m.IsMuted, member.IsMuted == true)
                 .SetProperty(m => m.IsPending, member.IsPending == true)
-                .SetProperty(m => m.TimeoutUntilUtc, member.CommunicationDisabledUntil != null ? member.CommunicationDisabledUntil.Value.UtcDateTime : (DateTime?)null));
-
-        if (rowsAffected == 0)
-        {
-            try
+                .SetProperty(m => m.TimeoutUntilUtc, member.CommunicationDisabledUntil != null ? member.CommunicationDisabledUntil.Value.UtcDateTime : (DateTime?)null),
+            () => new MemberEntity
             {
-                db.Members.Add(new MemberEntity
-                {
-                    UserId = userEntity.Id,
-                    GuildId = guildEntity.Id,
-                    Nickname = member.Nickname,
-                    GuildAvatarHash = member.GuildAvatarHash,
-                    JoinedAtUtc = member.JoinedAt.UtcDateTime,
-                    PremiumSinceUtc = member.PremiumSince?.UtcDateTime,
-                    IsDeafened = member.IsDeafened == true,
-                    IsMuted = member.IsMuted == true,
-                    IsPending = member.IsPending == true,
-                    TimeoutUntilUtc = member.CommunicationDisabledUntil?.UtcDateTime
-                });
-                await db.SaveChangesAsync();
-            }
-            catch (DbUpdateException ex) when (ex.InnerException is Npgsql.PostgresException { SqlState: "23505" })
-            {
-                // Unique constraint violation - race condition, another request inserted first
-                db.ChangeTracker.Clear();
-                await db.Members
-                    .Where(m => m.UserId == userEntity.Id && m.GuildId == guildEntity.Id)
-                    .ExecuteUpdateAsync(s => s
-                        .SetProperty(m => m.Nickname, member.Nickname)
-                        .SetProperty(m => m.GuildAvatarHash, member.GuildAvatarHash)
-                        .SetProperty(m => m.PremiumSinceUtc, member.PremiumSince != null ? member.PremiumSince.Value.UtcDateTime : (DateTime?)null)
-                        .SetProperty(m => m.IsDeafened, member.IsDeafened == true)
-                        .SetProperty(m => m.IsMuted, member.IsMuted == true)
-                        .SetProperty(m => m.IsPending, member.IsPending == true)
-                        .SetProperty(m => m.TimeoutUntilUtc, member.CommunicationDisabledUntil != null ? member.CommunicationDisabledUntil.Value.UtcDateTime : (DateTime?)null));
-            }
-        }
+                UserId = userEntity.Id,
+                GuildId = guildEntity.Id,
+                Nickname = member.Nickname,
+                GuildAvatarHash = member.GuildAvatarHash,
+                JoinedAtUtc = member.JoinedAt.UtcDateTime,
+                PremiumSinceUtc = member.PremiumSince?.UtcDateTime,
+                IsDeafened = member.IsDeafened == true,
+                IsMuted = member.IsMuted == true,
+                IsPending = member.IsPending == true,
+                TimeoutUntilUtc = member.CommunicationDisabledUntil?.UtcDateTime
+            },
+            m => m.Id);
     }
 }

--- a/tests/DiscordEventService.Tests/UserUpsertTests.cs
+++ b/tests/DiscordEventService.Tests/UserUpsertTests.cs
@@ -1,0 +1,100 @@
+using System.Reflection;
+using DiscordEventService.Data;
+using DiscordEventService.Data.Entities.Core;
+using DiscordEventService.Services;
+using DSharpPlus.Entities;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging.Abstractions;
+using Xunit;
+
+namespace DiscordEventService.Tests;
+
+public sealed class UserUpsertTests(PostgresFixture fixture) : IClassFixture<PostgresFixture>, IAsyncLifetime
+{
+    private DiscordDbContext _db = null!;
+
+    public async Task InitializeAsync()
+    {
+        _db = NewContext();
+        await _db.Database.MigrateAsync();
+        await _db.UserNameHistory.ExecuteDeleteAsync();
+        await _db.Users.ExecuteDeleteAsync();
+    }
+
+    public Task DisposeAsync() => _db.DisposeAsync().AsTask();
+
+    [Fact]
+    public async Task UpsertUser_WhenNew_InsertsUserAndWritesNoHistory()
+    {
+        var service = new UserService(_db, NullLogger<UserService>.Instance);
+
+        await service.UpsertUserAsync(MakeUser(100UL, "alice", "Alice"));
+
+        await using var verify = NewContext();
+        var row = await verify.Users.SingleAsync(u => u.DiscordId == 100UL);
+        Assert.Equal("alice", row.Username);
+        Assert.Equal("Alice", row.GlobalName);
+        Assert.Equal(0, await verify.UserNameHistory.CountAsync());
+    }
+
+    [Fact]
+    public async Task UpsertUser_WhenNameChanged_UpdatesUserAndWritesHistory()
+    {
+        var service = new UserService(_db, NullLogger<UserService>.Instance);
+        await service.UpsertUserAsync(MakeUser(200UL, "bob", "Bob"));
+        _db.ChangeTracker.Clear();
+
+        await service.UpsertUserAsync(MakeUser(200UL, "bobby", "Bobby"));
+
+        await using var verify = NewContext();
+        var row = await verify.Users.SingleAsync(u => u.DiscordId == 200UL);
+        Assert.Equal("bobby", row.Username);
+        Assert.Equal("Bobby", row.GlobalName);
+
+        var history = await verify.UserNameHistory.SingleAsync(h => h.UserId == row.Id);
+        Assert.Equal("bob", history.UsernameBefore);
+        Assert.Equal("bobby", history.UsernameAfter);
+        Assert.Equal("Bob", history.GlobalNameBefore);
+        Assert.Equal("Bobby", history.GlobalNameAfter);
+    }
+
+    [Fact]
+    public async Task UpsertUser_WhenUnchanged_WritesNoHistory()
+    {
+        var service = new UserService(_db, NullLogger<UserService>.Instance);
+        await service.UpsertUserAsync(MakeUser(300UL, "carol", "Carol"));
+        _db.ChangeTracker.Clear();
+
+        await service.UpsertUserAsync(MakeUser(300UL, "carol", "Carol"));
+
+        await using var verify = NewContext();
+        Assert.Equal(0, await verify.UserNameHistory.CountAsync());
+    }
+
+    private DiscordDbContext NewContext()
+    {
+        var options = new DbContextOptionsBuilder<DiscordDbContext>()
+            .UseNpgsql(fixture.Container.GetConnectionString())
+            .UseSnakeCaseNamingConvention()
+            .Options;
+        return new DiscordDbContext(options);
+    }
+
+    // DiscordUser exposes a parameterless ctor with non-public setters; reflection is the only
+    // way to build a fixture instance without a live gateway connection.
+    private static DiscordUser MakeUser(ulong id, string username, string globalName)
+    {
+        var user = (DiscordUser)Activator.CreateInstance(typeof(DiscordUser), nonPublic: true)!;
+        SetProp(user, nameof(DiscordUser.Id), id);
+        SetProp(user, nameof(DiscordUser.Username), username);
+        SetProp(user, nameof(DiscordUser.GlobalName), globalName);
+        SetProp(user, nameof(DiscordUser.Discriminator), "0");
+        return user;
+    }
+
+    private static void SetProp(DiscordUser user, string name, object value)
+    {
+        var property = typeof(DiscordUser).GetProperty(name, BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance);
+        property!.SetValue(user, value);
+    }
+}


### PR DESCRIPTION
Closes #160. §A2.2 of epic #154 (Architecture Deepening — Upsert & Retry Consolidation).

## What

Routes the remaining upsert services through the generic `DbSet.UpsertAsync` primitive added in #159 (#184), deleting their copy-pasted `ExecuteUpdate → Add → catch 23505 → ChangeTracker.Clear → retry → re-query` blocks.

- **`ChannelUpsertService.UpsertChannelAsync`** — 65 → ~37 lines, onto the primitive.
- **`UserService.UpsertUserAsync`** — keeps name-history detection (pre-query old values, write via primitive, then write the `UserNameHistory` row when username/global-name changed). Behavior unchanged.
- **`UserService.UpsertMemberAsync`** — composite-key (`UserId` + `GuildId`) upsert onto the primitive.

## Deliberately out of scope

- **`InsertPlaceholderAsync` left as-is.** It's *insert-or-get* (insert; on 23505 re-query the existing row **without touching it**), not upsert. The update-first primitive would stamp placeholder values (`Name='[unknown thread]'`, `Type=PublicThread`, `Position=0`) over an existing real channel row — a data-loss path. An insert-or-get sibling primitive belongs in **#161**.
- Backfill jobs, `BootQuickSyncService`, and the three transaction-wrapped `*EventHandler.cs` files are **#161** (§A2.3 inline 23505 handlers), not this issue.

## Metric

§A2 target: 18 hand-rolled 23505 copies → 1 primitive. #159 removed 1 (Guild); this removes 3 more (Channel upsert, User, Member). The Channel upsert path now has zero manual 23505 blocks; the placeholder keeps one by design.

## Tests

- 3 new Testcontainers integration tests pinning `UserService` name-history: new → no history; name changed → history row with correct before/after; unchanged → no history. (Existing 4 primitive tests still pass — 7 total green.)
- **Live-verified on the dev bot** (local Postgres + dev server): user upsert (`UPDATE users`, cold sync), channel **insert** path (new channel → `INSERT INTO channels`), and member upsert (`UPDATE members SET nickname` via nickname change) all ran through the primitive with zero 23505 / errors / disposal / "lost" lines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)