### PR TITLE
fix: make raw-event serialization failure loud and flagged (#195)

### DIFF
--- a/src/DiscordEventService/Data/Entities/Events/RawEventLogEntity.cs
+++ b/src/DiscordEventService/Data/Entities/Events/RawEventLogEntity.cs
@@ -48,4 +48,11 @@ public class RawEventLogEntity
     public DateTime ReceivedAtUtc { get; set; } = DateTime.UtcNow;
 
     public Guid? CorrelationId { get; set; }
+
+    /// <summary>
+    /// True when <see cref="EventJson"/> is a diagnostic stub written because the event args
+    /// could not be serialized — the original payload is unrecoverable, so this row must be
+    /// excluded from replay. Queryable marker; supersedes matching the stub's error string.
+    /// </summary>
+    public bool SerializationFailed { get; set; }
 }

--- a/src/DiscordEventService/Data/Migrations/20260529123116_P5_1_RawEventSerializationFailedFlag.Designer.cs
+++ b/src/DiscordEventService/Data/Migrations/20260529123116_P5_1_RawEventSerializationFailedFlag.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using DiscordEventService.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -11,9 +12,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace DiscordEventService.Data.Migrations
 {
     [DbContext(typeof(DiscordDbContext))]
-    partial class DiscordDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260529123116_P5_1_RawEventSerializationFailedFlag")]
+    partial class P5_1_RawEventSerializationFailedFlag
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/DiscordEventService/Data/Migrations/20260529123116_P5_1_RawEventSerializationFailedFlag.cs
+++ b/src/DiscordEventService/Data/Migrations/20260529123116_P5_1_RawEventSerializationFailedFlag.cs
@@ -1,0 +1,37 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace DiscordEventService.Data.Migrations
+{
+    /// <inheritdoc />
+    public partial class P5_1_RawEventSerializationFailedFlag : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<bool>(
+                name: "serialization_failed",
+                table: "raw_event_logs",
+                type: "boolean",
+                nullable: false,
+                defaultValue: false);
+
+            // Backfill the flag for pre-existing serialization-failure stubs so it is authoritative
+            // for all rows (these were previously detectable only by matching the stub's error
+            // string). The predicate is exact: the stub is the only payload with a top-level
+            // "error" field equal to the marker. Flag-set only — no data loss.
+            migrationBuilder.Sql(
+                "UPDATE raw_event_logs SET serialization_failed = true " +
+                "WHERE event_json->>'error' = 'Serialization failed';");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "serialization_failed",
+                table: "raw_event_logs");
+        }
+    }
+}

--- a/src/DiscordEventService/Services/OrphanReplayService.cs
+++ b/src/DiscordEventService/Services/OrphanReplayService.cs
@@ -31,14 +31,15 @@ public class OrphanReplayService(DiscordDbContext db, ILogger<OrphanReplayServic
                     && m.UserDiscordId == r.UserDiscordId
                     && m.ReceivedAtUtc >= r.ReceivedAtUtc.AddSeconds(-5)
                     && m.ReceivedAtUtc <= r.ReceivedAtUtc.AddSeconds(5)))
-            .Select(r => new { r.Id, r.UserDiscordId, r.ReceivedAtUtc, r.EventJson })
+            .Select(r => new { r.Id, r.UserDiscordId, r.ReceivedAtUtc, r.SerializationFailed })
             .ToListAsync(ct);
 
         var skipped = 0;
         foreach (var o in orphans)
         {
-            if (IsStubFallback(o.EventJson))
+            if (o.SerializationFailed)
             {
+                // Unreplayable serialization stub — the original payload is gone.
                 skipped++;
                 continue;
             }
@@ -52,11 +53,4 @@ public class OrphanReplayService(DiscordDbContext db, ILogger<OrphanReplayServic
 
         return new OrphanReplayResult(orphans.Count, 0, skipped);
     }
-
-    // Matches the stub written by RawEventLogService.SerializeEvent's catch path.
-    // Postgres jsonb normalizes whitespace to `"key": value` (with space), so
-    // we look for the spaced form. Substring match is order-independent because
-    // jsonb may reorder keys on storage.
-    private static bool IsStubFallback(string json)
-        => json.Contains("\"error\": \"Serialization failed\"", StringComparison.Ordinal);
 }

