### PR TITLE
feat: EmojiEventHandler is the single canonical writer of Emotes (#198)

### DIFF
--- a/src/DiscordEventService/Services/EventHandlers/EmojiEventHandler.cs
+++ b/src/DiscordEventService/Services/EventHandlers/EmojiEventHandler.cs
@@ -55,12 +55,22 @@ public sealed class EmojiEventHandler(EventPipeline pipeline) :
                     }
                 }
 
-                foreach (var id in removedIds)
+                // Soft-delete stale rows. EmojiEventHandler is now the single canonical writer of
+                // Emotes for GuildEmojisUpdated (GuildEventHandler no longer touches the table), so
+                // reconcile the full stored set: any of this guild's active emotes absent from
+                // EmojisAfter is stale. This is broader than the before/after diff — it also reaps
+                // rows the event's "before" snapshot omitted — and preserves the first deletion time.
+                // When the guild FK didn't resolve, fall back to the before/after diff (by DiscordId)
+                // so a transient guild-upsert miss still records the removals it can see.
+                var staleQuery = ctx.Db.Emotes.Where(em => !em.IsDeleted);
+                staleQuery = guildGuid is { } gid
+                    ? staleQuery.Where(em => em.GuildId == gid && !afterIds.Contains(em.DiscordId))
+                    : staleQuery.Where(em => removedIds.Contains(em.DiscordId));
+
+                foreach (var stale in await staleQuery.ToListAsync())
                 {
-                    await ctx.Db.Emotes.Where(em => em.DiscordId == id)
-                        .ExecuteUpdateAsync(s => s
-                            .SetProperty(em => em.IsDeleted, true)
-                            .SetProperty(em => em.DeletedAtUtc, (DateTime?)ctx.ReceivedAtUtc));
+                    stale.IsDeleted = true;
+                    stale.DeletedAtUtc ??= ctx.ReceivedAtUtc;
                 }
 
                 ctx.Db.EmojiEvents.Add(new EmojiEventEntity

--- a/src/DiscordEventService/Services/EventHandlers/GuildEventHandler.cs
+++ b/src/DiscordEventService/Services/EventHandlers/GuildEventHandler.cs
@@ -12,8 +12,7 @@ public sealed class GuildEventHandler(EventPipeline pipeline) :
     IEventHandler<GuildCreatedEventArgs>,
     IEventHandler<GuildAvailableEventArgs>,
     IEventHandler<GuildUpdatedEventArgs>,
-    IEventHandler<GuildDeletedEventArgs>,
-    IEventHandler<GuildEmojisUpdatedEventArgs>
+    IEventHandler<GuildDeletedEventArgs>
 {
     public async Task HandleEventAsync(DiscordClient sender, GuildCreatedEventArgs e)
     {
@@ -98,59 +97,6 @@ public sealed class GuildEventHandler(EventPipeline pipeline) :
                     await ctx.Db.SaveChangesAsync();
                 }
             });
-    }
-
-    public async Task HandleEventAsync(DiscordClient sender, GuildEmojisUpdatedEventArgs e)
-    {
-        // Already raw-logged by EmojiEventHandler; skip the duplicate raw row here.
-        await pipeline.Execute(e, "GuildEmojisUpdated", nameof(GuildEventHandler),
-            e.Guild.Id, null, null, async ctx =>
-            {
-                var guild = await ctx.Db.Guilds.FirstOrDefaultAsync(g => g.DiscordId == e.Guild.Id);
-                var guildGuid = guild?.Id;
-
-                var existingEmotes = await ctx.Db.Emotes
-                    .Where(em => em.GuildId == guildGuid)
-                    .ToDictionaryAsync(em => em.DiscordId);
-
-                var currentEmoteIds = e.EmojisAfter.Select(em => em.Key).ToHashSet();
-
-                foreach (var existingEmote in existingEmotes.Values)
-                {
-                    if (!currentEmoteIds.Contains(existingEmote.DiscordId))
-                    {
-                        existingEmote.IsDeleted = true;
-                        existingEmote.DeletedAtUtc ??= ctx.ReceivedAtUtc;
-                    }
-                }
-
-                foreach (var emoteKvp in e.EmojisAfter)
-                {
-                    var emote = emoteKvp.Value;
-                    if (!existingEmotes.TryGetValue(emote.Id, out var existingEmote))
-                    {
-                        ctx.Db.Emotes.Add(new EmoteEntity
-                        {
-                            DiscordId = emote.Id,
-                            GuildId = guildGuid,
-                            Name = emote.Name,
-                            IsAnimated = emote.IsAnimated,
-                            IsAvailable = emote.IsAvailable,
-                            IsDeleted = false
-                        });
-                    }
-                    else
-                    {
-                        existingEmote.Name = emote.Name;
-                        existingEmote.IsAnimated = emote.IsAnimated;
-                        existingEmote.IsAvailable = emote.IsAvailable;
-                        existingEmote.IsDeleted = false;
-                        existingEmote.DeletedAtUtc = null;
-                    }
-                }
-
-                await ctx.Db.SaveChangesAsync();
-            }, logRawEvent: false);
     }
 
     private static async Task UpsertChannelsAndRolesAsync(DiscordDbContext db, ILogger logger, DiscordGuild guild, Guid guildGuid)


