### PR TITLE
feat: BanEventHandler replayable failed-event trace on FK-miss (#196)

### DIFF
--- a/src/DiscordEventService/Services/EventHandlers/BanEventHandler.cs
+++ b/src/DiscordEventService/Services/EventHandlers/BanEventHandler.cs
@@ -16,16 +16,17 @@ public sealed class BanEventHandler(EventPipeline pipeline) :
         await pipeline.Execute(e, "GuildBanAdded", nameof(BanEventHandler),
             e.Guild.Id, null, e.Member.Id, async ctx =>
             {
-                var guildUpsert = ctx.Services.GetRequiredService<GuildUpsertService>();
-                var userService = ctx.Services.GetRequiredService<UserService>();
+                // Resolve the required guild+user FKs via the shared resolver: on a miss it logs and
+                // records a FailedEvent (replayable trace) instead of silently dropping the bans row.
+                // The BanEvent timeline row is FK-free (snowflake columns) and still lands below, so a
+                // resolve miss costs only the derived bans row, not the faithful timeline record.
+                var fks = await ctx.Services.GetRequiredService<FkResolver>()
+                    .ResolveAsync(ctx, e.Guild, e.Member, $"GuildId={e.Guild.Id} UserId={e.Member.Id}");
 
-                var guildResult = await guildUpsert.UpsertGuildAsync(e.Guild);
-                var userResult = await userService.UpsertUserAsync(e.Member);
-
-                if (guildResult.IsSuccess && userResult.IsSuccess)
+                if (fks.Success)
                 {
-                    var guildGuid = guildResult.Value;
-                    var userGuid = userResult.Value;
+                    var guildGuid = fks.GuildId;
+                    var userGuid = fks.UserId;
 
                     var existingBan = await ctx.Db.Bans
                         .FirstOrDefaultAsync(b => b.GuildId == guildGuid && b.UserId == userGuid && b.IsActive);
@@ -61,16 +62,16 @@ public sealed class BanEventHandler(EventPipeline pipeline) :
         await pipeline.Execute(e, "GuildBanRemoved", nameof(BanEventHandler),
             e.Guild.Id, null, e.Member.Id, async ctx =>
             {
-                var guildUpsert = ctx.Services.GetRequiredService<GuildUpsertService>();
-                var userService = ctx.Services.GetRequiredService<UserService>();
+                // See GuildBanAdded: resolve guild+user via the shared resolver so a miss is logged +
+                // recorded as a FailedEvent rather than silently skipping the unban. The BanEvent row
+                // is FK-free and still lands below regardless of resolution.
+                var fks = await ctx.Services.GetRequiredService<FkResolver>()
+                    .ResolveAsync(ctx, e.Guild, e.Member, $"GuildId={e.Guild.Id} UserId={e.Member.Id}");
 
-                var guildResult = await guildUpsert.UpsertGuildAsync(e.Guild);
-                var userResult = await userService.UpsertUserAsync(e.Member);
-
-                if (guildResult.IsSuccess && userResult.IsSuccess)
+                if (fks.Success)
                 {
-                    var guildGuid = guildResult.Value;
-                    var userGuid = userResult.Value;
+                    var guildGuid = fks.GuildId;
+                    var userGuid = fks.UserId;
 
                     await ctx.Db.Bans
                         .Where(b => b.GuildId == guildGuid && b.UserId == userGuid && b.IsActive)

--- a/src/DiscordEventService/Services/Pipeline/FkResolver.cs
+++ b/src/DiscordEventService/Services/Pipeline/FkResolver.cs
@@ -59,4 +59,46 @@ public sealed class FkResolver(
             $"Required FK not resolved ({logContext ?? "no context"}): guildResolved={guild.IsSuccess} channelResolved={channel.IsSuccess} userResolved={user.IsSuccess}"));
         return ResolvedFks.Failed;
     }
+
+    /// <summary>
+    /// Guild+user variant of <see cref="ResolveAsync(EventContext, DiscordGuild, DiscordChannel, DiscordUser, string?)"/>
+    /// for required-FK handlers whose core row has no channel (e.g. <c>bans</c>). Upserts the guild
+    /// and user, then validates both resolved. On any failure the resolver logs, records a
+    /// <c>FailedEvent</c> via <paramref name="ctx"/>, and returns <see cref="ResolvedUserFks.Failed"/> —
+    /// the caller skips the core-row write (and, for a faithful timeline, may still log the event row).
+    /// </summary>
+    public async Task<ResolvedUserFks> ResolveAsync(
+        EventContext ctx,
+        DiscordGuild guild,
+        DiscordUser user,
+        string? logContext = null)
+    {
+        var guildResult = await guildUpsert.UpsertGuildAsync(guild);
+        var userResult = await userService.UpsertUserAsync(user);
+
+        return await ValidateAsync(ctx, guildResult, userResult, logContext);
+    }
+
+    /// <summary>
+    /// Pure guild+user validation seam, mirroring the three-FK <see cref="ValidateAsync(EventContext, UpsertResult{Guid}, UpsertResult{Guid}, UpsertResult{Guid}, string?)"/>:
+    /// both success → <see cref="ResolvedUserFks.Resolved"/>; otherwise log + record failure +
+    /// <see cref="ResolvedUserFks.Failed"/>. Takes already-resolved results so it is unit-testable
+    /// without constructing DSharpPlus entities.
+    /// </summary>
+    internal static async Task<ResolvedUserFks> ValidateAsync(
+        EventContext ctx,
+        UpsertResult<Guid> guild,
+        UpsertResult<Guid> user,
+        string? logContext = null)
+    {
+        if (guild.IsSuccess && user.IsSuccess)
+            return ResolvedUserFks.Resolved(guild.Value, user.Value);
+
+        ctx.Logger.LogError(
+            "Could not resolve required FKs ({LogContext}): guildResolved={GuildResolved} userResolved={UserResolved}; skipping insert",
+            logContext ?? "no context", guild.IsSuccess, user.IsSuccess);
+        await ctx.RecordFailureAsync(new InvalidOperationException(
+            $"Required FK not resolved ({logContext ?? "no context"}): guildResolved={guild.IsSuccess} userResolved={user.IsSuccess}"));
+        return ResolvedUserFks.Failed;
+    }
 }

--- a/src/DiscordEventService/Services/Pipeline/ResolvedFks.cs
+++ b/src/DiscordEventService/Services/Pipeline/ResolvedFks.cs
@@ -12,3 +12,16 @@ public sealed record ResolvedFks(bool Success, Guid GuildId, Guid ChannelId, Gui
 
     public static readonly ResolvedFks Failed = new(false, default, default, default);
 }
+
+/// <summary>
+/// Outcome of the guild+user <see cref="FkResolver.ResolveAsync(EventContext, DSharpPlus.Entities.DiscordGuild, DSharpPlus.Entities.DiscordUser, string?)"/>
+/// overload, for required-FK handlers whose core row carries only a guild and a user FK (e.g.
+/// <c>bans</c>) and so cannot use the channel-bearing <see cref="ResolvedFks"/>. Same success/failure
+/// contract, minus the channel.
+/// </summary>
+public sealed record ResolvedUserFks(bool Success, Guid GuildId, Guid UserId)
+{
+    public static ResolvedUserFks Resolved(Guid guildId, Guid userId) => new(true, guildId, userId);
+
+    public static readonly ResolvedUserFks Failed = new(false, default, default);
+}

--- a/tests/DiscordEventService.Tests/FkResolverTests.cs
+++ b/tests/DiscordEventService.Tests/FkResolverTests.cs
@@ -63,6 +63,56 @@ public sealed class FkResolverTests
         Assert.Contains("MessageId=42", failure.Message);
     }
 
+    [Fact]
+    public async Task ValidateAsync_GuildUser_WhenBothResolve_ReturnsResolvedIdsAndDoesNotRecordFailure()
+    {
+        var guildId = Guid.NewGuid();
+        var userId = Guid.NewGuid();
+        var logger = new RecordingLogger();
+        var recordedFailures = new List<Exception>();
+        var ctx = NewContext(logger, recordedFailures);
+
+        var result = await FkResolver.ValidateAsync(
+            ctx,
+            UpsertResult<Guid>.Success(guildId),
+            UpsertResult<Guid>.Success(userId),
+            "GuildId=1 UserId=2");
+
+        Assert.True(result.Success);
+        Assert.Equal(guildId, result.GuildId);
+        Assert.Equal(userId, result.UserId);
+        Assert.Empty(recordedFailures);
+        Assert.DoesNotContain(logger.Entries, e => e.Level == LogLevel.Error);
+    }
+
+    [Theory]
+    [InlineData(false, true)]
+    [InlineData(true, false)]
+    [InlineData(false, false)]
+    public async Task ValidateAsync_GuildUser_WhenAnyFkFails_LogsRecordsFailureAndReturnsFailed(
+        bool guildOk, bool userOk)
+    {
+        var logger = new RecordingLogger();
+        var recordedFailures = new List<Exception>();
+        var ctx = NewContext(logger, recordedFailures);
+
+        var result = await FkResolver.ValidateAsync(
+            ctx,
+            guildOk ? UpsertResult<Guid>.Success(Guid.NewGuid()) : UpsertResult<Guid>.Failure("guild lost"),
+            userOk ? UpsertResult<Guid>.Success(Guid.NewGuid()) : UpsertResult<Guid>.Failure("user lost"),
+            "GuildId=7 UserId=8");
+
+        Assert.False(result.Success);
+        Assert.Equal(Guid.Empty, result.GuildId);
+        Assert.Equal(Guid.Empty, result.UserId);
+
+        // Logged an aggregate error and recorded exactly one FailedEvent carrying the log context.
+        Assert.Contains(logger.Entries, e => e.Level == LogLevel.Error);
+        var failure = Assert.Single(recordedFailures);
+        Assert.IsType<InvalidOperationException>(failure);
+        Assert.Contains("GuildId=7 UserId=8", failure.Message);
+    }
+
     private static EventContext NewContext(ILogger logger, List<Exception> recordedFailures) =>
         new(
             Db: null!,


### PR DESCRIPTION
Closes #196 · Part of epic #194 (§A2).

## Problem
`BanEventHandler` hand-rolled its guild+user FK handling: on a resolve miss it checked `IsSuccess`, silently skipped the derived `bans` core row, and made **no `RecordFailureAsync` call** — a dropped lifecycle fact with no replayable trace. (Only `MessageEventHandler` routed through the `FkResolver` built in #162.)

## Change
- **`FkResolver`** gains a guild+user overload for required-FK handlers whose core row has no channel (e.g. `bans`): `ResolveAsync(ctx, guild, user, logContext)` + a pure, DSharpPlus-free `ValidateAsync(ctx, guildResult, userResult, logContext)` returning a new `ResolvedUserFks`. Mirrors the existing three-FK path exactly; separate log message keeps the structured `guildResolved`/`userResolved` fields queryable.
- **`BanEventHandler`** (both `GuildBanAdded`/`GuildBanRemoved`) now resolves through `FkResolver`, so a required-FK miss yields the uniform contract: aggregate error log + `FailedEvent` + skip the `bans` write.

## Faithful-timeline note (deliberate, not the literal-issue "return")
The `BanEvent` timeline row is **FK-free** (snowflake `ulong` columns, no Guid FK — confirmed in `BanEventEntityConfiguration`) and still lands **unconditionally** on a miss. So unlike `MessageEventHandler`'s `if (!fks.Success) return;` (whose event row is FK-coupled inside its tx), Ban keeps writing its timeline row — a resolve miss now costs only the derived `bans` row, and loudly via a `FailedEvent`, with no `ban_events` regression. This matters because #200's recovery is ack-only/reconstruction-infeasible, so a dropped `ban_events` row would be permanently lost.

Soft nullable-FK handlers (Emoji) keep their intentional null-coalescing path. Scope guard respected: `StageInstanceEventHandler` is unchanged (its non-nullable FKs throw 23503 → caught + recorded by `EventPipeline`, not a silent orphan).

## Tests
- 4 new `FkResolverTests` for the guild+user `ValidateAsync` seam: success returns resolved ids + records no failure + no error log; each miss combo (guild/user) logs an aggregate error and records exactly one `FailedEvent` carrying the log context.
- Build green with `-warnaserror`; full suite **25/25**.
- Boot + cold-sync live-verified the new `FkResolver` DI wiring (bot connects, 0 errors). Live ban/unban skipped by request — happy path is structurally identical (resolver returns the same Guids; `bans` + `BanEvent` inserts unchanged) and the miss path isn't live-triggerable on a healthy guild.

🤖 Generated with [Claude Code](https://claude.com/claude-code)