### PR TITLE
feat: lifecycle-fact CHECK constraints on bans & activities (#199)

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -22,6 +22,8 @@ A row that records something that *happened* and later *ended*, where neither en
 
 _Do not_ shoehorn these into `is_deleted`/`deleted_at_utc`. The shared `bool` shape is a coincidence; the semantics differ.
 
+_DB-enforced_ (§B1 / #199): `is_active = false ⇔ end-timestamp IS NOT NULL` is a CHECK constraint on each — `ck_bans_lifecycle` (`unbanned_at_utc`), `ck_activities_lifecycle` (`ended_at_utc`) — mirroring the soft-delete constraint convention but on the domain end columns (`LifecycleFactConstraint`).
+
 ### References
 
 **Snowflake** (`*_discord_id`, `ulong`): the ID Discord uses (e.g. `user_discord_id`, `channel_discord_id`). The natural key, supplied by every gateway payload, never null on event-table rows. Canonical for **event tables**.

--- a/src/DiscordEventService/Data/Configurations/ActivityEntityConfiguration.cs
+++ b/src/DiscordEventService/Data/Configurations/ActivityEntityConfiguration.cs
@@ -20,5 +20,9 @@ internal sealed class ActivityEntityConfiguration : IEntityTypeConfiguration<Act
             .HasForeignKey(a => a.UserId).OnDelete(DeleteBehavior.NoAction);
         builder.HasOne(a => a.Guild).WithMany(g => g.Activities)
             .HasForeignKey(a => a.GuildId).OnDelete(DeleteBehavior.NoAction);
+
+        // Lifecycle-fact invariant (CONTEXT.md): stopping an activity is its natural end, so
+        // is_active=false ⇔ ended_at_utc IS NOT NULL. DB-enforced like the soft-delete convention.
+        builder.ToTable(t => t.HasCheckConstraint("ck_activities_lifecycle", LifecycleFactConstraint.Check("ended_at_utc")));
     }
 }

--- a/src/DiscordEventService/Data/Configurations/BanEntityConfiguration.cs
+++ b/src/DiscordEventService/Data/Configurations/BanEntityConfiguration.cs
@@ -11,5 +11,9 @@ internal sealed class BanEntityConfiguration : IEntityTypeConfiguration<BanEntit
         builder.HasIndex(b => b.GuildId);
         builder.HasIndex(b => new { b.GuildId, b.UserId });
         builder.HasIndex(b => new { b.GuildId, b.IsActive });
+
+        // Lifecycle-fact invariant (CONTEXT.md): an unban is the natural end of the ban, so
+        // is_active=false ⇔ unbanned_at_utc IS NOT NULL. DB-enforced like the soft-delete convention.
+        builder.ToTable(t => t.HasCheckConstraint("ck_bans_lifecycle", LifecycleFactConstraint.Check("unbanned_at_utc")));
     }
 }

--- a/src/DiscordEventService/Data/Configurations/LifecycleFactConstraint.cs
+++ b/src/DiscordEventService/Data/Configurations/LifecycleFactConstraint.cs
@@ -1,0 +1,15 @@
+namespace DiscordEventService.Data.Configurations;
+
+/// <summary>
+/// Shared CHECK constraint body for lifecycle-fact entities (Ban, Activity), enforcing the
+/// CONTEXT.md invariant <c>is_active = false ⇔ end-timestamp IS NOT NULL</c> at the DB level.
+/// Distinct from <see cref="SoftDeleteConstraint"/>: lifecycle facts use domain-specific end
+/// columns (<c>unbanned_at_utc</c> / <c>ended_at_utc</c>), not the soft-delete convention — the
+/// shared boolean shape is a coincidence, the semantics differ.
+/// </summary>
+internal static class LifecycleFactConstraint
+{
+    public static string Check(string endColumn) =>
+        $"(is_active = false AND {endColumn} IS NOT NULL) OR " +
+        $"(is_active = true AND {endColumn} IS NULL)";
+}