### PR DESCRIPTION
Closes #198 · Part of epic #194 (§A4).

## Problem
`GuildEmojisUpdated` was dispatched to **both** `EmojiEventHandler` and `GuildEventHandler` (both declared `IEventHandler<GuildEmojisUpdatedEventArgs>`). No duplicate raw/event row (GuildEventHandler used `logRawEvent:false`, never wrote `emoji_events`), but **both upserted the same `Emotes` core table** in two independent pipeline scopes on one dispatch, with divergent deletion logic — a real last-writer-wins / lost-update race on shared rows, notably `DeletedAtUtc`:
- `EmojiEventHandler`: soft-deleted only the before/after diff, set `DeletedAtUtc` unconditionally.
- `GuildEventHandler`: full-reconciled all guild emotes vs `EmojisAfter`, used `DeletedAtUtc ??=` (preserve first-deletion time).

## Change
- **Removed** `GuildEventHandler`'s `GuildEmojisUpdated` handler (interface declaration + method). It was *purely* emote logic, so its other guild responsibilities (Created/Available/Updated/Deleted) are untouched. No `Program.cs` change — `AddEventHandlers<T>` subscribes from the declared interfaces. `EmojiEventHandler` still raw-logs the event, so no `raw_event_logs` row is lost.
- **Widened** `EmojiEventHandler`'s deletion from the narrow before/after diff to the broader **"this guild's active emotes absent from `EmojisAfter`"** reconcile, adopting the preserve-first-deletion-time (`??=`) rule — this also reaps rows the event's stale "before" snapshot omitted. When the guild FK doesn't resolve, it **falls back to the before/after diff** so a transient guild-upsert miss still records visible removals (preserves the epic's no-silent-loss invariant). The global-lookup upsert loop is unchanged (robust to a null guild FK; `DiscordId` is unique). All writes land in one `SaveChanges`.

## Benefit
Single source of emoji lifecycle truth; removes the redundant double-upsert and the race on shared `Emotes` rows; deletion semantics reasoned about in one place.

## Verification
- Build green `-warnaserror`; suite **26/26** (no behavior covered by existing tests changed).
- **Live-verified on the dev bot via MCP** (emoji changes are gateway-triggerable, unlike bans/renames):
  - **Add** `create_emoji` → `Emotes` row upserted (not deleted).
  - **Delete** `delete_emoji` → row soft-deleted with valid `DeletedAtUtc`.
  - **Widen (discriminating)**: pre-seeded an *active* emote row for the guild that exists in **no** Discord event, then triggered `GuildEmojisUpdated` → the seeded row was soft-deleted by the broad reconcile. The old narrow before/after diff could **never** have touched it (never in `EmojisBefore`/`After`) — this is the proof the widening works.
  - **Dedup**: exactly **1** `raw_event_logs` + **1** `emoji_events` row per `GuildEmojisUpdated`; **0** `ck_emotes_soft_delete` CHECK violations; 0 errors/rollbacks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)