### PR TITLE
feat: unify dual DI registration into AddCoreServices() (#165)

### DIFF
--- a/src/DiscordEventService/Program.cs
+++ b/src/DiscordEventService/Program.cs
@@ -66,10 +66,10 @@ builder.Services.AddSingleton(rootSp =>
 {
     var clientBuilder = DiscordClientBuilder.CreateDefault(discordToken, DiscordIntents.All);
 
-    // Register ASP.NET Core services in DSharpPlus's DI container.
-    // NOTE: when adding a new registration here that event handlers depend on,
-    // also add the type to StartupValidator.RequiredChildContainerServices so
-    // missing registrations fail at startup instead of at runtime.
+    // Register ASP.NET Core services in DSharpPlus's DI container. Services event
+    // handlers share with the root container come from AddCoreServices(); add new
+    // shared services to CoreServiceRegistration.CoreServiceTypes (one line, both
+    // containers + StartupValidator pick them up automatically).
     clientBuilder.ConfigureServices(services =>
     {
         services.AddDbContext<DiscordDbContext>(options =>
@@ -83,18 +83,7 @@ builder.Services.AddSingleton(rootSp =>
 
         services.AddSingleton<IHostEnvironment>(builder.Environment);
         services.AddSingleton<EventPipeline>();
-        services.AddScoped<UserService>();
-        services.AddScoped<GuildUpsertService>();
-        services.AddScoped<ChannelUpsertService>();
-        services.AddScoped<FkResolver>();
-        services.AddScoped<RawEventLogService>();
-        services.AddScoped<FailedEventService>();
-        services.AddScoped<DowntimeTrackerService>();
-        // SocketLifecycleHandler.GuildDownloadCompleted enqueues backfills via
-        // GuildBackfillOrchestrator; it resolves from the DSharpPlus child
-        // container, so the orchestrator must be registered here too.
-        services.AddScoped<GuildBackfillOrchestrator>();
-        services.AddScoped<BootQuickSyncService>();
+        services.AddCoreServices();
         // IBackgroundJobClient forwards to the root container's registration.
         // Hangfire registers IBackgroundJobClient as Transient with DI-based
         // JobStorage resolution; using `new BackgroundJobClient()` directly
@@ -161,14 +150,10 @@ builder.Services.AddHostedService<HeartbeatBackgroundService>();
 // Memory cache for throttling
 builder.Services.AddMemoryCache();
 
-// Shared services
-builder.Services.AddScoped<UserService>();
-builder.Services.AddScoped<GuildUpsertService>();
-builder.Services.AddScoped<ChannelUpsertService>();
-builder.Services.AddScoped<FkResolver>();
-builder.Services.AddScoped<RawEventLogService>();
-builder.Services.AddScoped<FailedEventService>();
-builder.Services.AddScoped<DowntimeTrackerService>();
+// Shared services (registered in both the root and DSharpPlus child containers)
+builder.Services.AddCoreServices();
+
+// Root-only services (backfill/ops paths; event handlers don't resolve these)
 builder.Services.AddScoped<OrphanReplayService>();
 builder.Services.AddScoped<ThreadChannelBackfillService>();
 builder.Services.AddScoped<MemberRoleSnapshotBackfillService>();
@@ -203,7 +188,6 @@ builder.Services.AddScoped<ChannelsBackfillJob>();
 builder.Services.AddScoped<MembersBackfillJob>();
 builder.Services.AddScoped<MessagesBackfillJob>();
 builder.Services.AddScoped<ReactionsBackfillJob>();
-builder.Services.AddScoped<GuildBackfillOrchestrator>();
 builder.Services.AddScoped<PeriodicFullBackfillJob>();
 
 var app = builder.Build();

--- a/src/DiscordEventService/Services/CoreServiceRegistration.cs
+++ b/src/DiscordEventService/Services/CoreServiceRegistration.cs
@@ -1,0 +1,33 @@
+using DiscordEventService.Jobs;
+using DiscordEventService.Services.Pipeline;
+
+namespace DiscordEventService.Services;
+
+/// <summary>
+/// Single source of truth for the scoped services that both the root (ASP.NET Core) and the
+/// DSharpPlus child DI container need. Registration loops over <see cref="CoreServiceTypes"/> and
+/// <see cref="StartupValidator"/> validates the same list, so adding a service is one line here and
+/// it is registered in both containers and validated at startup.
+/// </summary>
+public static class CoreServiceRegistration
+{
+    public static readonly Type[] CoreServiceTypes =
+    [
+        typeof(UserService),
+        typeof(GuildUpsertService),
+        typeof(ChannelUpsertService),
+        typeof(FkResolver),
+        typeof(RawEventLogService),
+        typeof(FailedEventService),
+        typeof(DowntimeTrackerService),
+        typeof(GuildBackfillOrchestrator),
+        typeof(BootQuickSyncService),
+    ];
+
+    public static IServiceCollection AddCoreServices(this IServiceCollection services)
+    {
+        foreach (var type in CoreServiceTypes)
+            services.AddScoped(type);
+        return services;
+    }
+}

--- a/src/DiscordEventService/Services/StartupValidator.cs
+++ b/src/DiscordEventService/Services/StartupValidator.cs
@@ -1,5 +1,4 @@
 using DiscordEventService.Data;
-using DiscordEventService.Jobs;
 using DiscordEventService.Services.Pipeline;
 using Hangfire;
 using Microsoft.Extensions.Caching.Memory;
@@ -16,21 +15,16 @@ public static class StartupValidator
 {
     // Services event handlers resolve via scopeFactory.CreateScope().
     // Constructor-injected transitive dependencies are also validated by trying
-    // to construct each entry below.
+    // to construct each entry below. The shared scoped services come from
+    // CoreServiceRegistration (single source of truth); the rest are
+    // child-container infrastructure registered inline in Program.cs.
     private static readonly Type[] RequiredChildContainerServices =
     [
+        .. CoreServiceRegistration.CoreServiceTypes,
         typeof(DiscordDbContext),
-        typeof(UserService),
-        typeof(GuildUpsertService),
-        typeof(ChannelUpsertService),
-        typeof(RawEventLogService),
-        typeof(FailedEventService),
-        typeof(DowntimeTrackerService),
-        typeof(GuildBackfillOrchestrator),
         typeof(IBackgroundJobClient),
         typeof(IHostEnvironment),
         typeof(IMemoryCache),
-        typeof(BootQuickSyncService),
         typeof(EventPipeline),
     ];
 


### PR DESCRIPTION
Closes #165. Phase A4 (§A4.2) of epic #154.

## Problem

Scoped services shared by the **root** (ASP.NET Core) and **DSharpPlus child** containers were declared in **three** places — root block, child block, and `StartupValidator.RequiredChildContainerServices`. Adding a service meant editing all three; a miss was a silent runtime failure (child) or a validation gap (validator).

## Solution

New `CoreServiceRegistration` with a single `CoreServiceTypes` array as source of truth:
- `AddCoreServices()` loops over the array → registers in both containers.
- `StartupValidator` spreads the same array (`[.. CoreServiceRegistration.CoreServiceTypes, …infra]`) into its required list.

Adding a shared service is now **one `typeof()` line**.

## Bonus: closes a latent validator gap

`FkResolver` (added in #162) was registered in both containers but **never added to the validator list** — so a child-container regression of it would only surface at runtime. It's now validated automatically: **14 services resolved (was 13).**

## What stays inline

- Container infrastructure: `DbContext`, `IBackgroundJobClient` forwarding, `IHostEnvironment`, `IMemoryCache`, `EventPipeline`.
- Root-only services (`OrphanReplayService`, the three backfill services) — event handlers don't resolve these.
- Removed the now-duplicate root `GuildBackfillOrchestrator` registration (covered by `AddCoreServices`).

## Verification

- `dotnet build` clean (0 warnings).
- `VALIDATE_AND_EXIT=1` smoke test: root `ValidateOnBuild` + child `StartupValidator` both pass, 14 services resolved.
- Live test: bot boots, `MessageCreated` handled with all FKs resolved, message persisted, zero errors.

## Acceptance

- [x] Adding a service → 1 line in `CoreServiceTypes` → both containers + validated
- [x] `StartupValidator` still catches missing registrations
- [x] `dotnet build` clean
- [x] Live test: bot starts, handles events

🤖 Generated with [Claude Code](https://claude.com/claude-code)