### PR TITLE
feat: single-transaction upsert-then-history & presence two-save flows (#197)

### DIFF
--- a/src/DiscordEventService/Services/EventHandlers/PresenceEventHandler.cs
+++ b/src/DiscordEventService/Services/EventHandlers/PresenceEventHandler.cs
@@ -49,43 +49,59 @@ public sealed class PresenceEventHandler(EventPipeline pipeline) :
         await pipeline.Execute(eventDto, "PresenceUpdated", nameof(PresenceEventHandler),
             guildId, null, args.User.Id, async ctx =>
             {
-                ctx.Db.PresenceEvents.Add(new PresenceEventEntity
+                // Presence row, the user upsert, and activity tracking are one logical event:
+                // wrap them in a single transaction so a mid-flight failure can't leave a presence
+                // record with no activity tracking. ExecutionStrategy is required because
+                // EnableRetryOnFailure is configured; the top-of-delegate ChangeTracker.Clear keeps a
+                // retry from re-staging this attempt's entities. UpsertUserAsync runs inside the
+                // ambient transaction (it never opens its own), so the user update + name history
+                // commit atomically with the presence and activity rows.
+                var strategy = ctx.Db.Database.CreateExecutionStrategy();
+                await strategy.ExecuteAsync(async () =>
                 {
-                    UserDiscordId = args.User.Id,
-                    GuildDiscordId = guildId,
+                    ctx.Db.ChangeTracker.Clear();
+                    await using var tx = await ctx.Db.Database.BeginTransactionAsync();
 
-                    DesktopStatusBefore = GetStatusValue(args.PresenceBefore?.ClientStatus?.Desktop),
-                    MobileStatusBefore = GetStatusValue(args.PresenceBefore?.ClientStatus?.Mobile),
-                    WebStatusBefore = GetStatusValue(args.PresenceBefore?.ClientStatus?.Web),
+                    ctx.Db.PresenceEvents.Add(new PresenceEventEntity
+                    {
+                        UserDiscordId = args.User.Id,
+                        GuildDiscordId = guildId,
 
-                    DesktopStatusAfter = GetStatusValue(args.PresenceAfter?.ClientStatus?.Desktop),
-                    MobileStatusAfter = GetStatusValue(args.PresenceAfter?.ClientStatus?.Mobile),
-                    WebStatusAfter = GetStatusValue(args.PresenceAfter?.ClientStatus?.Web),
+                        DesktopStatusBefore = GetStatusValue(args.PresenceBefore?.ClientStatus?.Desktop),
+                        MobileStatusBefore = GetStatusValue(args.PresenceBefore?.ClientStatus?.Mobile),
+                        WebStatusBefore = GetStatusValue(args.PresenceBefore?.ClientStatus?.Web),
 
-                    ActivitiesBeforeJson = SerializeActivities(args.PresenceBefore?.Activities),
-                    ActivitiesAfterJson = SerializeActivities(args.PresenceAfter?.Activities),
+                        DesktopStatusAfter = GetStatusValue(args.PresenceAfter?.ClientStatus?.Desktop),
+                        MobileStatusAfter = GetStatusValue(args.PresenceAfter?.ClientStatus?.Mobile),
+                        WebStatusAfter = GetStatusValue(args.PresenceAfter?.ClientStatus?.Web),
 
-                    EventTimestampUtc = ctx.ReceivedAtUtc,
-                    ReceivedAtUtc = ctx.ReceivedAtUtc,
-                    RawEventJson = ctx.RawJson
-                });
+                        ActivitiesBeforeJson = SerializeActivities(args.PresenceBefore?.Activities),
+                        ActivitiesAfterJson = SerializeActivities(args.PresenceAfter?.Activities),
 
-                await ctx.Db.SaveChangesAsync();
+                        EventTimestampUtc = ctx.ReceivedAtUtc,
+                        ReceivedAtUtc = ctx.ReceivedAtUtc,
+                        RawEventJson = ctx.RawJson
+                    });
 
-                // Track activities in ActivityEntity — upsert the user first so we never silently
-                // skip activity tracking for unknown users (87k presence events historically).
-                var userService = ctx.Services.GetRequiredService<UserService>();
-                var userResult = await userService.UpsertUserAsync(args.User);
-
-                if (userResult.IsSuccess)
-                {
-                    await UpdateActivityTracking(ctx.Db, userResult.Value, args.PresenceBefore?.Activities, args.PresenceAfter?.Activities, ctx.ReceivedAtUtc);
                     await ctx.Db.SaveChangesAsync();
-                }
-                else
-                {
-                    ctx.Logger.LogWarning("Skipping activity tracking: UpsertUserAsync did not produce a User row for {UserId}", args.User.Id);
-                }
+
+                    // Track activities in ActivityEntity — upsert the user first so we never silently
+                    // skip activity tracking for unknown users (87k presence events historically).
+                    var userService = ctx.Services.GetRequiredService<UserService>();
+                    var userResult = await userService.UpsertUserAsync(args.User);
+
+                    if (userResult.IsSuccess)
+                    {
+                        await UpdateActivityTracking(ctx.Db, userResult.Value, args.PresenceBefore?.Activities, args.PresenceAfter?.Activities, ctx.ReceivedAtUtc);
+                        await ctx.Db.SaveChangesAsync();
+                    }
+                    else
+                    {
+                        ctx.Logger.LogWarning("Skipping activity tracking: UpsertUserAsync did not produce a User row for {UserId}", args.User.Id);
+                    }
+
+                    await tx.CommitAsync();
+                });
 
                 ctx.Logger.LogDebug("Recorded presence event for user {UserId}", args.User.Id);
             });