--- a/src/DiscordEventService/Data/Migrations/20260531134905_P5_2_LifecycleFactCheckConstraints.Designer.cs
+++ b/src/DiscordEventService/Data/Migrations/20260531134905_P5_2_LifecycleFactCheckConstraints.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using DiscordEventService.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -11,9 +12,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace DiscordEventService.Data.Migrations
 {
     [DbContext(typeof(DiscordDbContext))]
-    partial class DiscordDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260531134905_P5_2_LifecycleFactCheckConstraints")]
+    partial class P5_2_LifecycleFactCheckConstraints
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/DiscordEventService/Data/Migrations/20260531134905_P5_2_LifecycleFactCheckConstraints.cs
+++ b/src/DiscordEventService/Data/Migrations/20260531134905_P5_2_LifecycleFactCheckConstraints.cs
@@ -1,0 +1,36 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace DiscordEventService.Data.Migrations
+{
+    /// <inheritdoc />
+    public partial class P5_2_LifecycleFactCheckConstraints : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddCheckConstraint(
+                name: "ck_bans_lifecycle",
+                table: "bans",
+                sql: "(is_active = false AND unbanned_at_utc IS NOT NULL) OR (is_active = true AND unbanned_at_utc IS NULL)");
+
+            migrationBuilder.AddCheckConstraint(
+                name: "ck_activities_lifecycle",
+                table: "activities",
+                sql: "(is_active = false AND ended_at_utc IS NOT NULL) OR (is_active = true AND ended_at_utc IS NULL)");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropCheckConstraint(
+                name: "ck_bans_lifecycle",
+                table: "bans");
+
+            migrationBuilder.DropCheckConstraint(
+                name: "ck_activities_lifecycle",
+                table: "activities");
+        }
+    }
+}

--- a/tests/DiscordEventService.Tests/LifecycleFactConstraintTests.cs
+++ b/tests/DiscordEventService.Tests/LifecycleFactConstraintTests.cs
@@ -1,0 +1,114 @@
+using DiscordEventService.Data;
+using DiscordEventService.Data.Entities.Core;
+using Microsoft.EntityFrameworkCore;
+using Npgsql;
+using Xunit;
+
+namespace DiscordEventService.Tests;
+
+public sealed class LifecycleFactConstraintTests(PostgresFixture fixture)
+    : IClassFixture<PostgresFixture>, IAsyncLifetime
+{
+    private DiscordDbContext _db = null!;
+
+    public async Task InitializeAsync()
+    {
+        _db = NewContext();
+        await _db.Database.MigrateAsync();
+        await _db.Bans.ExecuteDeleteAsync();
+        await _db.Activities.ExecuteDeleteAsync();
+        await _db.Users.ExecuteDeleteAsync();
+        await _db.Guilds.ExecuteDeleteAsync();
+    }
+
+    public Task DisposeAsync() => _db.DisposeAsync().AsTask();
+
+    [Fact]
+    public async Task Activity_ActiveWithEndTimestamp_ViolatesLifecycleCheck()
+    {
+        var userId = await SeedUserAsync(10UL);
+        _db.Activities.Add(new ActivityEntity { UserId = userId, ActivityType = 0, Name = "X", IsActive = true, EndedAtUtc = DateTime.UtcNow });
+
+        await AssertCheckViolationAsync("ck_activities_lifecycle");
+    }
+
+    [Fact]
+    public async Task Activity_InactiveWithoutEndTimestamp_ViolatesLifecycleCheck()
+    {
+        var userId = await SeedUserAsync(11UL);
+        _db.Activities.Add(new ActivityEntity { UserId = userId, ActivityType = 0, Name = "X", IsActive = false, EndedAtUtc = null });
+
+        await AssertCheckViolationAsync("ck_activities_lifecycle");
+    }
+
+    [Fact]
+    public async Task Activity_ConsistentStates_Persist()
+    {
+        var userId = await SeedUserAsync(12UL);
+        _db.Activities.Add(new ActivityEntity { UserId = userId, ActivityType = 0, Name = "Active", IsActive = true, EndedAtUtc = null });
+        _db.Activities.Add(new ActivityEntity { UserId = userId, ActivityType = 0, Name = "Ended", IsActive = false, EndedAtUtc = DateTime.UtcNow });
+
+        await _db.SaveChangesAsync();
+
+        await using var verify = NewContext();
+        Assert.Equal(2, await verify.Activities.CountAsync());
+    }
+
+    [Fact]
+    public async Task Ban_InactiveWithoutUnbanTimestamp_ViolatesLifecycleCheck()
+    {
+        var (guildId, userId) = await SeedGuildAndUserAsync(20UL);
+        _db.Bans.Add(new BanEntity { GuildId = guildId, UserId = userId, BannedAtUtc = DateTime.UtcNow, IsActive = false, UnbannedAtUtc = null });
+
+        await AssertCheckViolationAsync("ck_bans_lifecycle");
+    }
+
+    [Fact]
+    public async Task Ban_ConsistentStates_Persist()
+    {
+        var (guildId, userId) = await SeedGuildAndUserAsync(21UL);
+        _db.Bans.Add(new BanEntity { GuildId = guildId, UserId = userId, BannedAtUtc = DateTime.UtcNow, IsActive = true, UnbannedAtUtc = null });
+
+        await _db.SaveChangesAsync();
+
+        await using var verify = NewContext();
+        Assert.Equal(1, await verify.Bans.CountAsync(b => b.IsActive));
+    }
+
+    private async Task AssertCheckViolationAsync(string constraintName)
+    {
+        var ex = await Assert.ThrowsAsync<DbUpdateException>(() => _db.SaveChangesAsync());
+        var pg = Assert.IsType<PostgresException>(ex.InnerException);
+        Assert.Equal("23514", pg.SqlState); // check_violation
+        Assert.Contains(constraintName, pg.ConstraintName);
+    }
+
+    private async Task<Guid> SeedUserAsync(ulong discordId)
+    {
+        var user = new UserEntity { DiscordId = discordId, Username = $"u{discordId}" };
+        _db.Users.Add(user);
+        await _db.SaveChangesAsync();
+        _db.ChangeTracker.Clear();
+        return user.Id;
+    }
+
+    private async Task<(Guid GuildId, Guid UserId)> SeedGuildAndUserAsync(ulong discordId)
+    {
+        var guild = new GuildEntity { DiscordId = discordId, Name = $"g{discordId}" };
+        var user = new UserEntity { DiscordId = discordId, Username = $"u{discordId}" };
+        _db.Guilds.Add(guild);
+        _db.Users.Add(user);
+        await _db.SaveChangesAsync();
+        _db.ChangeTracker.Clear();
+        return (guild.Id, user.Id);
+    }
+
+    private DiscordDbContext NewContext()
+    {
+        var options = new DbContextOptionsBuilder<DiscordDbContext>()
+            .UseNpgsql(fixture.Container.GetConnectionString())
+            .UseSnakeCaseNamingConvention()
+            .Options;
+        return new DiscordDbContext(options);
+    }
+}


