### PR TITLE
feat: consolidate inline 23505 handlers onto upsert primitives (#161)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -5,17 +5,17 @@
 - .NET (C#), use `dotnet build/run/format/restore`
 - PostgreSQL via `docker-compose.yml` (local dev DB on port 5432)
 - Dev bot account + separate Discord server configured in `.env`
-- Discord MCP (`SaseQ/discord-mcp` via Docker) available globally — use it for local testing: send messages, read channels, manage roles, etc. without prompting user
-- Production DB: READ ONLY, never run migrations or writes against prod. Prompt user for credentials and address before connecting. Use `docker run --rm -it postgres:18 psql` to query (no local psql installed)
+- Discord MCP (`SaseQ/discord-mcp` via Docker) available globally — **drive live tests autonomously with it**: send/edit messages, add reactions, read channels, join voice, manage roles, etc. without prompting the user. Only ask the user to act when the MCP is unavailable or the action genuinely can't be done via MCP
+- Production DB: READ ONLY (SELECT-only by convention), never run migrations or writes against prod. Connect via `docker run --rm postgres:18 psql ...` (no local psql installed). Connection details are in the agent's private local memory; DB is reachable only on the home network
 
 ## Development workflow
 
 1. **Code changes** — work locally, check `dotnet build` for warnings and errors
-2. **Test migrations** — run against local Postgres (`docker compose up -d postgres`)
-3. **Test locally** — run dev bot with `dotnet run` against local DB and dev Discord server. Prompt user to perform actions in Discord when needed (send messages, react, join voice, etc.) and verify behavior in logs and database
-4. **Test aggressively** — verify every change end-to-end whenever possible. Build green alone is not enough signal
+2. **Test migrations** — run against local Postgres: `docker compose up -d postgres` (container `wojtus-postgres`, host port 5432, db `postgres`). EF migrations auto-apply on bot boot. NEVER point the app at prod
+3. **Test locally** — boot the dev bot from `src/DiscordEventService` (background, log to a file), let it connect + cold-sync, then **drive the live test yourself via the Discord MCP** (send/edit/react/voice in the dev server) to exercise the changed paths. Verify in the bot log and the local DB. Only fall back to asking the user to act if the MCP is unavailable. (Concrete boot/stop recipe + dev guild id live in agent memory)
+4. **Test aggressively** — verify every change end-to-end whenever possible. Build green alone is not enough signal. For changes with a crisp behavioral contract, add a Testcontainers integration test (no DB mocking) **and** still live-verify on the dev bot
 5. **Create PR** — push branch, `gh pr create`, wait for GitHub Claude review
 6. **Review loop** — after every review round, read ALL comments (top-level + inline via `gh api repos/<o>/<r>/pulls/<N>/comments`). Apply fixes, push, repeat until approved and no outstanding comments
 7. **Wait for user approval** — do NOT merge without explicit user approval, even if review is clean and checks pass
-8. **Post-merge deployment** — after merge, watch deploy via `gh run watch`, then pull container logs (`mcp__homelab__GetContainerLogs` for `discord-event-service`) covering ~5 min before and after deploy. Surface anomalies
-9. **Post-deploy verification** — if needed, ask user to trigger actions in Discord, then check logs and prod database to confirm changes work in production
+8. **Post-merge deployment** — after merge, watch deploy via `gh run watch`, wait for container restart, then `mcp__homelab__get_container_status` (expect healthy) + pull logs (`mcp__homelab__GetContainerLogs` for `discord-event-service`) + targeted `mcp__homelab__QueryLoki` covering ~5–15 min around deploy. Surface anomalies (new patterns, unexpected callsites), not just error counts
+9. **Post-deploy verification** — **standard step, do it autonomously**: run read-only SELECT checks against the prod DB to confirm the change's data looks sane (recent rows, no duplicates/corruption from the change, relevant invariants hold). Connection details + a reusable verification query set are in agent memory. Drive any needed Discord actions via the MCP. Only prompt the user for the prod DB password (and only when not already in memory)

--- a/src/DiscordEventService/Data/DbSetUpsertExtensions.cs
+++ b/src/DiscordEventService/Data/DbSetUpsertExtensions.cs
@@ -14,10 +14,11 @@ internal static class DbSetUpsertExtensions
         Expression<Func<TEntity, bool>> match,
         Action<UpdateSettersBuilder<TEntity>> update,
         Func<TEntity> create,
-        Expression<Func<TEntity, TResult>> select)
+        Expression<Func<TEntity, TResult>> select,
+        CancellationToken cancellationToken = default)
         where TEntity : class
     {
-        var rowsAffected = await set.Where(match).ExecuteUpdateAsync(update);
+        var rowsAffected = await set.Where(match).ExecuteUpdateAsync(update, cancellationToken);
         if (rowsAffected == 0)
         {
             // No public API exposes the DbContext from a DbSet; this is the standard EF accessor.
@@ -25,15 +26,50 @@ internal static class DbSetUpsertExtensions
             try
             {
                 set.Add(create());
-                await db.SaveChangesAsync();
+                await db.SaveChangesAsync(cancellationToken);
             }
             catch (DbUpdateException ex) when (ex.InnerException is PostgresException { SqlState: "23505" })
             {
                 // Race: another writer inserted first — drop the failed Add and update instead.
                 db.ChangeTracker.Clear();
-                await set.Where(match).ExecuteUpdateAsync(update);
+                await set.Where(match).ExecuteUpdateAsync(update, cancellationToken);
             }
         }
-        return await set.Where(match).Select(select).FirstOrDefaultAsync();
+        return await set.Where(match).Select(select).FirstOrDefaultAsync(cancellationToken);
+    }
+
+    /// <summary>
+    /// Insert-or-get. Inserts <paramref name="create"/>; on a 23505 unique-violation race
+    /// (another writer inserted first), clears the failed Add and re-queries the existing row
+    /// <b>without modifying it</b>. Use when the conflicting row must be preserved as-is
+    /// (placeholder rows, snapshot insert-or-ignore, create-only message inserts) — routing
+    /// those through <see cref="UpsertAsync{TEntity,TResult}"/> would overwrite real data.
+    /// Returns the inserted entity (keys populated, no extra query) on the happy path, or the
+    /// existing row on conflict; <c>null</c> only if the row vanished after the conflict.
+    /// Transaction-passive: never opens its own strategy/transaction.
+    /// </summary>
+    public static async Task<TEntity?> GetOrInsertAsync<TEntity>(
+        this DbSet<TEntity> set,
+        Expression<Func<TEntity, bool>> match,
+        Func<TEntity> create,
+        CancellationToken cancellationToken = default)
+        where TEntity : class
+    {
+        // No public API exposes the DbContext from a DbSet; this is the standard EF accessor.
+        var db = set.GetService<ICurrentDbContext>().Context;
+        var entity = create();
+        try
+        {
+            set.Add(entity);
+            await db.SaveChangesAsync(cancellationToken);
+            return entity;
+        }
+        catch (DbUpdateException ex) when (ex.InnerException is PostgresException { SqlState: "23505" })
+        {
+            // Race: another writer inserted first — drop the failed Add and return the existing
+            // row untouched (deliberately NO update; the existing data may be richer than ours).
+            db.ChangeTracker.Clear();
+            return await set.Where(match).FirstOrDefaultAsync(cancellationToken);
+        }
     }
 }

--- a/src/DiscordEventService/Data/DbSetUpsertExtensions.cs
+++ b/src/DiscordEventService/Data/DbSetUpsertExtensions.cs
@@ -44,11 +44,12 @@ internal static class DbSetUpsertExtensions
     /// <b>without modifying it</b>. Use when the conflicting row must be preserved as-is
     /// (placeholder rows, snapshot insert-or-ignore, create-only message inserts) — routing
     /// those through <see cref="UpsertAsync{TEntity,TResult}"/> would overwrite real data.