--- a/src/DiscordEventService/Services/UserService.cs
+++ b/src/DiscordEventService/Services/UserService.cs
@@ -9,13 +9,61 @@ public class UserService(DiscordDbContext db, ILogger<UserService> logger)
 {
     public async Task<UpsertResult<Guid>> UpsertUserAsync(DiscordUser user)
     {
-        // Pre-query old values for name-history detection: the primitive only does the write,
-        // and on a 23505 race we have no reliable "before" to compare against (matches insert path).
+        // Pre-query old values for name-history detection: the set-based upsert only does the
+        // write, and on a 23505 race we have no reliable "before" to compare against.
         var existing = await db.Users
             .Where(u => u.DiscordId == user.Id)
             .Select(u => new { u.Id, u.Username, u.GlobalName })
             .FirstOrDefaultAsync();
 
+        var usernameChanged = existing is not null && existing.Username != user.Username;
+        var globalNameChanged = existing is not null && existing.GlobalName != user.GlobalName;
+
+        // A name change is the only flow that issues a SECOND write (the history row) after
+        // updating the user. Do it as load-modify-save committed in a SINGLE SaveChanges so the
+        // update and its history row land atomically (one implicit transaction, auto-retried under
+        // EnableRetryOnFailure). This avoids an explicit transaction + ChangeTracker.Clear, which on
+        // this shared DbContext would drop pending rows of batch-staging callers (e.g. the backfill
+        // jobs upsert authors mid-batch while messages/reactions are staged for one SaveChanges).
+        if (existing is not null && (usernameChanged || globalNameChanged))
+        {
+            var entity = await db.Users.FirstOrDefaultAsync(u => u.DiscordId == user.Id);
+            if (entity is null)
+            {
+                logger.LogError("UserUpsert lost the row for DiscordId={DiscordId} after detecting a name change", user.Id);
+                return UpsertResult<Guid>.Failure($"User upsert lost the row for DiscordId={user.Id}");
+            }
+
+            entity.Username = user.Username;
+            entity.GlobalName = user.GlobalName;
+            entity.Discriminator = user.Discriminator;
+            entity.AvatarHash = user.AvatarHash;
+
+            db.UserNameHistory.Add(new UserNameHistoryEntity
+            {
+                UserId = existing.Id,
+                UsernameBefore = usernameChanged ? existing.Username : null,
+                UsernameAfter = usernameChanged ? user.Username : null,
+                GlobalNameBefore = globalNameChanged ? existing.GlobalName : null,
+                GlobalNameAfter = globalNameChanged ? user.GlobalName : null,
+                ChangedAtUtc = DateTime.UtcNow
+            });
+
+            await db.SaveChangesAsync();
+
+            logger.LogInformation(
+                "User name changed for {DiscordId}: username {OldUser} → {NewUser}, globalName {OldGlobal} → {NewGlobal}",
+                user.Id,
+                usernameChanged ? existing.Username : "(unchanged)",
+                usernameChanged ? user.Username : "(unchanged)",
+                globalNameChanged ? existing.GlobalName : "(unchanged)",
+                globalNameChanged ? user.GlobalName : "(unchanged)");
+
+            return UpsertResult<Guid>.Success(existing.Id);
+        }
+
+        // No name change (or a brand-new user): a single set-based upsert. One statement, race-safe
+        // insert-or-update, and — unlike SaveChanges — it never flushes a caller's staged entities.
         var id = await db.Users.UpsertAsync(
             u => u.DiscordId == user.Id,
             s => s
@@ -39,37 +87,6 @@ public class UserService(DiscordDbContext db, ILogger<UserService> logger)
         {
             logger.LogError("UserUpsert lost the row for DiscordId={DiscordId} after upsert", user.Id);
             return UpsertResult<Guid>.Failure($"User upsert lost the row for DiscordId={user.Id}");
-        }
-
-        if (existing is null)
-        {
-            return UpsertResult<Guid>.Success(id);
-        }
-
-        var usernameChanged = existing.Username != user.Username;
-        var globalNameChanged = existing.GlobalName != user.GlobalName;
-
-        if (usernameChanged || globalNameChanged)
-        {
-            db.UserNameHistory.Add(new UserNameHistoryEntity
-            {
-                UserId = existing.Id,
-                UsernameBefore = usernameChanged ? existing.Username : null,
-                UsernameAfter = usernameChanged ? user.Username : null,
-                GlobalNameBefore = globalNameChanged ? existing.GlobalName : null,
-                GlobalNameAfter = globalNameChanged ? user.GlobalName : null,
-                ChangedAtUtc = DateTime.UtcNow
-            });
-            await db.SaveChangesAsync();
-            db.ChangeTracker.Clear();
-
-            logger.LogInformation(
-                "User name changed for {DiscordId}: username {OldUser} → {NewUser}, globalName {OldGlobal} → {NewGlobal}",
-                user.Id,
-                usernameChanged ? existing.Username : "(unchanged)",
-                usernameChanged ? user.Username : "(unchanged)",
-                globalNameChanged ? existing.GlobalName : "(unchanged)",
-                globalNameChanged ? user.GlobalName : "(unchanged)");
         }
 
         return UpsertResult<Guid>.Success(id);

--- a/tests/DiscordEventService.Tests/UserUpsertTests.cs
+++ b/tests/DiscordEventService.Tests/UserUpsertTests.cs
@@ -71,6 +71,24 @@ public sealed class UserUpsertTests(PostgresFixture fixture) : IClassFixture<Pos
         Assert.Equal(0, await verify.UserNameHistory.CountAsync());
     }
 
+    [Fact]
+    public async Task UpsertUser_WhenOnlyAvatarChanged_UpdatesUserWithoutHistory()
+    {
+        var service = new UserService(_db, NullLogger<UserService>.Instance);
+        await service.UpsertUserAsync(MakeUser(500UL, "dave", "Dave", avatarHash: "avatar_v1"));
+        _db.ChangeTracker.Clear();
+
+        // Same name, different avatar: the common set-based path must still refresh mutable fields
+        // but must NOT write a name-history row (history is for username/globalName changes only).
+        await service.UpsertUserAsync(MakeUser(500UL, "dave", "Dave", avatarHash: "avatar_v2"));
+
+        await using var verify = NewContext();
+        var row = await verify.Users.SingleAsync(u => u.DiscordId == 500UL);
+        Assert.Equal("avatar_v2", row.AvatarHash);
+        Assert.Equal("dave", row.Username);
+        Assert.Equal(0, await verify.UserNameHistory.CountAsync());
+    }
+
     private DiscordDbContext NewContext()
     {
         var options = new DbContextOptionsBuilder<DiscordDbContext>()
@@ -82,13 +100,15 @@ public sealed class UserUpsertTests(PostgresFixture fixture) : IClassFixture<Pos
 
     // DiscordUser exposes a parameterless ctor with non-public setters; reflection is the only
     // way to build a fixture instance without a live gateway connection.
-    private static DiscordUser MakeUser(ulong id, string username, string globalName)
+    private static DiscordUser MakeUser(ulong id, string username, string globalName, string? avatarHash = null)
     {
         var user = (DiscordUser)Activator.CreateInstance(typeof(DiscordUser), nonPublic: true)!;
         SetProp(user, nameof(DiscordUser.Id), id);
         SetProp(user, nameof(DiscordUser.Username), username);
         SetProp(user, nameof(DiscordUser.GlobalName), globalName);
         SetProp(user, nameof(DiscordUser.Discriminator), "0");
+        if (avatarHash is not null)
+            SetProp(user, nameof(DiscordUser.AvatarHash), avatarHash);
         return user;
     }
 


### PR DESCRIPTION
Closes #197 · Part of epic #194 (§A3).

## Problem
Two flows issued more than one independent write per logical event with no enclosing transaction, so a mid-flight failure left a torn timeline:
1. **`UserService.UpsertUserAsync`** — committed the name change via a set-based `ExecuteUpdate` (auto-committed immediately), THEN a separate `SaveChanges` for the `UserNameHistory` row → failure between them = name change with **no history row**.
2. **`PresenceEventHandler`** — saved presence, upserted the user (a save), then saved again for activity tracking, no enclosing tx → mid-flight failure = presence with **no activity**.

## Change
- **`UpsertUserAsync`**: the name-change path is now **load-modify-save committed in a single `SaveChanges`**, so the user update and its history row land atomically (one implicit transaction, auto-retried under `EnableRetryOnFailure`). The common no-name-change/insert path keeps the set-based `UpsertAsync`.
- **`PresenceEventHandler`**: presence + user upsert + activity tracking now run in one `CreateExecutionStrategy` + `BeginTransaction` + top-of-delegate `ChangeTracker.Clear` + `Commit` — the pattern `MessageEventHandler`/`MemberEventHandler` already prove out. `UpsertUserAsync` participates in the ambient tx (it never opens its own), so nothing nests.

## Why single-SaveChanges, not an explicit tx + Clear (important)
A blanket explicit transaction + `ChangeTracker.Clear()` inside `UpsertUserAsync` would **corrupt batch-staging callers**: `MessagesBackfillJob` (`:215`) and `ReactionsBackfillJob` (`:231`) upsert authors **mid-batch** while messages/reactions are staged for a single per-batch `SaveChanges` (`:293` / `:261`). A `Clear()` there would silently drop their pending rows — the exact loss class this epic fights. A single `SaveChanges` needs no `Clear` (nothing to re-stage on retry) and is the minimal atomic unit. The old post-save `ChangeTracker.Clear` is removed for the same reason.

## Behavioral note (surfaced, not hidden)
load-modify-save runs through `SaveChanges`, so a name change now bumps `users.last_updated_utc` via `UpdateTimestamps()` — the old `ExecuteUpdate` did not. A rename is genuinely an update, so this is more correct, but it is a visible change. (Confirmed live: a forced rename bumped `last_updated_utc` from 2026-05-29 to the rename instant.)

## Scope guard (verified)
`MessageEventHandler` is the **reference pattern**, not a defect — `ExtractAndSaveMentionsAsync`'s delete+re-add already runs inside its outer `BeginTransactionAsync`/`CommitAsync` at both call sites. Not touched.

## Tests / verification
- Existing `UserUpsertTests` exercise the restructured insert / name-change / unchanged paths; added an **avatar-only-change** case asserting the common path still refreshes mutable fields **without** a spurious history row. Build green with `-warnaserror`; suite **26/26**.
- **Live-verified on the dev bot**: 16 `PresenceUpdated` events through the new transactional Flow 2 (0 rollbacks/errors, presence + activity rows landing); cold-sync upserted 22 users via the common path; and a **forced name change** (staleified a member's local username) drove the load-modify-save path end-to-end through the real handler → `user_name_history` row written, username restored, `last_updated_utc` bumped, all atomic.

🤖 Generated with [Claude Code](https://claude.com/claude-code)