### PR DESCRIPTION
Closes #199 · Part of epic #194 (§B1).

## Problem
`CONTEXT.md` names **Ban** and **Activity** as *lifecycle facts* with the invariant `is_active=false ⇔ end-timestamp IS NOT NULL` (`UnbannedAtUtc` / `EndedAtUtc`), but neither config carried a CHECK — while the analogous soft-delete invariant (`is_deleted ⇔ deleted_at_utc`) **is** DB-enforced across ~10 entities via `SoftDeleteConstraint`. So lifecycle facts were an enforcement-gap outlier: a C# bug flipping `IsActive` without setting the end timestamp (or vice versa) would persist silently.

## Change
Add a `HasCheckConstraint` to each config, mirroring the soft-delete convention but on the **domain end columns** (per CONTEXT.md — not shoehorned into `is_deleted`/`deleted_at_utc`), via a shared `LifecycleFactConstraint` helper:
- `ck_bans_lifecycle`: `(is_active=false AND unbanned_at_utc IS NOT NULL) OR (is_active=true AND unbanned_at_utc IS NULL)`
- `ck_activities_lifecycle`: same with `ended_at_utc`

One EF migration (`P5_2`). CONTEXT.md marks the invariant DB-enforced.

## Safety (defense-in-depth, not repair — no outage risk)
- **Read-only prod check: ZERO existing violations** — `bans` 0 rows; `activities` **8569 rows, 0 violations**. The boot-time `ALTER ADD CONSTRAINT` validates every row atomically and the bot is its own sole writer during the migration, so a stale count would fail loudly at deploy rather than corrupt silently.
- **Write-path audit**: every live path maintains the invariant — `BanEventHandler` add (`true`/null) & remove (`false`/set); `PresenceEventHandler` start (`true`/null) & end (`false`/set); `BootQuickSync` insert (`true`/null); and there is **no bulk `ExecuteUpdate`/`ExecuteDelete` on `activities`** anywhere. So no new post-deploy failures.

## Tests / verification
- **5 Testcontainers cases**: each constraint rejects an inconsistent row (Postgres `23514`, asserted by constraint name) and accepts consistent ones. Build green `-warnaserror`; suite **31/31** (the fixtures' `MigrateAsync` also proves the migration applies cleanly on a fresh DB).
- **Live-verified on the dev bot**: migration auto-applied on the real local DB (58 activities, 0 violations) → clean boot, both constraints present with correct definitions, live presence/activity processing continued (touches + start/end) with 0 violations and 0 errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)