### PR TITLE
feat: typed UpsertResult<Guid> from upsert services, eliminate Guid.Empty signal (#163)

### DIFF
--- a/src/DiscordEventService/Services/BootQuickSyncService.cs
+++ b/src/DiscordEventService/Services/BootQuickSyncService.cs
@@ -59,8 +59,8 @@ public class BootQuickSyncService(
                 var guildUpsert = scope.ServiceProvider.GetRequiredService<GuildUpsertService>();
                 var channelUpsert = scope.ServiceProvider.GetRequiredService<ChannelUpsertService>();
 
-                var guildId = await guildUpsert.UpsertGuildAsync(guild);
-                var channelId = await channelUpsert.UpsertChannelAsync(channel, guildId);
+                var guildId = (await guildUpsert.UpsertGuildAsync(guild)).Value;
+                var channelId = (await channelUpsert.UpsertChannelAsync(channel, guildId)).Value;
 
                 var existingDiscordIds = await db.Messages
                     .Where(m => messages.Select(msg => msg.Id).Contains(m.DiscordId))
@@ -167,10 +167,10 @@ public class BootQuickSyncService(
 
         var guildGuid = await db.Guilds
             .Where(g => g.DiscordId == guild.Id)
-            .Select(g => g.Id)
+            .Select(g => (Guid?)g.Id)
             .FirstOrDefaultAsync();
 
-        if (guildGuid == Guid.Empty) return (0, 0);
+        if (guildGuid is null) return (0, 0);
 
         var members = new List<DiscordMember>();
         await foreach (var member in guild.GetAllMembersAsync())
@@ -185,13 +185,9 @@ public class BootQuickSyncService(
                 var presence = member.Presence;
                 if (presence is null) continue;
 
-                await userService.UpsertUserAsync(member);
-                var userGuid = await db.Users
-                    .Where(u => u.DiscordId == member.Id)
-                    .Select(u => u.Id)
-                    .FirstOrDefaultAsync();
-
-                if (userGuid == Guid.Empty) continue;
+                var userResult = await userService.UpsertUserAsync(member);
+                if (!userResult.IsSuccess) continue;
+                var userGuid = userResult.Value;
 
                 var activitiesJson = SerializeActivities(presence.Activities);
 
@@ -225,7 +221,7 @@ public class BootQuickSyncService(
                             db.Activities.Add(new ActivityEntity
                             {
                                 UserId = userGuid,
-                                GuildId = guildGuid,
+                                GuildId = guildGuid.Value,
                                 ActivityType = (int)activity.ActivityType,
                                 Name = activity.Name,
                                 StreamUrl = activity.StreamUrl,

--- a/src/DiscordEventService/Services/ChannelUpsertService.cs
+++ b/src/DiscordEventService/Services/ChannelUpsertService.cs
@@ -7,7 +7,7 @@ namespace DiscordEventService.Services;
 
 public class ChannelUpsertService(DiscordDbContext db, ILogger<ChannelUpsertService> logger)
 {
-    public async Task<Guid> UpsertChannelAsync(DiscordChannel channel, Guid guildId)
+    public async Task<UpsertResult<Guid>> UpsertChannelAsync(DiscordChannel channel, Guid guildId)
     {
         var id = await db.Channels.UpsertAsync(
             c => c.DiscordId == channel.Id,
@@ -41,9 +41,10 @@ public class ChannelUpsertService(DiscordDbContext db, ILogger<ChannelUpsertServ
         if (id == Guid.Empty)
         {
             logger.LogError("ChannelUpsert lost the row for DiscordId={DiscordId} after upsert", channel.Id);
+            return UpsertResult<Guid>.Failure($"Channel upsert lost the row for DiscordId={channel.Id}");
         }
 
-        return id;
+        return UpsertResult<Guid>.Success(id);
     }
 
     public async Task<Guid> InsertPlaceholderAsync(ulong channelDiscordId, Guid guildId, DateTime firstOrphanSeenUtc)

--- a/src/DiscordEventService/Services/EventHandlers/AutoModRuleEventHandler.cs
+++ b/src/DiscordEventService/Services/EventHandlers/AutoModRuleEventHandler.cs
@@ -25,19 +25,16 @@ public sealed class AutoModRuleEventHandler(EventPipeline pipeline) :
                 if (e.Rule.Guild != null)
                 {
                     var guildUpsert = ctx.Services.GetRequiredService<GuildUpsertService>();
-                    var id = await guildUpsert.UpsertGuildAsync(e.Rule.Guild);
-                    guildGuid = id != Guid.Empty ? id : null;
+                    var guildResult = await guildUpsert.UpsertGuildAsync(e.Rule.Guild);
+                    guildGuid = guildResult.IsSuccess ? guildResult.Value : null;
                 }
 
                 Guid? creatorGuid = null;
                 if (e.Rule.Creator != null)
                 {
                     var userService = ctx.Services.GetRequiredService<UserService>();
-                    await userService.UpsertUserAsync(e.Rule.Creator);
-                    creatorGuid = await ctx.Db.Users
-                        .Where(u => u.DiscordId == e.Rule.Creator.Id)
-                        .Select(u => (Guid?)u.Id)
-                        .FirstOrDefaultAsync();
+                    var creatorResult = await userService.UpsertUserAsync(e.Rule.Creator);
+                    creatorGuid = creatorResult.IsSuccess ? creatorResult.Value : null;
                 }
 
                 ctx.Db.AutoModRules.Add(new AutoModRuleEntity

--- a/src/DiscordEventService/Services/EventHandlers/BanEventHandler.cs
+++ b/src/DiscordEventService/Services/EventHandlers/BanEventHandler.cs
@@ -19,15 +19,14 @@ public sealed class BanEventHandler(EventPipeline pipeline) :
                 var guildUpsert = ctx.Services.GetRequiredService<GuildUpsertService>();
                 var userService = ctx.Services.GetRequiredService<UserService>();
 
-                var guildGuid = await guildUpsert.UpsertGuildAsync(e.Guild);
-                await userService.UpsertUserAsync(e.Member);
-                var userGuid = await ctx.Db.Users
-                    .Where(u => u.DiscordId == e.Member.Id)
-                    .Select(u => u.Id)
-                    .FirstOrDefaultAsync();
+                var guildResult = await guildUpsert.UpsertGuildAsync(e.Guild);
+                var userResult = await userService.UpsertUserAsync(e.Member);
 
-                if (guildGuid != Guid.Empty && userGuid != Guid.Empty)
+                if (guildResult.IsSuccess && userResult.IsSuccess)
                 {
+                    var guildGuid = guildResult.Value;
+                    var userGuid = userResult.Value;
+
                     var existingBan = await ctx.Db.Bans
                         .FirstOrDefaultAsync(b => b.GuildId == guildGuid && b.UserId == userGuid && b.IsActive);
 
@@ -65,15 +64,14 @@ public sealed class BanEventHandler(EventPipeline pipeline) :
                 var guildUpsert = ctx.Services.GetRequiredService<GuildUpsertService>();
                 var userService = ctx.Services.GetRequiredService<UserService>();
 
-                var guildGuid = await guildUpsert.UpsertGuildAsync(e.Guild);
-                await userService.UpsertUserAsync(e.Member);
-                var userGuid = await ctx.Db.Users
-                    .Where(u => u.DiscordId == e.Member.Id)
-                    .Select(u => u.Id)
-                    .FirstOrDefaultAsync();
+                var guildResult = await guildUpsert.UpsertGuildAsync(e.Guild);
+                var userResult = await userService.UpsertUserAsync(e.Member);
 
-                if (guildGuid != Guid.Empty && userGuid != Guid.Empty)
+                if (guildResult.IsSuccess && userResult.IsSuccess)
                 {
+                    var guildGuid = guildResult.Value;
+                    var userGuid = userResult.Value;
+
                     await ctx.Db.Bans
                         .Where(b => b.GuildId == guildGuid && b.UserId == userGuid && b.IsActive)
                         .ExecuteUpdateAsync(s => s

--- a/src/DiscordEventService/Services/EventHandlers/ChannelEventHandler.cs
+++ b/src/DiscordEventService/Services/EventHandlers/ChannelEventHandler.cs
@@ -21,7 +21,7 @@ public sealed class ChannelEventHandler(EventPipeline pipeline) :
             e.Guild.Id, e.Channel.Id, null, async ctx =>
             {
                 var guildUpsert = ctx.Services.GetRequiredService<GuildUpsertService>();
-                var guildGuid = await guildUpsert.UpsertGuildAsync(e.Guild);
+                var guildGuid = (await guildUpsert.UpsertGuildAsync(e.Guild)).Value;
 
                 ChannelEventEntity NewChannelEvent() => new()
                 {

--- a/src/DiscordEventService/Services/EventHandlers/EmojiEventHandler.cs
+++ b/src/DiscordEventService/Services/EventHandlers/EmojiEventHandler.cs
@@ -17,7 +17,8 @@ public sealed class EmojiEventHandler(EventPipeline pipeline) :
             e.Guild.Id, null, null, async ctx =>
             {
                 var guildUpsert = ctx.Services.GetRequiredService<GuildUpsertService>();
-                var guildGuid = await guildUpsert.UpsertGuildAsync(e.Guild);
+                var guildResult = await guildUpsert.UpsertGuildAsync(e.Guild);
+                var guildGuid = guildResult.IsSuccess ? guildResult.Value : (Guid?)null;
 
                 var beforeIds = e.EmojisBefore.Keys.ToHashSet();
                 var afterIds = e.EmojisAfter.Keys.ToHashSet();
@@ -38,7 +39,7 @@ public sealed class EmojiEventHandler(EventPipeline pipeline) :
                         ctx.Db.Emotes.Add(new EmoteEntity
                         {
                             DiscordId = emoji.Id,
-                            GuildId = guildGuid != Guid.Empty ? guildGuid : null,
+                            GuildId = guildGuid,
                             Name = emoji.Name,
                             IsAnimated = emoji.IsAnimated,
                             IsAvailable = emoji.IsAvailable

--- a/src/DiscordEventService/Services/EventHandlers/IntegrationEventHandler.cs
+++ b/src/DiscordEventService/Services/EventHandlers/IntegrationEventHandler.cs
@@ -18,7 +18,7 @@ public sealed class IntegrationEventHandler(EventPipeline pipeline) :
             e.Guild.Id, null, null, async ctx =>
             {
                 var guildUpsert = ctx.Services.GetRequiredService<GuildUpsertService>();
-                var guildGuid = await guildUpsert.UpsertGuildAsync(e.Guild);
+                var guildGuid = (await guildUpsert.UpsertGuildAsync(e.Guild)).Value;
 
                 ctx.Db.Integrations.Add(new IntegrationEntity
                 {

--- a/src/DiscordEventService/Services/EventHandlers/InviteEventHandler.cs
+++ b/src/DiscordEventService/Services/EventHandlers/InviteEventHandler.cs
@@ -20,16 +20,13 @@ public sealed class InviteEventHandler(EventPipeline pipeline) :
                 var channelUpsert = ctx.Services.GetRequiredService<ChannelUpsertService>();
                 var userService = ctx.Services.GetRequiredService<UserService>();
 
-                var guildGuid = await guildUpsert.UpsertGuildAsync(e.Guild);
-                var channelGuid = await channelUpsert.UpsertChannelAsync(e.Channel, guildGuid);
+                var guildResult = await guildUpsert.UpsertGuildAsync(e.Guild);
+                var channelResult = await channelUpsert.UpsertChannelAsync(e.Channel, guildResult.Value);
                 Guid? inviterGuid = null;
                 if (e.Invite.Inviter != null)
                 {
-                    await userService.UpsertUserAsync(e.Invite.Inviter);
-                    inviterGuid = await ctx.Db.Users
-                        .Where(u => u.DiscordId == e.Invite.Inviter.Id)
-                        .Select(u => u.Id)
-                        .FirstOrDefaultAsync();
+                    var inviterResult = await userService.UpsertUserAsync(e.Invite.Inviter);
+                    inviterGuid = inviterResult.IsSuccess ? inviterResult.Value : null;
                 }
 
                 var invite = e.Invite;
@@ -40,8 +37,8 @@ public sealed class InviteEventHandler(EventPipeline pipeline) :
                     ctx.Db.Invites.Add(inviteEntity);
                 }
 
-                if (guildGuid != Guid.Empty) inviteEntity.GuildId = guildGuid;
-                if (channelGuid != Guid.Empty) inviteEntity.ChannelId = channelGuid;
+                if (guildResult.IsSuccess) inviteEntity.GuildId = guildResult.Value;
+                if (channelResult.IsSuccess) inviteEntity.ChannelId = channelResult.Value;
                 inviteEntity.InviterId = inviterGuid;
                 inviteEntity.MaxAge = invite.MaxAge;
                 inviteEntity.MaxUses = invite.MaxUses;

--- a/src/DiscordEventService/Services/EventHandlers/MessageEventHandler.cs
+++ b/src/DiscordEventService/Services/EventHandlers/MessageEventHandler.cs
@@ -28,7 +28,7 @@ public sealed class MessageEventHandler(EventPipeline pipeline) :
                 var guildUpsert = ctx.Services.GetRequiredService<GuildUpsertService>();
                 var channelUpsert = ctx.Services.GetRequiredService<ChannelUpsertService>();
 
-                await userService.UpsertUserAsync(e.Author);
+                var authorResult = await userService.UpsertUserAsync(e.Author);
 
                 var attachmentsJson = e.Message.Attachments.Count > 0
                     ? JsonSerializer.Serialize(e.Message.Attachments.Select(a => new { a.Id, a.Url, a.FileName, a.FileSize }))
@@ -42,22 +42,22 @@ public sealed class MessageEventHandler(EventPipeline pipeline) :
                 // the channel (a thread) wasn't yet in our DB. §P1.9 closes that hole; §P2.6 (#74)
                 // makes the FKs NOT NULL so any regression in the upsert services becomes a loud
                 // skip + FailedEvent instead of a silent NULL FK row.
-                var guildId = await guildUpsert.UpsertGuildAsync(e.Guild);
-                var channelId = await channelUpsert.UpsertChannelAsync(e.Channel, guildId);
-                var authorId = await ctx.Db.Users
-                    .Where(u => u.DiscordId == e.Author.Id)
-                    .Select(u => u.Id)
-                    .FirstOrDefaultAsync();
+                var guildResult = await guildUpsert.UpsertGuildAsync(e.Guild);
+                var channelResult = await channelUpsert.UpsertChannelAsync(e.Channel, guildResult.Value);
 
-                if (guildId == Guid.Empty || channelId == Guid.Empty || authorId == Guid.Empty)
+                if (!guildResult.IsSuccess || !channelResult.IsSuccess || !authorResult.IsSuccess)
                 {
                     ctx.Logger.LogError(
-                        "MessageCreated: could not resolve required FKs for MessageId={MessageId} (guildId={GuildId} channelId={ChannelId} authorId={AuthorId}); skipping insert",
-                        e.Message.Id, guildId, channelId, authorId);
+                        "MessageCreated: could not resolve required FKs for MessageId={MessageId} (guildResolved={GuildResolved} channelResolved={ChannelResolved} authorResolved={AuthorResolved}); skipping insert",
+                        e.Message.Id, guildResult.IsSuccess, channelResult.IsSuccess, authorResult.IsSuccess);
                     await ctx.RecordFailureAsync(new InvalidOperationException(
-                        $"Required FK not resolved: guild={guildId} channel={channelId} author={authorId}"));
+                        $"Required FK not resolved: guildResolved={guildResult.IsSuccess} channelResolved={channelResult.IsSuccess} authorResolved={authorResult.IsSuccess}"));
                     return;
                 }
+
+                var guildId = guildResult.Value;
+                var channelId = channelResult.Value;
+                var authorId = authorResult.Value;
 
                 MessageEventEntity NewMessageEvent() => new()
                 {

--- a/src/DiscordEventService/Services/EventHandlers/PresenceEventHandler.cs
+++ b/src/DiscordEventService/Services/EventHandlers/PresenceEventHandler.cs
@@ -75,15 +75,11 @@ public sealed class PresenceEventHandler(EventPipeline pipeline) :
                 // Track activities in ActivityEntity — upsert the user first so we never silently
                 // skip activity tracking for unknown users (87k presence events historically).
                 var userService = ctx.Services.GetRequiredService<UserService>();
-                await userService.UpsertUserAsync(args.User);
-                var userGuid = await ctx.Db.Users
-                    .Where(u => u.DiscordId == args.User.Id)
-                    .Select(u => u.Id)
-                    .FirstOrDefaultAsync();
+                var userResult = await userService.UpsertUserAsync(args.User);
 
-                if (userGuid != Guid.Empty)
+                if (userResult.IsSuccess)
                 {
-                    await UpdateActivityTracking(ctx.Db, userGuid, args.PresenceBefore?.Activities, args.PresenceAfter?.Activities, ctx.ReceivedAtUtc);
+                    await UpdateActivityTracking(ctx.Db, userResult.Value, args.PresenceBefore?.Activities, args.PresenceAfter?.Activities, ctx.ReceivedAtUtc);
                     await ctx.Db.SaveChangesAsync();
                 }
                 else

--- a/src/DiscordEventService/Services/EventHandlers/RoleEventHandler.cs
+++ b/src/DiscordEventService/Services/EventHandlers/RoleEventHandler.cs
@@ -20,7 +20,7 @@ public sealed class RoleEventHandler(EventPipeline pipeline) :
             e.Guild.Id, null, null, async ctx =>
             {
                 var guildUpsert = ctx.Services.GetRequiredService<GuildUpsertService>();
-                var guildGuid = await guildUpsert.UpsertGuildAsync(e.Guild);
+                var guildGuid = (await guildUpsert.UpsertGuildAsync(e.Guild)).Value;
 
                 RoleEventEntity NewRoleEvent() => new()
                 {

--- a/src/DiscordEventService/Services/EventHandlers/StickerEventHandler.cs
+++ b/src/DiscordEventService/Services/EventHandlers/StickerEventHandler.cs
@@ -17,7 +17,8 @@ public sealed class StickerEventHandler(EventPipeline pipeline) :
             e.Guild.Id, null, null, async ctx =>
             {
                 var guildUpsert = ctx.Services.GetRequiredService<GuildUpsertService>();
-                var guildGuid = await guildUpsert.UpsertGuildAsync(e.Guild);
+                var guildResult = await guildUpsert.UpsertGuildAsync(e.Guild);
+                var guildGuid = guildResult.IsSuccess ? guildResult.Value : (Guid?)null;
 
                 var beforeIds = e.StickersBefore.Keys.ToHashSet();
                 var afterIds = e.StickersAfter.Keys.ToHashSet();
@@ -37,7 +38,7 @@ public sealed class StickerEventHandler(EventPipeline pipeline) :
                         ctx.Db.Stickers.Add(new StickerEntity
                         {
                             DiscordId = sticker.Id,
-                            GuildId = guildGuid != Guid.Empty ? guildGuid : null,
+                            GuildId = guildGuid,
                             Name = sticker.Name ?? string.Empty,
                             Description = sticker.Description,
                             Tags = sticker.Tags != null ? string.Join(",", sticker.Tags) : null,

--- a/src/DiscordEventService/Services/EventHandlers/ThreadEventHandler.cs
+++ b/src/DiscordEventService/Services/EventHandlers/ThreadEventHandler.cs
@@ -23,7 +23,7 @@ public sealed class ThreadEventHandler(EventPipeline pipeline) :
 
                 // Threads are channels (ADR-0003): upsert the thread into `channels` so messages
                 // sent into it have a non-null channel_id from the first event onward.
-                var guildId = await guildUpsert.UpsertGuildAsync(e.Guild);
+                var guildId = (await guildUpsert.UpsertGuildAsync(e.Guild)).Value;
                 await channelUpsert.UpsertChannelAsync(e.Thread, guildId);
 
                 // For message threads (parent is text/news), thread ID == starter message ID
@@ -57,7 +57,7 @@ public sealed class ThreadEventHandler(EventPipeline pipeline) :
                 var guildUpsert = ctx.Services.GetRequiredService<GuildUpsertService>();
                 var channelUpsert = ctx.Services.GetRequiredService<ChannelUpsertService>();
 
-                var guildId = await guildUpsert.UpsertGuildAsync(e.Guild);
+                var guildId = (await guildUpsert.UpsertGuildAsync(e.Guild)).Value;
                 await channelUpsert.UpsertChannelAsync(e.ThreadAfter, guildId);
 
                 ctx.Db.ThreadEvents.Add(new ThreadEventEntity

--- a/src/DiscordEventService/Services/GuildUpsertService.cs
+++ b/src/DiscordEventService/Services/GuildUpsertService.cs
@@ -6,7 +6,7 @@ namespace DiscordEventService.Services;
 
 public class GuildUpsertService(DiscordDbContext db, ILogger<GuildUpsertService> logger)
 {
-    public async Task<Guid> UpsertGuildAsync(DiscordGuild guild)
+    public async Task<UpsertResult<Guid>> UpsertGuildAsync(DiscordGuild guild)
     {
         var id = await db.Guilds.UpsertAsync(
             g => g.DiscordId == guild.Id,
@@ -27,8 +27,9 @@ public class GuildUpsertService(DiscordDbContext db, ILogger<GuildUpsertService>
         if (id == Guid.Empty)
         {
             logger.LogError("GuildUpsert lost the row for DiscordId={DiscordId} after upsert", guild.Id);
+            return UpsertResult<Guid>.Failure($"Guild upsert lost the row for DiscordId={guild.Id}");
         }
 
-        return id;
+        return UpsertResult<Guid>.Success(id);
     }
 }

--- a/src/DiscordEventService/Services/ThreadChannelBackfillService.cs
+++ b/src/DiscordEventService/Services/ThreadChannelBackfillService.cs
@@ -75,12 +75,12 @@ public class ThreadChannelBackfillService(
         {
             var existing = await db.Channels
                 .Where(c => c.DiscordId == entry.ChannelDiscordId)
-                .Select(c => c.Id)
+                .Select(c => (Guid?)c.Id)
                 .FirstOrDefaultAsync(ct);
 
-            if (existing != Guid.Empty)
+            if (existing is not null)
             {
-                resolvedChannelGuids[entry.ChannelDiscordId] = existing;
+                resolvedChannelGuids[entry.ChannelDiscordId] = existing.Value;
                 continue;
             }
 
@@ -93,10 +93,10 @@ public class ThreadChannelBackfillService(
             var guildDiscordId = entry.GuildDiscordIds[0];
             var guildGuid = await db.Guilds
                 .Where(g => g.DiscordId == guildDiscordId)
-                .Select(g => g.Id)
+                .Select(g => (Guid?)g.Id)
                 .FirstOrDefaultAsync(ct);
 
-            if (guildGuid == Guid.Empty)
+            if (guildGuid is null)
             {
                 logger.LogError(
                     "Guild {GuildDiscordId} for orphan channel {ChannelDiscordId} not present in DB; skipping",
@@ -107,7 +107,7 @@ public class ThreadChannelBackfillService(
             try
             {
                 var live = await client.GetChannelAsync(entry.ChannelDiscordId);
-                var id = await channelUpsert.UpsertChannelAsync(live, guildGuid);
+                var id = (await channelUpsert.UpsertChannelAsync(live, guildGuid.Value)).Value;
                 resolvedChannelGuids[entry.ChannelDiscordId] = id;
                 fetched++;
                 logger.LogInformation("Backfilled channel {DiscordId} via Discord API as {Type}", entry.ChannelDiscordId, live.Type);
@@ -129,7 +129,7 @@ public class ThreadChannelBackfillService(
             var firstOrphan = orphans
                 .Where(o => orphanResolution.TryGetValue(o.Id, out var c) && c.ChannelDiscordId == entry.ChannelDiscordId)
                 .Min(o => o.FirstSeenUtc);
-            var placeholderId = await channelUpsert.InsertPlaceholderAsync(entry.ChannelDiscordId, guildGuid, firstOrphan);
+            var placeholderId = await channelUpsert.InsertPlaceholderAsync(entry.ChannelDiscordId, guildGuid.Value, firstOrphan);
             resolvedChannelGuids[entry.ChannelDiscordId] = placeholderId;
             placeholders++;
         }

--- a/src/DiscordEventService/Services/UpsertResult.cs
+++ b/src/DiscordEventService/Services/UpsertResult.cs
@@ -1,0 +1,13 @@
+namespace DiscordEventService.Services;
+
+/// <summary>
+/// Outcome of an upsert: success carries the resolved <typeparamref name="T"/>; failure carries a
+/// reason (already logged by the service). Replaces the prior <c>Guid.Empty</c>-as-error sentinel so
+/// callers branch on <see cref="IsSuccess"/> instead of pattern-matching a magic value.
+/// </summary>
+public sealed record UpsertResult<T>(bool IsSuccess, T? Value, string? FailureReason)
+{
+    public static UpsertResult<T> Success(T value) => new(true, value, null);
+
+    public static UpsertResult<T> Failure(string reason) => new(false, default, reason);
+}

--- a/src/DiscordEventService/Services/UserService.cs
+++ b/src/DiscordEventService/Services/UserService.cs
@@ -7,7 +7,7 @@ namespace DiscordEventService.Services;
 
 public class UserService(DiscordDbContext db, ILogger<UserService> logger)
 {
-    public async Task UpsertUserAsync(DiscordUser user)
+    public async Task<UpsertResult<Guid>> UpsertUserAsync(DiscordUser user)
     {
         // Pre-query old values for name-history detection: the primitive only does the write,
         // and on a 23505 race we have no reliable "before" to compare against (matches insert path).
@@ -16,7 +16,7 @@ public class UserService(DiscordDbContext db, ILogger<UserService> logger)
             .Select(u => new { u.Id, u.Username, u.GlobalName })
             .FirstOrDefaultAsync();
 
-        await db.Users.UpsertAsync(
+        var id = await db.Users.UpsertAsync(
             u => u.DiscordId == user.Id,
             s => s
                 .SetProperty(u => u.Username, user.Username)
@@ -35,9 +35,15 @@ public class UserService(DiscordDbContext db, ILogger<UserService> logger)
             },
             u => u.Id);
 
+        if (id == Guid.Empty)
+        {
+            logger.LogError("UserUpsert lost the row for DiscordId={DiscordId} after upsert", user.Id);
+            return UpsertResult<Guid>.Failure($"User upsert lost the row for DiscordId={user.Id}");
+        }
+
         if (existing is null)
         {
-            return;
+            return UpsertResult<Guid>.Success(id);
         }
 
         var usernameChanged = existing.Username != user.Username;
@@ -65,25 +71,31 @@ public class UserService(DiscordDbContext db, ILogger<UserService> logger)
                 globalNameChanged ? existing.GlobalName : "(unchanged)",
                 globalNameChanged ? user.GlobalName : "(unchanged)");
         }
+
+        return UpsertResult<Guid>.Success(id);
     }
 
     public async Task UpsertMemberAsync(DiscordMember member)
     {
-        await UpsertUserAsync(member);
+        var userResult = await UpsertUserAsync(member);
 
-        // Get the User and Guild Guids
-        var userEntity = await db.Users.FirstOrDefaultAsync(u => u.DiscordId == member.Id);
-        var guildEntity = await db.Guilds.FirstOrDefaultAsync(g => g.DiscordId == member.Guild.Id);
+        // User Guid comes back from the upsert; the guild must already exist (we don't upsert it here).
+        var guildId = await db.Guilds
+            .Where(g => g.DiscordId == member.Guild.Id)
+            .Select(g => g.Id)
+            .FirstOrDefaultAsync();
 
-        if (userEntity is null || guildEntity is null)
+        if (!userResult.IsSuccess || guildId == Guid.Empty)
         {
-            logger.LogWarning("Cannot upsert member: User={UserFound} Guild={GuildFound} for MemberId={MemberId} GuildId={GuildId}",
-                userEntity != null, guildEntity != null, member.Id, member.Guild.Id);
+            logger.LogWarning("Cannot upsert member: User={UserResolved} Guild={GuildResolved} for MemberId={MemberId} GuildId={GuildId}",
+                userResult.IsSuccess, guildId != Guid.Empty, member.Id, member.Guild.Id);
             return;
         }
 
+        var userId = userResult.Value;
+
         await db.Members.UpsertAsync(
-            m => m.UserId == userEntity.Id && m.GuildId == guildEntity.Id,
+            m => m.UserId == userId && m.GuildId == guildId,
             s => s
                 .SetProperty(m => m.Nickname, member.Nickname)
                 .SetProperty(m => m.GuildAvatarHash, member.GuildAvatarHash)
@@ -94,8 +106,8 @@ public class UserService(DiscordDbContext db, ILogger<UserService> logger)
                 .SetProperty(m => m.TimeoutUntilUtc, member.CommunicationDisabledUntil != null ? member.CommunicationDisabledUntil.Value.UtcDateTime : (DateTime?)null),
             () => new MemberEntity
             {
-                UserId = userEntity.Id,
-                GuildId = guildEntity.Id,
+                UserId = userId,
+                GuildId = guildId,
                 Nickname = member.Nickname,
                 GuildAvatarHash = member.GuildAvatarHash,
                 JoinedAtUtc = member.JoinedAt.UtcDateTime,

--- a/tests/DiscordEventService.Tests/UpsertResultTests.cs
+++ b/tests/DiscordEventService.Tests/UpsertResultTests.cs
@@ -1,0 +1,29 @@
+using DiscordEventService.Services;
+using Xunit;
+
+namespace DiscordEventService.Tests;
+
+public sealed class UpsertResultTests
+{
+    [Fact]
+    public void Success_CarriesValueAndNoFailureReason()
+    {
+        var id = Guid.NewGuid();
+
+        var result = UpsertResult<Guid>.Success(id);
+
+        Assert.True(result.IsSuccess);
+        Assert.Equal(id, result.Value);
+        Assert.Null(result.FailureReason);
+    }
+
+    [Fact]
+    public void Failure_HasNoValueAndCarriesReason()
+    {
+        var result = UpsertResult<Guid>.Failure("lost the row");
+
+        Assert.False(result.IsSuccess);
+        Assert.Equal(Guid.Empty, result.Value);
+        Assert.Equal("lost the row", result.FailureReason);
+    }
+}


### PR DESCRIPTION
Closes #163 (§A3.2 of epic #154). Depends on the now-merged §A2 work (#161).

## What

Replaces the `Guid.Empty`-as-error sentinel with a typed `UpsertResult<T>(bool IsSuccess, T? Value, string? FailureReason)` (Success/Failure factories). Upsert services now own their failure logging; callers branch on `IsSuccess`/`Value` instead of pattern-matching a magic value.

### Services
- `GuildUpsertService.UpsertGuildAsync` / `ChannelUpsertService.UpsertChannelAsync`: `Guid` → `UpsertResult<Guid>`
- `UserService.UpsertUserAsync`: `void` → `UpsertResult<Guid>` (callers no longer re-query the id)
- `UpsertMemberAsync` uses the `UpsertUserAsync` result internally, dropping its user re-query

### Callers (~25 sites across 13 files)
- **Hard path** (`MessageEventHandler`): `IsSuccess` check + `RecordFailureAsync`; dropped the author re-query.
- **Soft nullable-FK** (`Sticker/Emoji/AutoMod/Invite`): `result.IsSuccess ? result.Value : (Guid?)null`.
- **Conditional** (`Ban`, `Presence`): `IsSuccess` guards; dropped redundant user re-queries.
- **Unconditional FK** (`Channel/Role/Integration/Thread` Created): `.Value`.
- `BootQuickSyncService` / `ThreadChannelBackfillService`: result `.Value` for upserts; the remaining **query-miss** `Guid.Empty` checks converted to nullable projections (`Select(x => (Guid?)…)`).

Net: removed several now-redundant `db.Users…Select(u => u.Id).FirstOrDefaultAsync()` re-queries (the upsert now returns the id directly).

## Acceptance
- ✅ No `== Guid.Empty` checks remain outside the upsert services (remaining ones are the services' own primitive-return checks).
- ✅ Callers use `IsSuccess`/`Value`.
- ✅ `dotnet build` clean (8 pre-existing baseline warnings, no new).

## Testing
- **Unit:** new `UpsertResultTests` pins the Success/Failure contract the 25 callers depend on. Full suite **12/12 green**. (Service-level negative path needs a constructed `DiscordGuild` — impractical without DSharpPlus mocking, which the guidelines forbid; that all-or-fail negative case lands naturally in #162's FkResolver, which is unit-testable.)
- **Live (dev bot + local Postgres):** MessageCreated → message persisted with **all FKs non-null** (guild/channel/author resolved via `UpsertResult`) + 1 Created event; role assign → `GuildMemberUpdated → UpsertMemberAsync` upserted the member + wrote the member_event + opened the snapshot. Presence ingestion flowing. **0 errors / 23505 / aborted-tx / FK-not-resolved** across the session.

Next in epic #154: §A3.1 #162 (FkResolver, built on this typed result).

🤖 Generated with [Claude Code](https://claude.com/claude-code)