-    /// Returns the inserted entity (keys populated, no extra query) on the happy path, or the
-    /// existing row on conflict; <c>null</c> only if the row vanished after the conflict.
+    /// Returns <c>(Entity, Inserted)</c>: on the happy path the freshly-inserted entity (keys
+    /// populated, no extra query) with <c>Inserted = true</c>; on conflict the existing row with
+    /// <c>Inserted = false</c> (<c>Entity = null</c> only if the row vanished after the conflict).
     /// Transaction-passive: never opens its own strategy/transaction.
     /// </summary>
-    public static async Task<TEntity?> GetOrInsertAsync<TEntity>(
+    public static async Task<(TEntity? Entity, bool Inserted)> GetOrInsertAsync<TEntity>(
         this DbSet<TEntity> set,
         Expression<Func<TEntity, bool>> match,
         Func<TEntity> create,
@@ -62,14 +63,14 @@ internal static class DbSetUpsertExtensions
         {
             set.Add(entity);
             await db.SaveChangesAsync(cancellationToken);
-            return entity;
+            return (entity, true);
         }
         catch (DbUpdateException ex) when (ex.InnerException is PostgresException { SqlState: "23505" })
         {
             // Race: another writer inserted first — drop the failed Add and return the existing
             // row untouched (deliberately NO update; the existing data may be richer than ours).
             db.ChangeTracker.Clear();
-            return await set.Where(match).FirstOrDefaultAsync(cancellationToken);
+            return (await set.Where(match).FirstOrDefaultAsync(cancellationToken), false);
         }
     }
 }

