### PR TITLE
feat: wire tests into CI + clear -warnaserror warnings (#186)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,20 @@
+name: CI
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+    branches: [master]
+
+permissions:
+  contents: read
+  checks: write
+
+jobs:
+  ci:
+    # Format, build (-warnaserror), and run the xUnit + Testcontainers suite.
+    # ubuntu-latest provides Docker for Testcontainers (Postgres 18).
+    uses: wiktorkowalski/github-workflows/.github/workflows/dotnet-ci.yml@master
+    with:
+      dotnet-version: "10.0.x"
+    secrets: inherit

--- a/src/DiscordEventService/Services/EventHandlers/AutoModRuleEventHandler.cs
+++ b/src/DiscordEventService/Services/EventHandlers/AutoModRuleEventHandler.cs
@@ -15,14 +15,15 @@ public sealed class AutoModRuleEventHandler(EventPipeline pipeline) :
 {
     public async Task HandleEventAsync(DiscordClient sender, AutoModerationRuleCreatedEventArgs e)
     {
-        var guildDiscordId = e.Rule.Guild?.Id ?? 0UL;
+        // DSharpPlus annotates Rule nullable on this EventArgs, but the gateway payload always carries it.
+        var guildDiscordId = e.Rule!.Guild?.Id ?? 0UL;
         var creatorDiscordId = e.Rule.Creator?.Id ?? 0UL;
 
         await pipeline.Execute(e, "AutoModRuleCreatedRule", nameof(AutoModRuleEventHandler),
             guildDiscordId, null, creatorDiscordId, async ctx =>
             {
                 Guid? guildGuid = null;
-                if (e.Rule.Guild != null)
+                if (e.Rule.Guild is not null)
                 {
                     var guildUpsert = ctx.Services.GetRequiredService<GuildUpsertService>();
                     var guildResult = await guildUpsert.UpsertGuildAsync(e.Rule.Guild);
@@ -30,7 +31,7 @@ public sealed class AutoModRuleEventHandler(EventPipeline pipeline) :
                 }
 
                 Guid? creatorGuid = null;
-                if (e.Rule.Creator != null)
+                if (e.Rule.Creator is not null)
                 {
                     var userService = ctx.Services.GetRequiredService<UserService>();
                     var creatorResult = await userService.UpsertUserAsync(e.Rule.Creator);
@@ -69,7 +70,8 @@ public sealed class AutoModRuleEventHandler(EventPipeline pipeline) :
 
     public async Task HandleEventAsync(DiscordClient sender, AutoModerationRuleUpdatedEventArgs e)
     {
-        var guildDiscordId = e.Rule.Guild?.Id ?? 0UL;
+        // DSharpPlus annotates Rule nullable on this EventArgs, but the gateway payload always carries it.
+        var guildDiscordId = e.Rule!.Guild?.Id ?? 0UL;
 
         await pipeline.Execute(e, "AutoModRuleUpdatedRule", nameof(AutoModRuleEventHandler),
             guildDiscordId, null, e.Rule.Creator?.Id, async ctx =>

--- a/src/DiscordEventService/Services/RawEventLogService.cs
+++ b/src/DiscordEventService/Services/RawEventLogService.cs
@@ -117,8 +117,6 @@ public class RawEventLogService(DiscordDbContext dbContext, ILogger<RawEventLogS
             var property = base.CreateProperty(member, memberSerialization);
             if (property.Converter?.GetType().Name == ProblemConverterName)
                 property.Converter = null;
-            if (property.MemberConverter?.GetType().Name == ProblemConverterName)
-                property.MemberConverter = null;
             if (property.ItemConverter?.GetType().Name == ProblemConverterName)
                 property.ItemConverter = null;
             if (SensitiveProperties.Contains(member.Name))

--- a/src/DiscordEventService/Services/ThreadChannelBackfillService.cs
+++ b/src/DiscordEventService/Services/ThreadChannelBackfillService.cs
@@ -12,184 +12,12 @@ public class ThreadChannelBackfillService(
     ChannelUpsertService channelUpsert,
     ILogger<ThreadChannelBackfillService> logger)
 {
-    public record Result(
-        int OrphansScanned,
-        int ChannelsFetched,
-        int Placeholders,
-        int MessagesLinked,
-        int Unresolved,
-        int ExistingThreadsRepaired);
+    public record Result(int ThreadsRepaired);
 
     public async Task<Result> BackfillAsync(CancellationToken ct)
     {
-        var orphanResult = await BackfillOrphansAsync(ct);
         var repaired = await BackfillIncompleteThreadChannelsAsync(ct);
-        return orphanResult with { ExistingThreadsRepaired = repaired };
-    }
-
-    private async Task<Result> BackfillOrphansAsync(CancellationToken ct)
-    {
-        var orphans = await db.Messages
-            .Where(m => m.ChannelId == null)
-            .Select(m => new { m.Id, m.DiscordId, m.FirstSeenUtc, m.GuildId })
-            .ToListAsync(ct);
-
-        if (orphans.Count == 0)
-        {
-            return new Result(0, 0, 0, 0, 0, 0);
-        }
-
-        // Hybrid resolver: try a deterministic match first (event_json->'message'->>'id' = orphan.DiscordId),
-        // fall back to nearest-timestamp ±2s when the raw JSON is stub-fallback (pre-#99 serializer bug).
-        var orphanResolution = new Dictionary<Guid, (ulong ChannelDiscordId, ulong GuildDiscordId)>();
-        foreach (var orphan in orphans)
-        {
-            var resolved = await ResolveOrphanChannelAsync(orphan.DiscordId, orphan.FirstSeenUtc, ct);
-            if (resolved is var (cid, gid))
-            {
-                orphanResolution[orphan.Id] = (cid, gid);
-            }
-            else
-            {
-                logger.LogWarning(
-                    "Could not resolve channel_discord_id for orphan message {MessageId} (DiscordId={DiscordId})",
-                    orphan.Id, orphan.DiscordId);
-            }
-        }
-
-        // Group orphans by (channel, guild) so we upsert each channel under its own guild.
-        var uniqueChannels = orphanResolution
-            .Values
-            .GroupBy(v => v.ChannelDiscordId)
-            .Select(g => new
-            {
-                ChannelDiscordId = g.Key,
-                GuildDiscordIds = g.Select(v => v.GuildDiscordId).Distinct().ToList()
-            })
-            .ToList();
-
-        int fetched = 0;
-        int placeholders = 0;
-        var resolvedChannelGuids = new Dictionary<ulong, Guid>();
-        foreach (var entry in uniqueChannels)
-        {
-            var existing = await db.Channels
-                .Where(c => c.DiscordId == entry.ChannelDiscordId)
-                .Select(c => (Guid?)c.Id)
-                .FirstOrDefaultAsync(ct);
-
-            if (existing is not null)
-            {
-                resolvedChannelGuids[entry.ChannelDiscordId] = existing.Value;
-                continue;
-            }
-
-            if (entry.GuildDiscordIds.Count != 1)
-            {
-                logger.LogWarning(
-                    "Orphan channel {ChannelId} appears under multiple guild_discord_ids ({Count}); using first",
-                    entry.ChannelDiscordId, entry.GuildDiscordIds.Count);
-            }
-            var guildDiscordId = entry.GuildDiscordIds[0];
-            var guildGuid = await db.Guilds
-                .Where(g => g.DiscordId == guildDiscordId)
-                .Select(g => (Guid?)g.Id)
-                .FirstOrDefaultAsync(ct);
-
-            if (guildGuid is null)
-            {
-                logger.LogError(
-                    "Guild {GuildDiscordId} for orphan channel {ChannelDiscordId} not present in DB; skipping",
-                    guildDiscordId, entry.ChannelDiscordId);
-                continue;
-            }
-
-            try
-            {
-                var live = await client.GetChannelAsync(entry.ChannelDiscordId);
-                var id = (await channelUpsert.UpsertChannelAsync(live, guildGuid.Value)).Value;
-                resolvedChannelGuids[entry.ChannelDiscordId] = id;
-                fetched++;
-                logger.LogInformation("Backfilled channel {DiscordId} via Discord API as {Type}", entry.ChannelDiscordId, live.Type);
-                continue;
-            }
-            catch (NotFoundException)
-            {
-                logger.LogWarning(
-                    "Discord 404 for {DiscordId}; inserting placeholder",
-                    entry.ChannelDiscordId);
-            }
-            catch (UnauthorizedException)
-            {
-                logger.LogWarning(
-                    "Discord 403 for {DiscordId}; inserting placeholder",
-                    entry.ChannelDiscordId);
-            }
-
-            var firstOrphan = orphans
-                .Where(o => orphanResolution.TryGetValue(o.Id, out var c) && c.ChannelDiscordId == entry.ChannelDiscordId)
-                .Min(o => o.FirstSeenUtc);
-            var placeholderId = await channelUpsert.InsertPlaceholderAsync(entry.ChannelDiscordId, guildGuid.Value, firstOrphan);
-            resolvedChannelGuids[entry.ChannelDiscordId] = placeholderId;
-            placeholders++;
-        }
-
-        int linked = 0;
-        foreach (var (orphanId, (channelDiscordId, _)) in orphanResolution)
-        {
-            if (!resolvedChannelGuids.TryGetValue(channelDiscordId, out var channelGuid))
-            {
-                continue;
-            }
-
-            var rows = await db.Messages
-                .Where(m => m.Id == orphanId && m.ChannelId == null)
-                .ExecuteUpdateAsync(s => s.SetProperty(m => m.ChannelId, channelGuid), ct);
-            linked += rows;
-        }
-
-        var unresolved = orphans.Count - orphanResolution.Count;
-        return new Result(orphans.Count, fetched, placeholders, linked, unresolved, 0);
-    }
-
-    private async Task<(ulong ChannelDiscordId, ulong GuildDiscordId)?> ResolveOrphanChannelAsync(
-        ulong orphanDiscordId, DateTime orphanFirstSeenUtc, CancellationToken ct)
-    {
-        // Deterministic match via JSON message-id (post-#99 events have intact JSON).
-        var idText = orphanDiscordId.ToString();
-        var jsonMatch = await db.RawEventLogs
-            .FromSqlInterpolated($@"
-                SELECT *
-                FROM raw_event_logs
-                WHERE event_type = 'MessageCreated'
-                  AND channel_discord_id IS NOT NULL
-                  AND event_json->'message'->>'id' = {idText}
-                LIMIT 1")
-            .Select(r => new { r.ChannelDiscordId, r.GuildDiscordId })
-            .FirstOrDefaultAsync(ct);
-
-        if (jsonMatch is { ChannelDiscordId: { } jsonCid })
-        {
-            return (jsonCid, jsonMatch.GuildDiscordId);
-        }
-
-        // Fallback: nearest-timestamp match within ±2s — only path that works for pre-#99 stub JSON.
-        var windowStart = orphanFirstSeenUtc.AddSeconds(-2);
-        var windowEnd = orphanFirstSeenUtc.AddSeconds(2);
-
-        var candidates = await db.RawEventLogs
-            .Where(r => r.EventType == "MessageCreated"
-                && r.ReceivedAtUtc >= windowStart
-                && r.ReceivedAtUtc <= windowEnd
-                && r.ChannelDiscordId != null)
-            .Select(r => new { r.ChannelDiscordId, r.GuildDiscordId, r.ReceivedAtUtc })
-            .ToListAsync(ct);
-
-        var best = candidates
-            .OrderBy(c => Math.Abs((c.ReceivedAtUtc - orphanFirstSeenUtc).TotalMilliseconds))
-            .FirstOrDefault();
-
-        return best is { ChannelDiscordId: { } cid } ? (cid, best.GuildDiscordId) : null;
+        return new Result(repaired);
     }
 
     private async Task<int> BackfillIncompleteThreadChannelsAsync(CancellationToken ct)
@@ -202,7 +30,7 @@ public class ThreadChannelBackfillService(
             .Select(c => new { c.Id, c.DiscordId, c.GuildId })
             .ToListAsync(ct);
 
-        int repaired = 0;
+        var repaired = 0;
         foreach (var thread in incomplete)
         {
             try

--- a/tests/DiscordEventService.Tests/DiscordEventService.Tests.csproj
+++ b/tests/DiscordEventService.Tests/DiscordEventService.Tests.csproj
@@ -9,6 +9,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="coverlet.collector" Version="6.0.4" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
     <PackageReference Include="xunit" Version="2.9.3" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" />


### PR DESCRIPTION
Closes #186.

## What
Adopts the new reusable `dotnet-ci.yml` (format → build `-warnaserror` → xUnit/Testcontainers → coverage) as `.github/workflows/ci.yml`, running on PR and push to `master`.

- **Runner:** `ubuntu-latest` (GitHub-hosted) supplies Docker for Testcontainers (Postgres 18), sidestepping the homelab-runner Docker question raised in #186.
- **`build.yml` unchanged:** still owns the docker-build/deploy path; deploy stays `master`-only. On PRs it builds (no push/deploy); `ci.yml` adds format + the test suite alongside it.
- **Coverage:** added `coverlet.collector` to the test project so the CI coverage summary is actually populated (it defaults on but emitted nothing without the collector).

## Latent warnings cleared (`-warnaserror` promotes these to errors)
The reusable CI defaults `treat-warnings-as-errors: true`. Master had 8 latent diagnostics; fixed at the source rather than disabling the flag:

| File | Diag | Fix |
|------|------|-----|
| `AutoModRuleEventHandler` | CS8602 ×2 | DSharpPlus over-annotates `Rule` nullable on the Created/Updated `EventArgs`; null-forgive at first deref (runtime-identical to the existing `e.Rule.Guild` access). |
| `AutoModRuleEventHandler` | CS8604 + CS8625 | `DiscordGuild`'s `==`/`!=` operators take non-nullable operands → switched `!= null` to `is not null`. |
| `RawEventLogService` | CS0618 ×2 | Dropped the obsolete `JsonProperty.MemberConverter` block — it aliases `Converter`, already handled one line above. |
| `ThreadChannelBackfillService` | CS8073 ×2 | Removed `BackfillOrphansAsync` + `ResolveOrphanChannelAsync`. The `m.ChannelId == null` orphan query has been **permanently dead** since §P2.6 (#128) made `channel_id` NOT NULL + FK Restrict. Kept the live thread-repair path; `Result` shrinks to `ThreadsRepaired`. |

**Contract note:** the `POST /api/ops/backfill-thread-channels` response shrinks from 6 fields to `{ threadsRepaired }`. It still performs the live thread-repair work; only the always-zero orphan counters are gone.

## Verification (local)
- `dotnet build -warnaserror`: 0 warnings, 0 errors.
- `dotnet test`: 12/12 pass (xUnit + Testcontainers, real Postgres 18).
- Coverage `coverage.cobertura.xml` now emitted.
- `dotnet format --verify-no-changes`: clean.

## Follow-up (not in this PR)
Marking the CI check **required** is GitHub branch-protection config, not workflow YAML — needs setting once the check appears. Flagging per #186's "test job gates merges".

🤖 Generated with [Claude Code](https://claude.com/claude-code)