--- a/src/DiscordEventService/Services/Pipeline/EventPipeline.cs
+++ b/src/DiscordEventService/Services/Pipeline/EventPipeline.cs
@@ -43,12 +43,25 @@ public sealed class EventPipeline(IServiceScopeFactory scopeFactory, ILoggerFact
                 if (logRawEvent)
                 {
                     var rawEventService = scope.ServiceProvider.GetRequiredService<RawEventLogService>();
-                    rawJson = await rawEventService.SerializeAndLogAsync(
+                    var serialized = await rawEventService.SerializeAndLogAsync(
                         e, eventType, guildId, channelId, userId, correlationId: correlationId);
+                    rawJson = serialized.Json;
 
                     // Flush the raw event row before handler logic. Any ChangeTracker.Clear()
                     // in upsert services would silently drop staged raw_event_logs rows otherwise.
                     await db.SaveChangesAsync();
+
+                    // Serialization failure means raw_event_logs holds an unreplayable stub. The
+                    // row is flagged (serialization_failed=true); surface it loudly and record a
+                    // FailedEvent so it is alertable. The handler still runs — it acts on the live
+                    // event args, not the JSON, so structured ingestion is unaffected.
+                    if (serialized.Error is not null)
+                    {
+                        logger.LogError(serialized.Error,
+                            "Failed to serialize {EventType} in {HandlerName}; stored a flagged stub in raw_event_logs (payload unrecoverable)",
+                            eventType, handlerName);
+                        await RecordFailureAsync(serialized.Error);
+                    }
                 }
 
                 var context = new EventContext(db, scope.ServiceProvider, correlationId, rawJson, receivedAt, logger, RecordFailureAsync);

--- a/src/DiscordEventService/Services/RawEventLogService.cs
+++ b/src/DiscordEventService/Services/RawEventLogService.cs
@@ -6,8 +6,23 @@ using System.Reflection;
 
 namespace DiscordEventService.Services;
 
+/// <summary>
+/// Outcome of serializing an event. <see cref="Error"/> is non-null when serialization failed,
+/// in which case <see cref="Json"/> is a diagnostic stub (not the real payload).
+/// </summary>
+public sealed record EventSerializationResult(string Json, Exception? Error)
+{
+    public bool Failed => Error is not null;
+}
+
 public class RawEventLogService(DiscordDbContext dbContext, ILogger<RawEventLogService> logger)
 {
+    /// <summary>
+    /// Marker value placed in the <c>error</c> field of a serialization-failure stub.
+    /// Kept as a constant so detectors don't hard-code the literal.
+    /// </summary>
+    public const string SerializationFailedMarker = "Serialization failed";
+
     // #107 switched to Newtonsoft to fix System.Text.Json's
     // KeyNotFoundException('deprecated') on DSharpPlus's [JsonProperty]-tagged
     // properties (DiscordVoiceRegion.IsDeprecated). But Newtonsoft, when it
@@ -30,23 +45,28 @@ public class RawEventLogService(DiscordDbContext dbContext, ILogger<RawEventLogS
     };
 
     /// <summary>
-    /// Serializes an event args object to JSON, handling any serialization errors gracefully.
+    /// Serializes an event args object to JSON. On failure returns a diagnostic stub and reports
+    /// the exception via <see cref="EventSerializationResult.Error"/> so the caller can flag the
+    /// row and record the failure — the failure is NOT swallowed here (no log; the caller owns it,
+    /// where it has handler/correlation context).
     /// </summary>
-    public string SerializeEvent<T>(T eventArgs) where T : class
+    public EventSerializationResult SerializeEvent<T>(T eventArgs) where T : class
     {
         try
         {
-            return JsonConvert.SerializeObject(eventArgs, JsonSettings);
+            return new EventSerializationResult(JsonConvert.SerializeObject(eventArgs, JsonSettings), null);
         }
         catch (Exception ex)
         {
-            logger.LogWarning(ex, "Failed to serialize {EventType}, falling back to type info only", typeof(T).Name);
-            return JsonConvert.SerializeObject(new
+            // Keep a diagnostic stub (error type/message stay queryable), but surface the failure
+            // so the row is flagged and a FailedEvent is recorded instead of masquerading as success.
+            var stub = JsonConvert.SerializeObject(new
             {
-                Error = "Serialization failed",
+                Error = SerializationFailedMarker,
                 EventType = typeof(T).Name,
                 Message = ex.Message
             }, JsonSettings);
+            return new EventSerializationResult(stub, ex);
         }
     }
 
@@ -59,7 +79,8 @@ public class RawEventLogService(DiscordDbContext dbContext, ILogger<RawEventLogS
         ulong guildId = 0,
         ulong? channelId = null,
         ulong? userId = null,
-        Guid? correlationId = null)
+        Guid? correlationId = null,
+        bool serializationFailed = false)
     {
         try
         {
@@ -72,7 +93,8 @@ public class RawEventLogService(DiscordDbContext dbContext, ILogger<RawEventLogS
                 EventJson = eventJson,
                 JsonSizeBytes = System.Text.Encoding.UTF8.GetByteCount(eventJson),
                 ReceivedAtUtc = DateTime.UtcNow,
-                CorrelationId = correlationId
+                CorrelationId = correlationId,
+                SerializationFailed = serializationFailed
             };
 
             await dbContext.RawEventLogs.AddAsync(rawEvent);
@@ -87,7 +109,7 @@ public class RawEventLogService(DiscordDbContext dbContext, ILogger<RawEventLogS
     /// <summary>
     /// Convenience method to serialize and log in one call.
     /// </summary>
-    public async Task<string> SerializeAndLogAsync<T>(
+    public async Task<EventSerializationResult> SerializeAndLogAsync<T>(
         T eventArgs,
         string eventType,
         ulong guildId = 0,
@@ -95,9 +117,9 @@ public class RawEventLogService(DiscordDbContext dbContext, ILogger<RawEventLogS
         ulong? userId = null,
         Guid? correlationId = null) where T : class
     {
-        var json = SerializeEvent(eventArgs);
-        await LogRawEventAsync(eventType, json, guildId, channelId, userId, correlationId);
-        return json;
+        var result = SerializeEvent(eventArgs);
+        await LogRawEventAsync(eventType, result.Json, guildId, channelId, userId, correlationId, result.Failed);
+        return result;
     }
 
     private sealed class BypassRecursiveConverterResolver : CamelCasePropertyNamesContractResolver

--- a/tests/DiscordEventService.Tests/RawEventSerializationTests.cs
+++ b/tests/DiscordEventService.Tests/RawEventSerializationTests.cs
@@ -1,0 +1,105 @@
+using DiscordEventService.Data;
+using DiscordEventService.Services;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging.Abstractions;
+using Xunit;
+
+namespace DiscordEventService.Tests;
+
+// A payload whose getter throws during serialization, forcing SerializeEvent's failure path.
+file sealed class ThrowingPayload
+{
+    public string Ok => "fine";
+    public string Boom => throw new InvalidOperationException("kaboom");
+}
+
+file sealed class GoodPayload
+{
+    public string Name { get; init; } = "ok";
+    public int Count { get; init; } = 1;
+}
+
+public sealed class SerializeEventUnitTests
+{
+    // dbContext/logger are unused by SerializeEvent, so no DB needed here.
+    private static RawEventLogService NewService()
+        => new(null!, NullLogger<RawEventLogService>.Instance);
+
+    [Fact]
+    public void SerializeEvent_WhenSuccessful_ReturnsJsonWithNoError()
+    {
+        var result = NewService().SerializeEvent(new GoodPayload());
+
+        Assert.False(result.Failed);
+        Assert.Null(result.Error);
+        Assert.Contains("\"name\":\"ok\"", result.Json);
+    }
+
+    [Fact]
+    public void SerializeEvent_WhenSerializationThrows_ReturnsFlaggedStubAndError()
+    {
+        var result = NewService().SerializeEvent(new ThrowingPayload());
+
+        Assert.True(result.Failed);
+        Assert.NotNull(result.Error);
+        // Stub keeps the marker + type so the error stays queryable, but is NOT the real payload.
+        Assert.Contains(RawEventLogService.SerializationFailedMarker, result.Json);
+        Assert.Contains(nameof(ThrowingPayload), result.Json);
+    }
+}
+
+public sealed class RawEventLogPersistenceTests(PostgresFixture fixture)
+    : IClassFixture<PostgresFixture>, IAsyncLifetime
+{
+    private DiscordDbContext _db = null!;
+
+    public async Task InitializeAsync()
+    {
+        _db = NewContext();
+        await _db.Database.MigrateAsync();
+        await _db.RawEventLogs.ExecuteDeleteAsync();
+    }
+
+    public Task DisposeAsync() => _db.DisposeAsync().AsTask();
+
+    [Fact]
+    public async Task SerializeAndLogAsync_WhenSerializationFails_PersistsFlaggedStub()
+    {
+        var service = new RawEventLogService(_db, NullLogger<RawEventLogService>.Instance);
+
+        var result = await service.SerializeAndLogAsync(new ThrowingPayload(), "ThrowingEvent");
+        await _db.SaveChangesAsync();
+
+        Assert.True(result.Failed);
+
+        await using var verify = NewContext();
+        var row = await verify.RawEventLogs.SingleAsync(r => r.EventType == "ThrowingEvent");
+        Assert.True(row.SerializationFailed);
+        Assert.Contains(RawEventLogService.SerializationFailedMarker, row.EventJson);
+    }
+
+    [Fact]
+    public async Task SerializeAndLogAsync_WhenSerializationSucceeds_PersistsUnflaggedRow()
+    {
+        var service = new RawEventLogService(_db, NullLogger<RawEventLogService>.Instance);
+
+        var result = await service.SerializeAndLogAsync(new GoodPayload(), "GoodEvent");
+        await _db.SaveChangesAsync();
+
+        Assert.False(result.Failed);
+
+        await using var verify = NewContext();
+        var row = await verify.RawEventLogs.SingleAsync(r => r.EventType == "GoodEvent");
+        Assert.False(row.SerializationFailed);
+        Assert.DoesNotContain(RawEventLogService.SerializationFailedMarker, row.EventJson);
+    }
+
+    private DiscordDbContext NewContext()
+    {
+        var options = new DbContextOptionsBuilder<DiscordDbContext>()
+            .UseNpgsql(fixture.Container.GetConnectionString())
+            .UseSnakeCaseNamingConvention()
+            .Options;
+        return new DiscordDbContext(options);
+    }
+}


### PR DESCRIPTION
Closes #195. First child of epic #194 (§A1) and the recommended first move.

## Problem
`RawEventLogService.SerializeEvent` caught every serialization exception, logged only at **Warning**, and returned a `{Error:"Serialization failed", …}` stub as the sole record — the original payload was unrecoverable, no `failed_events` row was written (the swallow happened *inside* `SerializeEvent`, before the pipeline's catch), and stubs were detectable only by a fragile Ordinal substring match. `raw_event_logs` is the documented replay **source of truth**, so a degraded row here is data loss disguised as graceful handling.

**Prod evidence:** a read-only scan found **3,333 historical stub rows** (~3.4% of 96k) — serialization *was* failing silently (`"Only channel categories contain children."`, the `'deprecated'` key error). The last one is dated **2026-05-13**; zero in the 14 days since (the #120 ContractResolver hotfix fixed the triggers), so making this loud will **not** flood `failed_events` going forward.

## Changes
- `SerializeEvent` returns `EventSerializationResult(Json, Error)` instead of swallowing — the diagnostic stub is still produced (error type/message stay queryable) but the failure is reported. The old Warning log is removed (it had no handler/correlation context).
- `RawEventLogEntity` gains a queryable `serialization_failed` flag; `LogRawEventAsync` / `SerializeAndLogAsync` thread it through.
- `EventPipeline` logs the failure **once at Error** (with handler + correlation context) and records a `FailedEvent`. The handler **still runs** — it acts on the live event args, not the JSON, so structured ingestion is unaffected.
- `OrphanReplayService` detects stubs via the **flag**, not the substring match (dead `IsStubFallback` removed).
- Migration adds the column and **backfills** it for the 3,333 pre-existing stubs (`event_json->>'error' = 'Serialization failed'` — verified exact: LIKE count == jsonb count == 3333). Flag-set only, no data loss; auto-applies on next boot.

## Testing
- **Unit:** `SerializeEvent` returns a failed result + flagged stub on a throwing payload; clean result on a good one.
- **Testcontainers:** `SerializeAndLogAsync` persists the row with `serialization_failed` true/false matching the outcome.
- 21/21 tests green; build clean with `-warnaserror`.
- **Live (dev bot):** MessageCreated / MessageReactionAdded / PresenceUpdated / GuildCreated all raw-logged with `serialization_failed=false` and valid JSON. The *failure* path can't be triggered live (the triggers are fixed) — it's covered by the tests, by design.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