--- a/src/DiscordEventService/Jobs/ChannelsBackfillJob.cs
+++ b/src/DiscordEventService/Jobs/ChannelsBackfillJob.cs
@@ -41,9 +41,9 @@ public class ChannelsBackfillJob(
             {
                 cancellationToken.ThrowIfCancellationRequested();
 
-                var rowsAffected = await db.Channels
-                    .Where(c => c.DiscordId == channel.Id)
-                    .ExecuteUpdateAsync(s => s
+                await db.Channels.UpsertAsync(
+                    c => c.DiscordId == channel.Id,
+                    s => s
                         .SetProperty(c => c.Name, channel.Name)
                         .SetProperty(c => c.Type, (ChannelType)(int)channel.Type)
                         .SetProperty(c => c.Topic, channel.Topic)
@@ -55,34 +55,22 @@ public class ChannelsBackfillJob(
                         .SetProperty(c => c.ParentDiscordId, channel.ParentId)
                         .SetProperty(c => c.IsDeleted, false)
                         .SetProperty(c => c.DeletedAtUtc, (DateTime?)null),
+                    () => new ChannelEntity
+                    {
+                        DiscordId = channel.Id,
+                        GuildId = guildEntity.Id,
+                        ParentDiscordId = channel.ParentId,
+                        Name = channel.Name,
+                        Type = (ChannelType)(int)channel.Type,
+                        Topic = channel.Topic,
+                        Bitrate = channel.Bitrate,
+                        UserLimit = channel.UserLimit,
+                        RateLimitPerUser = channel.PerUserRateLimit,
+                        IsNsfw = channel.IsNSFW,
+                        Position = channel.Position
+                    },
+                    c => c.Id,
                     cancellationToken);
-
-                if (rowsAffected == 0)
-                {
-                    try
-                    {
-                        db.Channels.Add(new ChannelEntity
-                        {
-                            DiscordId = channel.Id,
-                            GuildId = guildEntity.Id,
-                            ParentDiscordId = channel.ParentId,
-                            Name = channel.Name,
-                            Type = (ChannelType)(int)channel.Type,
-                            Topic = channel.Topic,
-                            Bitrate = channel.Bitrate,
-                            UserLimit = channel.UserLimit,
-                            RateLimitPerUser = channel.PerUserRateLimit,
-                            IsNsfw = channel.IsNSFW,
-                            Position = channel.Position
-                        });
-                        await db.SaveChangesAsync(cancellationToken);
-                    }
-                    catch (DbUpdateException ex) when (ex.InnerException is Npgsql.PostgresException { SqlState: "23505" })
-                    {
-                        logger.LogDebug("Channel {ChannelId} already exists (race condition), skipping insert", channel.Id);
-                        db.ChangeTracker.Clear();
-                    }
-                }
 
                 checkpoint.ProcessedCount++;
 

--- a/src/DiscordEventService/Jobs/EmojisBackfillJob.cs
+++ b/src/DiscordEventService/Jobs/EmojisBackfillJob.cs
@@ -40,36 +40,24 @@ public class EmojisBackfillJob(
             {
                 cancellationToken.ThrowIfCancellationRequested();
 
-                var rowsAffected = await db.Emotes
-                    .Where(e => e.DiscordId == emoji.Id)
-                    .ExecuteUpdateAsync(s => s
+                await db.Emotes.UpsertAsync(
+                    e => e.DiscordId == emoji.Id,
+                    s => s
                         .SetProperty(e => e.Name, emoji.Name)
                         .SetProperty(e => e.IsAnimated, emoji.IsAnimated)
                         .SetProperty(e => e.IsAvailable, emoji.IsAvailable)
                         .SetProperty(e => e.IsDeleted, false)
                         .SetProperty(e => e.DeletedAtUtc, (DateTime?)null),
+                    () => new EmoteEntity
+                    {
+                        DiscordId = emoji.Id,
+                        GuildId = guildEntity.Id,
+                        Name = emoji.Name,
+                        IsAnimated = emoji.IsAnimated,
+                        IsAvailable = emoji.IsAvailable
+                    },
+                    e => e.Id,
                     cancellationToken);
-
-                if (rowsAffected == 0)
-                {
-                    try
-                    {
-                        db.Emotes.Add(new EmoteEntity
-                        {
-                            DiscordId = emoji.Id,
-                            GuildId = guildEntity.Id,
-                            Name = emoji.Name,
-                            IsAnimated = emoji.IsAnimated,
-                            IsAvailable = emoji.IsAvailable
-                        });
-                        await db.SaveChangesAsync(cancellationToken);
-                    }
-                    catch (DbUpdateException ex) when (ex.InnerException is Npgsql.PostgresException { SqlState: "23505" })
-                    {
-                        logger.LogDebug("Emoji {EmojiId} already exists (race condition), skipping insert", emoji.Id);
-                        db.ChangeTracker.Clear();
-                    }
-                }
 
                 checkpoint.ProcessedCount++;
 

--- a/src/DiscordEventService/Jobs/RolesBackfillJob.cs
+++ b/src/DiscordEventService/Jobs/RolesBackfillJob.cs
@@ -42,9 +42,9 @@ public class RolesBackfillJob(
 
                 var permissions = long.TryParse(role.Permissions.ToString(), out var perm) ? perm : 0;
 
-                var rowsAffected = await db.Roles
-                    .Where(r => r.DiscordId == role.Id)
-                    .ExecuteUpdateAsync(s => s
+                await db.Roles.UpsertAsync(
+                    r => r.DiscordId == role.Id,
+                    s => s
                         .SetProperty(r => r.Name, role.Name)
                         .SetProperty(r => r.Color, role.Color.Value)
                         .SetProperty(r => r.IsHoisted, role.IsHoisted)
@@ -54,32 +54,20 @@ public class RolesBackfillJob(
                         .SetProperty(r => r.IsMentionable, role.IsMentionable)
                         .SetProperty(r => r.IsDeleted, false)
                         .SetProperty(r => r.DeletedAtUtc, (DateTime?)null),
+                    () => new RoleEntity
+                    {
+                        DiscordId = role.Id,
+                        GuildId = guildEntity.Id,
+                        Name = role.Name,
+                        Color = role.Color.Value,
+                        IsHoisted = role.IsHoisted,
+                        Position = role.Position,
+                        Permissions = permissions,
+                        IsManaged = role.IsManaged,
+                        IsMentionable = role.IsMentionable
+                    },
+                    r => r.Id,
                     cancellationToken);
-
-                if (rowsAffected == 0)
-                {
-                    try
-                    {
-                        db.Roles.Add(new RoleEntity
-                        {
-                            DiscordId = role.Id,
-                            GuildId = guildEntity.Id,
-                            Name = role.Name,
-                            Color = role.Color.Value,
-                            IsHoisted = role.IsHoisted,
-                            Position = role.Position,
-                            Permissions = permissions,
-                            IsManaged = role.IsManaged,
-                            IsMentionable = role.IsMentionable
-                        });
-                        await db.SaveChangesAsync(cancellationToken);
-                    }
-                    catch (DbUpdateException ex) when (ex.InnerException is Npgsql.PostgresException { SqlState: "23505" })
-                    {
-                        logger.LogDebug("Role {RoleId} already exists (race condition), skipping insert", role.Id);
-                        db.ChangeTracker.Clear();
-                    }
-                }
 
                 checkpoint.ProcessedCount++;
 

--- a/src/DiscordEventService/Jobs/StickersBackfillJob.cs
+++ b/src/DiscordEventService/Jobs/StickersBackfillJob.cs
@@ -42,9 +42,9 @@ public class StickersBackfillJob(
 
                 var tags = sticker.Tags != null ? string.Join(",", sticker.Tags) : null;
 
-                var rowsAffected = await db.Stickers
-                    .Where(s => s.DiscordId == sticker.Id)
-                    .ExecuteUpdateAsync(s => s
+                await db.Stickers.UpsertAsync(
+                    s => s.DiscordId == sticker.Id,
+                    s => s
                         .SetProperty(st => st.Name, sticker.Name ?? string.Empty)
                         .SetProperty(st => st.Description, sticker.Description)
                         .SetProperty(st => st.Tags, tags)
@@ -53,32 +53,20 @@ public class StickersBackfillJob(
                         .SetProperty(st => st.IsAvailable, true)
                         .SetProperty(st => st.IsDeleted, false)
                         .SetProperty(st => st.DeletedAtUtc, (DateTime?)null),
+                    () => new StickerEntity
+                    {
+                        DiscordId = sticker.Id,
+                        GuildId = guildEntity.Id,
+                        PackId = sticker.PackId,
+                        Name = sticker.Name ?? string.Empty,
+                        Description = sticker.Description,
+                        Tags = tags,
+                        Type = (int)sticker.Type,
+                        FormatType = (int)sticker.FormatType,
+                        IsAvailable = true
+                    },
+                    s => s.Id,
                     cancellationToken);
-
-                if (rowsAffected == 0)
-                {
-                    try
-                    {
-                        db.Stickers.Add(new StickerEntity
-                        {
-                            DiscordId = sticker.Id,
-                            GuildId = guildEntity.Id,
-                            PackId = sticker.PackId,
-                            Name = sticker.Name ?? string.Empty,
-                            Description = sticker.Description,
-                            Tags = tags,
-                            Type = (int)sticker.Type,
-                            FormatType = (int)sticker.FormatType,
-                            IsAvailable = true
-                        });
-                        await db.SaveChangesAsync(cancellationToken);
-                    }
-                    catch (DbUpdateException ex) when (ex.InnerException is Npgsql.PostgresException { SqlState: "23505" })
-                    {
-                        logger.LogDebug("Sticker {StickerId} already exists (race condition), skipping insert", sticker.Id);
-                        db.ChangeTracker.Clear();
-                    }
-                }
 
                 checkpoint.ProcessedCount++;
 

--- a/src/DiscordEventService/Services/BootQuickSyncService.cs
+++ b/src/DiscordEventService/Services/BootQuickSyncService.cs
@@ -92,22 +92,30 @@ public class BootQuickSyncService(
                         ? JsonSerializer.Serialize(message.Embeds)
                         : null;
 
-                    db.Messages.Add(new MessageEntity
-                    {
-                        DiscordId = message.Id,
-                        ChannelId = channelId,
-                        GuildId = guildId,
-                        AuthorId = authorId,
-                        Content = string.IsNullOrEmpty(message.Content) ? null : message.Content,
-                        ReplyToDiscordId = message.ReferencedMessage?.Id,
-                        HasAttachments = message.Attachments.Count > 0,
-                        HasEmbeds = message.Embeds.Count > 0,
-                        AttachmentsJson = attachmentsJson,
-                        EmbedsJson = embedsJson,
-                        Flags = (int)(message.Flags ?? 0),
-                        CreatedAtUtc = message.Timestamp.UtcDateTime,
-                        EditedAtUtc = message.EditedTimestamp?.UtcDateTime
-                    });
+                    // Insert-or-ignore per message: the existingSet pre-check filters known rows;
+                    // this guards the race where a live MessageCreated inserts the same message
+                    // during boot. On conflict we skip the backfilled event (the live path logs
+                    // its own Created event) and don't count it.
+                    var (_, inserted) = await db.Messages.GetOrInsertAsync(
+                        m => m.DiscordId == message.Id,
+                        () => new MessageEntity
+                        {
+                            DiscordId = message.Id,
+                            ChannelId = channelId,
+                            GuildId = guildId,
+                            AuthorId = authorId,
+                            Content = string.IsNullOrEmpty(message.Content) ? null : message.Content,
+                            ReplyToDiscordId = message.ReferencedMessage?.Id,
+                            HasAttachments = message.Attachments.Count > 0,
+                            HasEmbeds = message.Embeds.Count > 0,
+                            AttachmentsJson = attachmentsJson,
+                            EmbedsJson = embedsJson,
+                            Flags = (int)(message.Flags ?? 0),
+                            CreatedAtUtc = message.Timestamp.UtcDateTime,
+                            EditedAtUtc = message.EditedTimestamp?.UtcDateTime
+                        });
+
+                    if (!inserted) continue;
 
                     db.MessageEvents.Add(new MessageEventEntity
                     {
@@ -125,17 +133,9 @@ public class BootQuickSyncService(
                         EventTimestampUtc = message.Timestamp.UtcDateTime,
                         ReceivedAtUtc = DateTime.UtcNow
                     });
+                    await db.SaveChangesAsync();
 
                     totalInserted++;
-                }
-
-                try
-                {
-                    await db.SaveChangesAsync();
-                }
-                catch (DbUpdateException ex) when (ex.InnerException is Npgsql.PostgresException { SqlState: "23505" })
-                {
-                    db.ChangeTracker.Clear();
                 }
             }
             catch (DSharpPlus.Exceptions.UnauthorizedException)

--- a/src/DiscordEventService/Services/ChannelUpsertService.cs
+++ b/src/DiscordEventService/Services/ChannelUpsertService.cs
@@ -52,9 +52,12 @@ public class ChannelUpsertService(DiscordDbContext db, ILogger<ChannelUpsertServ
             "Inserting placeholder channel row for unresolvable thread DiscordId={DiscordId}; first orphan message seen at {FirstSeen}",
             channelDiscordId, firstOrphanSeenUtc);
 
-        try
-        {
-            var placeholder = new ChannelEntity
+        // Insert-or-get: a concurrent writer (or a real ChannelCreate) may have inserted the row
+        // first. On conflict we return the existing row UNTOUCHED — never overwrite a real channel
+        // with placeholder values.
+        var (channel, _) = await db.Channels.GetOrInsertAsync(
+            c => c.DiscordId == channelDiscordId,
+            () => new ChannelEntity
             {
                 DiscordId = channelDiscordId,
                 GuildId = guildId,
@@ -62,19 +65,11 @@ public class ChannelUpsertService(DiscordDbContext db, ILogger<ChannelUpsertServ
                 Type = ChannelType.PublicThread,
                 Position = 0,
                 IsDeleted = false
-            };
-            db.Channels.Add(placeholder);
-            await db.SaveChangesAsync();
-            return placeholder.Id;
-        }
-        catch (DbUpdateException ex) when (ex.InnerException is Npgsql.PostgresException { SqlState: "23505" })
-        {
-            db.ChangeTracker.Clear();
-            return await db.Channels
-                .Where(c => c.DiscordId == channelDiscordId)
-                .Select(c => c.Id)
-                .FirstAsync();
-        }
+            });
+
+        return channel?.Id
+            ?? throw new InvalidOperationException(
+                $"Placeholder channel {channelDiscordId} vanished after insert-or-get");
     }
 
     public async Task MarkDeletedAsync(ulong channelDiscordId, DateTime deletedAtUtc)

--- a/src/DiscordEventService/Services/EventHandlers/ChannelEventHandler.cs
+++ b/src/DiscordEventService/Services/EventHandlers/ChannelEventHandler.cs
@@ -1,3 +1,4 @@
+using DiscordEventService.Data;
 using DiscordEventService.Data.Entities.Core;
 using DiscordEventService.Data.Entities.Events;
 using DiscordEventService.Services.Pipeline;
@@ -36,38 +37,49 @@ public sealed class ChannelEventHandler(EventPipeline pipeline) :
                     RawEventJson = ctx.RawJson
                 };
 
-                var channelEntity = await ctx.Db.Channels
-                    .FirstOrDefaultAsync(c => c.DiscordId == e.Channel.Id);
-
-                if (channelEntity == null)
+                // Upsert the channel (handles the 23505 race internally) before staging the event,
+                // then commit channel + event together. ExecutionStrategy is required because
+                // EnableRetryOnFailure is configured on the DbContext.
+                var strategy = ctx.Db.Database.CreateExecutionStrategy();
+                await strategy.ExecuteAsync(async () =>
                 {
-                    channelEntity = new ChannelEntity
-                    {
-                        DiscordId = e.Channel.Id,
-                        GuildId = guildGuid
-                    };
-                    ctx.Db.Channels.Add(channelEntity);
-                }
+                    await using var tx = await ctx.Db.Database.BeginTransactionAsync();
 
-                UpdateChannelEntity(channelEntity, e.Channel);
-                ctx.Db.ChannelEvents.Add(NewChannelEvent());
+                    await ctx.Db.Channels.UpsertAsync(
+                        c => c.DiscordId == e.Channel.Id,
+                        s => s
+                            .SetProperty(c => c.Name, e.Channel.Name)
+                            .SetProperty(c => c.Type, (ChannelType)e.Channel.Type)
+                            .SetProperty(c => c.Topic, e.Channel.Topic)
+                            .SetProperty(c => c.Position, e.Channel.Position)
+                            .SetProperty(c => c.ParentDiscordId, e.Channel.ParentId)
+                            .SetProperty(c => c.Bitrate, e.Channel.Bitrate)
+                            .SetProperty(c => c.UserLimit, e.Channel.UserLimit)
+                            .SetProperty(c => c.RateLimitPerUser, e.Channel.PerUserRateLimit)
+                            .SetProperty(c => c.IsNsfw, e.Channel.IsNSFW)
+                            .SetProperty(c => c.IsDeleted, false)
+                            .SetProperty(c => c.DeletedAtUtc, (DateTime?)null),
+                        () => new ChannelEntity
+                        {
+                            DiscordId = e.Channel.Id,
+                            GuildId = guildGuid,
+                            Name = e.Channel.Name,
+                            Type = (ChannelType)e.Channel.Type,
+                            Topic = e.Channel.Topic,
+                            Position = e.Channel.Position,
+                            ParentDiscordId = e.Channel.ParentId,
+                            Bitrate = e.Channel.Bitrate,
+                            UserLimit = e.Channel.UserLimit,
+                            RateLimitPerUser = e.Channel.PerUserRateLimit,
+                            IsNsfw = e.Channel.IsNSFW,
+                            IsDeleted = false
+                        },
+                        c => c.Id);
 
-                try
-                {
-                    await ctx.Db.SaveChangesAsync();
-                }
-                catch (DbUpdateException dbEx) when (dbEx.InnerException is Npgsql.PostgresException { SqlState: "23505" })
-                {
-                    // Concurrent insert won the race. Re-fetch the now-existing row, update it, re-add the event.
-                    ctx.Db.ChangeTracker.Clear();
-                    var existing = await ctx.Db.Channels.FirstOrDefaultAsync(c => c.DiscordId == e.Channel.Id);
-                    if (existing != null)
-                    {
-                        UpdateChannelEntity(existing, e.Channel);
-                    }
                     ctx.Db.ChannelEvents.Add(NewChannelEvent());
                     await ctx.Db.SaveChangesAsync();
-                }
+                    await tx.CommitAsync();
+                });
             });
     }
 

--- a/src/DiscordEventService/Services/EventHandlers/ChannelEventHandler.cs
+++ b/src/DiscordEventService/Services/EventHandlers/ChannelEventHandler.cs
@@ -43,6 +43,9 @@ public sealed class ChannelEventHandler(EventPipeline pipeline) :
                 var strategy = ctx.Db.Database.CreateExecutionStrategy();
                 await strategy.ExecuteAsync(async () =>
                 {
+                    // Reset the tracker so an EnableRetryOnFailure retry doesn't re-stage entities
+                    // left Added by a rolled-back attempt.
+                    ctx.Db.ChangeTracker.Clear();
                     await using var tx = await ctx.Db.Database.BeginTransactionAsync();
 
                     await ctx.Db.Channels.UpsertAsync(

--- a/src/DiscordEventService/Services/EventHandlers/GuildEventHandler.cs
+++ b/src/DiscordEventService/Services/EventHandlers/GuildEventHandler.cs
@@ -22,80 +22,33 @@ public sealed class GuildEventHandler(EventPipeline pipeline) :
             {
                 ctx.Logger.LogInformation("GuildCreated event received for GuildId={GuildId} Name={GuildName}", e.Guild.Id, e.Guild.Name);
 
-                void ApplyGuildFields(GuildEntity g)
-                {
-                    g.Name = e.Guild.Name;
-                    g.IconHash = e.Guild.IconHash;
-                    g.OwnerId = e.Guild.OwnerId;
-                    g.LeftAtUtc = null;
-                }
-
-                // Wrap the two-stage upsert (Guild flush for Guid, then channels/roles) in
-                // one transaction so a partial failure (e.g. FK error on roles after Guild
-                // already flushed) rolls back atomically. ExecutionStrategy is required
-                // because EnableRetryOnFailure is configured on the DbContext.
+                // Upsert the guild (for its Guid) then every channel/role, all in one transaction
+                // so a partial failure rolls back atomically. Each upsert handles its own 23505
+                // race internally. ExecutionStrategy is required because EnableRetryOnFailure is
+                // configured on the DbContext.
                 var strategy = ctx.Db.Database.CreateExecutionStrategy();
                 await strategy.ExecuteAsync(async () =>
                 {
-                    ctx.Db.ChangeTracker.Clear();
                     await using var tx = await ctx.Db.Database.BeginTransactionAsync();
 
-                    var existingGuild = await ctx.Db.Guilds
-                        .Where(g => g.DiscordId == e.Guild.Id)
-                        .FirstOrDefaultAsync();
-                    if (existingGuild == null)
-                    {
-                        existingGuild = new GuildEntity
+                    var guildGuid = await ctx.Db.Guilds.UpsertAsync(
+                        g => g.DiscordId == e.Guild.Id,
+                        s => s
+                            .SetProperty(g => g.Name, e.Guild.Name)
+                            .SetProperty(g => g.IconHash, e.Guild.IconHash)
+                            .SetProperty(g => g.OwnerId, e.Guild.OwnerId)
+                            .SetProperty(g => g.LeftAtUtc, (DateTime?)null),
+                        () => new GuildEntity
                         {
                             DiscordId = e.Guild.Id,
                             Name = e.Guild.Name,
                             IconHash = e.Guild.IconHash,
                             OwnerId = e.Guild.OwnerId,
                             LeftAtUtc = null
-                        };
-                        ctx.Db.Guilds.Add(existingGuild);
-                        try
-                        {
-                            await ctx.Db.SaveChangesAsync(); // Flush to get the Guid Id (committed atomically with the rest at tx.CommitAsync).
-                        }
-                        catch (DbUpdateException dbEx) when (dbEx.InnerException is Npgsql.PostgresException { SqlState: "23505" })
-                        {
-                            // Concurrent insert won the race. Re-fetch and update.
-                            ctx.Db.ChangeTracker.Clear();
-                            existingGuild = await ctx.Db.Guilds
-                                .Where(g => g.DiscordId == e.Guild.Id)
-                                .FirstOrDefaultAsync()
-                                ?? throw new InvalidOperationException($"Guild {e.Guild.Id} disappeared after 23505 conflict");
-                            ApplyGuildFields(existingGuild);
-                        }
-                    }
-                    else
-                    {
-                        ApplyGuildFields(existingGuild);
-                    }
-
-                    var guildGuid = existingGuild.Id;
+                        },
+                        g => g.Id);
 
                     await UpsertChannelsAndRolesAsync(ctx.Db, ctx.Logger, e.Guild, guildGuid);
-
-                    try
-                    {
-                        await ctx.Db.SaveChangesAsync();
-                    }
-                    catch (DbUpdateException dbEx) when (dbEx.InnerException is Npgsql.PostgresException { SqlState: "23505" })
-                    {
-                        // Concurrent GuildCreated inserted a channel/role that wasn't in our batch lookup.
-                        // Clear drops the Guild field updates set above, so re-fetch and re-apply them
-                        // alongside the channel/role re-batch-load before saving.
-                        ctx.Db.ChangeTracker.Clear();
-                        var refreshedGuild = await ctx.Db.Guilds.FirstOrDefaultAsync(g => g.DiscordId == e.Guild.Id);
-                        if (refreshedGuild != null)
-                        {
-                            ApplyGuildFields(refreshedGuild);
-                        }
-                        await UpsertChannelsAndRolesAsync(ctx.Db, ctx.Logger, e.Guild, guildGuid);
-                        await ctx.Db.SaveChangesAsync();
-                    }
 
                     await tx.CommitAsync();
                 });
@@ -199,23 +152,32 @@ public sealed class GuildEventHandler(EventPipeline pipeline) :
 
     private static async Task UpsertChannelsAndRolesAsync(DiscordDbContext db, ILogger logger, DiscordGuild guild, Guid guildGuid)
     {
-        // Batch load existing channels
-        var channelIds = guild.Channels.Keys.ToList();
-        var existingChannels = await db.Channels
-            .Where(c => channelIds.Contains(c.DiscordId))
-            .ToDictionaryAsync(c => c.DiscordId);
-
+        // Per-entity upsert: each channel/role goes through the shared primitive, which absorbs
+        // the 23505 race a concurrent GuildCreate could otherwise cause in a batched insert.
         foreach (var channel in guild.Channels.Values)
         {
-            if (!existingChannels.TryGetValue(channel.Id, out var existingChannel))
-            {
-                db.Channels.Add(new ChannelEntity
+            var mappedType = MapChannelType(channel.Type, logger);
+            await db.Channels.UpsertAsync(
+                c => c.DiscordId == channel.Id,
+                s => s
+                    .SetProperty(c => c.Name, channel.Name)
+                    .SetProperty(c => c.ParentDiscordId, channel.Parent?.Id)
+                    .SetProperty(c => c.Type, mappedType)
+                    .SetProperty(c => c.Topic, channel.Topic)
+                    .SetProperty(c => c.Bitrate, channel.Bitrate)
+                    .SetProperty(c => c.UserLimit, channel.UserLimit)
+                    .SetProperty(c => c.RateLimitPerUser, channel.PerUserRateLimit)
+                    .SetProperty(c => c.IsNsfw, false)
+                    .SetProperty(c => c.Position, channel.Position)
+                    .SetProperty(c => c.IsDeleted, false)
+                    .SetProperty(c => c.DeletedAtUtc, (DateTime?)null),
+                () => new ChannelEntity
                 {
                     DiscordId = channel.Id,
                     GuildId = guildGuid,
                     ParentDiscordId = channel.Parent?.Id,
                     Name = channel.Name,
-                    Type = MapChannelType(channel.Type, logger),
+                    Type = mappedType,
                     Topic = channel.Topic,
                     Bitrate = channel.Bitrate,
                     UserLimit = channel.UserLimit,
@@ -223,35 +185,26 @@ public sealed class GuildEventHandler(EventPipeline pipeline) :
                     IsNsfw = false,
                     Position = channel.Position,
                     IsDeleted = false
-                });
-            }
-            else
-            {
-                existingChannel.Name = channel.Name;
-                existingChannel.ParentDiscordId = channel.Parent?.Id;
-                existingChannel.Type = MapChannelType(channel.Type, logger);
-                existingChannel.Topic = channel.Topic;
-                existingChannel.Bitrate = channel.Bitrate;
-                existingChannel.UserLimit = channel.UserLimit;
-                existingChannel.RateLimitPerUser = channel.PerUserRateLimit;
-                existingChannel.IsNsfw = false;
-                existingChannel.Position = channel.Position;
-                existingChannel.IsDeleted = false;
-                existingChannel.DeletedAtUtc = null;
-            }
+                },
+                c => c.Id);
         }
-
-        // Batch load existing roles
-        var roleIds = guild.Roles.Keys.ToList();
-        var existingRoles = await db.Roles
-            .Where(r => roleIds.Contains(r.DiscordId))
-            .ToDictionaryAsync(r => r.DiscordId);
 
         foreach (var role in guild.Roles.Values)
         {
-            if (!existingRoles.TryGetValue(role.Id, out var existingRole))
-            {
-                db.Roles.Add(new RoleEntity
+            var permissions = long.TryParse(role.Permissions.ToString(), out var p) ? p : 0;
+            await db.Roles.UpsertAsync(
+                r => r.DiscordId == role.Id,
+                s => s
+                    .SetProperty(r => r.Name, role.Name)
+                    .SetProperty(r => r.Color, role.Color.Value)
+                    .SetProperty(r => r.IsHoisted, role.IsHoisted)
+                    .SetProperty(r => r.Position, role.Position)
+                    .SetProperty(r => r.Permissions, permissions)
+                    .SetProperty(r => r.IsManaged, role.IsManaged)
+                    .SetProperty(r => r.IsMentionable, role.IsMentionable)
+                    .SetProperty(r => r.IsDeleted, false)
+                    .SetProperty(r => r.DeletedAtUtc, (DateTime?)null),
+                () => new RoleEntity
                 {
                     DiscordId = role.Id,
                     GuildId = guildGuid,
@@ -259,24 +212,12 @@ public sealed class GuildEventHandler(EventPipeline pipeline) :
                     Color = role.Color.Value,
                     IsHoisted = role.IsHoisted,
                     Position = role.Position,
-                    Permissions = long.TryParse(role.Permissions.ToString(), out var p) ? p : 0,
+                    Permissions = permissions,
                     IsManaged = role.IsManaged,
                     IsMentionable = role.IsMentionable,
                     IsDeleted = false
-                });
-            }
-            else
-            {
-                existingRole.Name = role.Name;
-                existingRole.Color = role.Color.Value;
-                existingRole.IsHoisted = role.IsHoisted;
-                existingRole.Position = role.Position;
-                existingRole.Permissions = long.TryParse(role.Permissions.ToString(), out var perm) ? perm : 0;
-                existingRole.IsManaged = role.IsManaged;
-                existingRole.IsMentionable = role.IsMentionable;
-                existingRole.IsDeleted = false;
-                existingRole.DeletedAtUtc = null;
-            }
+                },
+                r => r.Id);
         }
     }
 

--- a/src/DiscordEventService/Services/EventHandlers/GuildEventHandler.cs
+++ b/src/DiscordEventService/Services/EventHandlers/GuildEventHandler.cs
@@ -29,6 +29,9 @@ public sealed class GuildEventHandler(EventPipeline pipeline) :
                 var strategy = ctx.Db.Database.CreateExecutionStrategy();
                 await strategy.ExecuteAsync(async () =>
                 {
+                    // Reset the tracker so an EnableRetryOnFailure retry doesn't re-stage entities
+                    // left Added by a rolled-back attempt.
+                    ctx.Db.ChangeTracker.Clear();
                     await using var tx = await ctx.Db.Database.BeginTransactionAsync();
 
                     var guildGuid = await ctx.Db.Guilds.UpsertAsync(

--- a/src/DiscordEventService/Services/EventHandlers/MemberEventHandler.cs
+++ b/src/DiscordEventService/Services/EventHandlers/MemberEventHandler.cs
@@ -176,23 +176,17 @@ public sealed class MemberEventHandler(EventPipeline pipeline) :
 
         foreach (var roleId in rolesAdded)
         {
-            try
-            {
-                db.MemberRoleSnapshots.Add(new MemberRoleSnapshotEntity
+            // Insert-or-ignore: an open snapshot for this (member, role) may already exist
+            // (filtered unique index). On conflict the existing snapshot is left untouched.
+            await db.MemberRoleSnapshots.GetOrInsertAsync(
+                s => s.MemberId == member.Id && s.RoleDiscordId == roleId && s.RevokedAtUtc == null,
+                () => new MemberRoleSnapshotEntity
                 {
                     MemberId = member.Id,
                     RoleDiscordId = roleId,
                     GrantedAtUtc = eventTime,
                     SourceEventId = sourceEventId
                 });
-                await db.SaveChangesAsync();
-            }
-            catch (DbUpdateException ex) when (ex.InnerException is Npgsql.PostgresException { SqlState: "23505" })
-            {
-                db.ChangeTracker.Clear();
-                logger.LogDebug("Duplicate role snapshot skipped: Member={MemberId} Role={RoleDiscordId}",
-                    member.Id, roleId);
-            }
         }
 
         foreach (var roleId in rolesRemoved)

--- a/src/DiscordEventService/Services/EventHandlers/MessageEventHandler.cs
+++ b/src/DiscordEventService/Services/EventHandlers/MessageEventHandler.cs
@@ -77,60 +77,40 @@ public sealed class MessageEventHandler(EventPipeline pipeline) :
                     RawEventJson = ctx.RawJson
                 };
 
-                // Wrap multi-row writes in a transaction so the 23505 retry path
-                // (ExecuteUpdate + insert) is atomic. ExecutionStrategy is required
-                // because EnableRetryOnFailure is configured on the DbContext.
+                // Wrap message + event + mentions in one transaction so they commit atomically.
+                // ExecutionStrategy is required because EnableRetryOnFailure is configured on the
+                // DbContext. MessageCreated is insert-or-ignore: a duplicate carries identical
+                // create-time content (edits arrive as MessageUpdated), so on a 23505 race the
+                // existing row is kept untouched and we just log the Created event.
                 var strategy = ctx.Db.Database.CreateExecutionStrategy();
                 await strategy.ExecuteAsync(async () =>
                 {
                     ctx.Db.ChangeTracker.Clear();
                     await using var tx = await ctx.Db.Database.BeginTransactionAsync();
 
-                    var messageEntity = new MessageEntity
-                    {
-                        DiscordId = e.Message.Id,
-                        ChannelId = channelId,
-                        GuildId = guildId,
-                        AuthorId = authorId,
-                        Content = NormalizeContent(e.Message.Content),
-                        ReplyToDiscordId = e.Message.ReferencedMessage?.Id,
-                        HasAttachments = e.Message.Attachments.Count > 0,
-                        HasEmbeds = e.Message.Embeds.Count > 0,
-                        AttachmentsJson = attachmentsJson,
-                        EmbedsJson = embedsJson,
-                        Flags = (int)(e.Message.Flags ?? 0),
-                        CreatedAtUtc = e.Message.Timestamp.UtcDateTime
-                    };
-                    ctx.Db.Messages.Add(messageEntity);
-                    ctx.Db.MessageEvents.Add(NewMessageEvent());
+                    // Insert the message first (before staging the event), so the primitive's
+                    // change-tracker clear on a conflict can't drop a pending event Add.
+                    var (messageEntity, _) = await ctx.Db.Messages.GetOrInsertAsync(
+                        m => m.DiscordId == e.Message.Id,
+                        () => new MessageEntity
+                        {
+                            DiscordId = e.Message.Id,
+                            ChannelId = channelId,
+                            GuildId = guildId,
+                            AuthorId = authorId,
+                            Content = NormalizeContent(e.Message.Content),
+                            ReplyToDiscordId = e.Message.ReferencedMessage?.Id,
+                            HasAttachments = e.Message.Attachments.Count > 0,
+                            HasEmbeds = e.Message.Embeds.Count > 0,
+                            AttachmentsJson = attachmentsJson,
+                            EmbedsJson = embedsJson,
+                            Flags = (int)(e.Message.Flags ?? 0),
+                            CreatedAtUtc = e.Message.Timestamp.UtcDateTime
+                        });
 
-                    Guid messageId;
-                    try
-                    {
-                        await ctx.Db.SaveChangesAsync();
-                        messageId = messageEntity.Id;
-                    }
-                    catch (DbUpdateException dbEx) when (dbEx.InnerException is Npgsql.PostgresException { SqlState: "23505" })
-                    {
-                        ctx.Db.ChangeTracker.Clear();
-                        var normalizedContent = NormalizeContent(e.Message.Content);
-                        await ctx.Db.Messages
-                            .Where(m => m.DiscordId == e.Message.Id)
-                            .ExecuteUpdateAsync(s => s
-                                .SetProperty(m => m.Content, normalizedContent)
-                                .SetProperty(m => m.HasAttachments, e.Message.Attachments.Count > 0)
-                                .SetProperty(m => m.HasEmbeds, e.Message.Embeds.Count > 0)
-                                .SetProperty(m => m.AttachmentsJson, attachmentsJson)
-                                .SetProperty(m => m.EmbedsJson, embedsJson)
-                                .SetProperty(m => m.Flags, (int)(e.Message.Flags ?? 0))
-                                .SetProperty(m => m.ReplyToDiscordId, e.Message.ReferencedMessage?.Id));
-                        ctx.Db.MessageEvents.Add(NewMessageEvent());
-                        await ctx.Db.SaveChangesAsync();
-                        messageId = await ctx.Db.Messages
-                            .Where(m => m.DiscordId == e.Message.Id)
-                            .Select(m => m.Id)
-                            .FirstAsync();
-                    }
+                    var messageId = messageEntity!.Id;
+                    ctx.Db.MessageEvents.Add(NewMessageEvent());
+                    await ctx.Db.SaveChangesAsync();
 
                     await ExtractAndSaveMentionsAsync(ctx.Db, messageId, e.Message);
                     await tx.CommitAsync();

--- a/src/DiscordEventService/Services/EventHandlers/RoleEventHandler.cs
+++ b/src/DiscordEventService/Services/EventHandlers/RoleEventHandler.cs
@@ -42,6 +42,9 @@ public sealed class RoleEventHandler(EventPipeline pipeline) :
                 var strategy = ctx.Db.Database.CreateExecutionStrategy();
                 await strategy.ExecuteAsync(async () =>
                 {
+                    // Reset the tracker so an EnableRetryOnFailure retry doesn't re-stage entities
+                    // left Added by a rolled-back attempt.
+                    ctx.Db.ChangeTracker.Clear();
                     await using var tx = await ctx.Db.Database.BeginTransactionAsync();
 
                     await ctx.Db.Roles.UpsertAsync(

--- a/src/DiscordEventService/Services/EventHandlers/RoleEventHandler.cs
+++ b/src/DiscordEventService/Services/EventHandlers/RoleEventHandler.cs
@@ -1,3 +1,4 @@
+using DiscordEventService.Data;
 using DiscordEventService.Data.Entities.Core;
 using DiscordEventService.Data.Entities.Events;
 using DiscordEventService.Services.Pipeline;
@@ -33,38 +34,47 @@ public sealed class RoleEventHandler(EventPipeline pipeline) :
                     RawEventJson = ctx.RawJson
                 };
 
-                var roleEntity = await ctx.Db.Roles
-                    .FirstOrDefaultAsync(r => r.DiscordId == e.Role.Id);
+                var permissions = long.TryParse(e.Role.Permissions.ToString(), out var perm) ? perm : 0;
 
-                if (roleEntity == null)
+                // Upsert the role (handles the 23505 race internally) before staging the event,
+                // then commit role + event together. ExecutionStrategy is required because
+                // EnableRetryOnFailure is configured on the DbContext.
+                var strategy = ctx.Db.Database.CreateExecutionStrategy();
+                await strategy.ExecuteAsync(async () =>
                 {
-                    roleEntity = new RoleEntity
-                    {
-                        DiscordId = e.Role.Id,
-                        GuildId = guildGuid
-                    };
-                    ctx.Db.Roles.Add(roleEntity);
-                }
+                    await using var tx = await ctx.Db.Database.BeginTransactionAsync();
 
-                UpdateRoleEntity(roleEntity, e.Role);
-                ctx.Db.RoleEvents.Add(NewRoleEvent());
+                    await ctx.Db.Roles.UpsertAsync(
+                        r => r.DiscordId == e.Role.Id,
+                        s => s
+                            .SetProperty(r => r.Name, e.Role.Name)
+                            .SetProperty(r => r.Color, e.Role.Color.Value)
+                            .SetProperty(r => r.IsHoisted, e.Role.IsHoisted)
+                            .SetProperty(r => r.Position, e.Role.Position)
+                            .SetProperty(r => r.Permissions, permissions)
+                            .SetProperty(r => r.IsManaged, e.Role.IsManaged)
+                            .SetProperty(r => r.IsMentionable, e.Role.IsMentionable)
+                            .SetProperty(r => r.IsDeleted, false)
+                            .SetProperty(r => r.DeletedAtUtc, (DateTime?)null),
+                        () => new RoleEntity
+                        {
+                            DiscordId = e.Role.Id,
+                            GuildId = guildGuid,
+                            Name = e.Role.Name,
+                            Color = e.Role.Color.Value,
+                            IsHoisted = e.Role.IsHoisted,
+                            Position = e.Role.Position,
+                            Permissions = permissions,
+                            IsManaged = e.Role.IsManaged,
+                            IsMentionable = e.Role.IsMentionable,
+                            IsDeleted = false
+                        },
+                        r => r.Id);
 
-                try
-                {
-                    await ctx.Db.SaveChangesAsync();
-                }
-                catch (DbUpdateException dbEx) when (dbEx.InnerException is Npgsql.PostgresException { SqlState: "23505" })
-                {
-                    // Concurrent insert won the race. Re-fetch, update, re-add the event.
-                    ctx.Db.ChangeTracker.Clear();
-                    var existing = await ctx.Db.Roles.FirstOrDefaultAsync(r => r.DiscordId == e.Role.Id);
-                    if (existing != null)
-                    {
-                        UpdateRoleEntity(existing, e.Role);
-                    }
                     ctx.Db.RoleEvents.Add(NewRoleEvent());
                     await ctx.Db.SaveChangesAsync();
-                }
+                    await tx.CommitAsync();
+                });
             });
     }
 

--- a/src/DiscordEventService/Services/MemberRoleSnapshotBackfillService.cs
+++ b/src/DiscordEventService/Services/MemberRoleSnapshotBackfillService.cs
@@ -77,22 +77,19 @@ public class MemberRoleSnapshotBackfillService(
                 if (openRoles.Contains(roleId))
                     continue;
 
-                try
-                {
-                    db.MemberRoleSnapshots.Add(new MemberRoleSnapshotEntity
+                // Insert-or-ignore: the openRoles pre-check skips known duplicates; this guards
+                // the rare race where a live event inserts the same open snapshot concurrently.
+                var (_, inserted) = await db.MemberRoleSnapshots.GetOrInsertAsync(
+                    s => s.MemberId == memberId && s.RoleDiscordId == roleId && s.RevokedAtUtc == null,
+                    () => new MemberRoleSnapshotEntity
                     {
                         MemberId = memberId,
                         RoleDiscordId = roleId,
                         GrantedAtUtc = evt.EventTimestampUtc,
                         SourceEventId = evt.Id
-                    });
-                    await db.SaveChangesAsync(ct);
-                    created++;
-                }
-                catch (DbUpdateException ex) when (ex.InnerException is Npgsql.PostgresException { SqlState: "23505" })
-                {
-                    db.ChangeTracker.Clear();
-                }
+                    },
+                    ct);
+                if (inserted) created++;
             }
 
             foreach (var roleId in rolesRemoved)
@@ -163,21 +160,18 @@ public class MemberRoleSnapshotBackfillService(
                     if (openRolesForMember.Contains(role.Id))
                         continue;
 
-                    try
-                    {
-                        db.MemberRoleSnapshots.Add(new MemberRoleSnapshotEntity
+                    // Insert-or-ignore: openRolesForMember pre-check skips known duplicates; this
+                    // guards the rare race where a live event inserts the same snapshot concurrently.
+                    var (_, inserted) = await db.MemberRoleSnapshots.GetOrInsertAsync(
+                        s => s.MemberId == memberId && s.RoleDiscordId == role.Id && s.RevokedAtUtc == null,
+                        () => new MemberRoleSnapshotEntity
                         {
                             MemberId = memberId,
                             RoleDiscordId = role.Id,
                             GrantedAtUtc = DateTime.UtcNow
-                        });
-                        await db.SaveChangesAsync(ct);
-                        seeded++;
-                    }
-                    catch (DbUpdateException ex) when (ex.InnerException is Npgsql.PostgresException { SqlState: "23505" })
-                    {
-                        db.ChangeTracker.Clear();
-                    }
+                        },
+                        ct);
+                    if (inserted) seeded++;
                 }
             }
         }

--- a/tests/DiscordEventService.Tests/GetOrInsertTests.cs
+++ b/tests/DiscordEventService.Tests/GetOrInsertTests.cs
@@ -1,0 +1,94 @@
+using DiscordEventService.Data;
+using DiscordEventService.Data.Entities.Core;
+using Microsoft.EntityFrameworkCore;
+using Xunit;
+
+namespace DiscordEventService.Tests;
+
+public sealed class GetOrInsertTests(PostgresFixture fixture) : IClassFixture<PostgresFixture>, IAsyncLifetime
+{
+    private DiscordDbContext _db = null!;
+
+    public async Task InitializeAsync()
+    {
+        _db = NewContext();
+        await _db.Database.MigrateAsync();
+        await _db.Guilds.ExecuteDeleteAsync();
+    }
+
+    public Task DisposeAsync() => _db.DisposeAsync().AsTask();
+
+    [Fact]
+    public async Task GetOrInsertAsync_WhenNew_InsertsAndReportsInserted()
+    {
+        var (entity, inserted) = await _db.Guilds.GetOrInsertAsync(
+            g => g.DiscordId == 100UL,
+            () => new GuildEntity { DiscordId = 100UL, Name = "Alpha" });
+
+        Assert.True(inserted);
+        Assert.NotNull(entity);
+        Assert.NotEqual(Guid.Empty, entity!.Id);
+
+        await using var verify = NewContext();
+        var row = await verify.Guilds.SingleAsync(g => g.DiscordId == 100UL);
+        Assert.Equal("Alpha", row.Name);
+    }
+
+    [Fact]
+    public async Task GetOrInsertAsync_WhenExists_ReturnsExistingRowUntouched()
+    {
+        _db.Guilds.Add(new GuildEntity { DiscordId = 200UL, Name = "Original" });
+        await _db.SaveChangesAsync();
+        var originalId = await _db.Guilds.Where(g => g.DiscordId == 200UL).Select(g => g.Id).SingleAsync();
+        _db.ChangeTracker.Clear();
+
+        // The factory collides on the unique DiscordId index → 23505 → existing row is returned
+        // WITHOUT being overwritten (the data-loss guard the placeholder/snapshot paths rely on).
+        var (entity, inserted) = await _db.Guilds.GetOrInsertAsync(
+            g => g.DiscordId == 200UL,
+            () => new GuildEntity { DiscordId = 200UL, Name = "SHOULD_NOT_OVERWRITE" });
+
+        Assert.False(inserted);
+        Assert.NotNull(entity);
+        Assert.Equal(originalId, entity!.Id);
+        Assert.Equal("Original", entity.Name);
+
+        await using var verify = NewContext();
+        var rows = await verify.Guilds.Where(g => g.DiscordId == 200UL).ToListAsync();
+        Assert.Single(rows);
+        Assert.Equal("Original", rows[0].Name);
+    }
+
+    [Fact]
+    public async Task GetOrInsertAsync_WhenConcurrent_CreatesSingleRowAndOneInserter()
+    {
+        const ulong discordId = 400UL;
+        var tasks = Enumerable.Range(0, 8).Select(async i =>
+        {
+            await using var ctx = NewContext();
+            return await ctx.Guilds.GetOrInsertAsync(
+                g => g.DiscordId == discordId,
+                () => new GuildEntity { DiscordId = discordId, Name = $"Concurrent-{i}" });
+        });
+
+        var results = await Task.WhenAll(tasks);
+
+        // Exactly one caller wins the insert; the rest observe the conflict and return the row.
+        Assert.Equal(1, results.Count(r => r.Inserted));
+        Assert.All(results, r => Assert.NotNull(r.Entity));
+        var ids = results.Select(r => r.Entity!.Id).Distinct().ToList();
+        Assert.Single(ids);
+
+        await using var verify = NewContext();
+        Assert.Equal(1, await verify.Guilds.CountAsync(g => g.DiscordId == discordId));
+    }
+
+    private DiscordDbContext NewContext()
+    {
+        var options = new DbContextOptionsBuilder<DiscordDbContext>()
+            .UseNpgsql(fixture.Container.GetConnectionString())
+            .UseSnakeCaseNamingConvention()
+            .Options;
+        return new DiscordDbContext(options);
+    }
+}


### PR DESCRIPTION
Closes #161 (§A2.3 of epic #154).

## What

Removes every hand-rolled `23505`/`ChangeTracker.Clear` retry block from the codebase. After this PR, `grep -rn 'SqlState: "23505"' src/` returns **only** the upsert-primitive file.

### New sibling primitive
`DbSetUpsertExtensions.GetOrInsertAsync<T>(match, create, ct)` — **insert-or-get**: inserts; on a 23505 race re-queries the existing row **without modifying it** (the data-loss guard that update-first `UpsertAsync` can't provide for placeholder/snapshot/create-only rows). Returns `(Entity, Inserted)` so callers can count real inserts. Both primitives gained an optional `CancellationToken`.

### Migrations
- **Group A — backfill jobs** (`Emojis/Stickers/Roles/Channels`): hand-rolled ExecuteUpdate-first + 23505 catch → `UpsertAsync`.
- **Group B — insert-or-ignore / insert-or-get** → `GetOrInsertAsync`:
  - `ChannelUpsertService.InsertPlaceholderAsync` (preserves the real row on conflict)
  - `MemberRoleSnapshot` inserts (`MemberEventHandler` + `MemberRoleSnapshotBackfillService` ×2; counters now exact via `Inserted`)
  - `MessageCreated` message insert (insert-or-ignore: a duplicate `MessageCreated` carries identical create-time content — edits arrive as `MessageUpdated`)
  - `BootQuickSyncService` message sync (now per-message; also fixes a latent `totalInserted` over-count when the old batch save was dropped on conflict)
- **Group C — genuine upsert + event row** → `UpsertAsync` called **before** staging the event, inside a tx so entity+event commit atomically:
  - `ChannelCreated`, `RoleCreated`, `GuildCreated`
  - `GuildCreated`'s channel/role **batch is now per-entity** `UpsertAsync` (eliminates the batch-level 23505 race class; trades ~4 round-trips for ~2×N on the cold-sync/boot path — accepted as a one-time, low-guild-count cost).

## Reviewer notes
- **New tx wrapper on `ChannelCreated`/`RoleCreated`:** these previously had no execution-strategy/transaction (one `SaveChanges`). Splitting the entity upsert (its own save) from the event-row save would lose atomicity, so a `CreateExecutionStrategy()` + `BeginTransactionAsync` wrapper was added to keep them atomic as before (strategy is required because `EnableRetryOnFailure` is configured). Trade-off: a transient failure *during commit* could in principle retry and append a duplicate audit-event row — low impact (event log is append-only, not deduped).
- The in-tx conflict path relies on EF's per-`SaveChanges` savepoint rollback — the same mechanism the already-deployed Message/Member/Guild handlers use.

## Testing
- **Build:** clean (8 pre-existing baseline warnings, no new ones).
- **Integration:** new `GetOrInsertTests` (Testcontainers, Postgres 18) pinning insert / untouched-on-conflict / 8-way-race → exactly one row + one inserter. Full suite **10/10 green**.
- **Live (dev bot + local Postgres, driven via Discord MCP):** GuildCreated cold-sync (update path, no dupes), MessageCreated, MessageUpdated, ChannelCreated, RoleCreated, member role add→snapshot insert, role remove→snapshot revoke. Every path: correct entity + exactly one event row, **0 errors / 23505 / aborted-transaction in the log**.

Also folds in the session's `CLAUDE.md` workflow-doc update (per request).

🤖 Generated with [Claude Code](https://claude.com/claude-code)