### PR TITLE
feat: failed-event resolve/ack writer + ops endpoint (#200)

### DIFF
--- a/src/DiscordEventService/Endpoints/OpsEndpoints.cs
+++ b/src/DiscordEventService/Endpoints/OpsEndpoints.cs
@@ -30,6 +30,11 @@ public static class OpsEndpoints
         group.MapPost("/backfill-message-mentions", BackfillMessageMentions)
             .WithName("BackfillMessageMentions")
             .Produces<MessageMentionsBackfillService.Result>(StatusCodes.Status200OK);
+
+        group.MapPost("/failed-events/{id:guid}/resolve", ResolveFailedEvent)
+            .WithName("ResolveFailedEvent")
+            .Produces(StatusCodes.Status200OK)
+            .Produces(StatusCodes.Status404NotFound);
     }
 
     private static async Task<IResult> StartDowntime(
@@ -91,6 +96,20 @@ public static class OpsEndpoints
     {
         var result = await svc.BackfillAsync(ct);
         return Results.Ok(result);
+    }
+
+    // Acknowledge/resolve a dead-letter row so the HealthCheckJob alert can clear by explicit
+    // action. A 0-row update (unknown id or already resolved) is a clean 404, not a 500.
+    private static async Task<IResult> ResolveFailedEvent(
+        Guid id,
+        string? notes,
+        FailedEventService svc,
+        CancellationToken ct)
+    {
+        var resolved = await svc.ResolveAsync(id, notes, ct);
+        return resolved
+            ? Results.Ok(new { id, resolved = true })
+            : Results.NotFound(new { error = $"No unresolved failed event with id {id}" });
     }
 }
 

--- a/src/DiscordEventService/Services/FailedEventService.cs
+++ b/src/DiscordEventService/Services/FailedEventService.cs
@@ -1,6 +1,7 @@
 using System.Text.Json;
 using DiscordEventService.Data;
 using DiscordEventService.Data.Entities.Events;
+using Microsoft.EntityFrameworkCore;
 
 namespace DiscordEventService.Services;
 
@@ -90,5 +91,36 @@ public class FailedEventService(DiscordDbContext db, ILogger<FailedEventService>
                     eventType, handlerName);
             }
         }
+    }
+
+    /// <summary>
+    /// Acknowledges/resolves a failed event so the <c>HealthCheckJob</c> alert (which counts
+    /// <c>!IsResolved</c> rows in a window) can clear by explicit operator action rather than only
+    /// by aging out. Idempotent: filters on <c>!IsResolved</c>, so re-resolving or a missing id is a
+    /// no-op returning <c>false</c>. A single set-based update — no transaction ceremony.
+    /// </summary>
+    /// <remarks>
+    /// This is the feasible dead-letter kernel (ack/annotate). Automatic replay via
+    /// <c>EventJson</c> reconstruction is deliberately NOT implemented: that payload is lossy
+    /// (BypassRecursiveConverterResolver, MaxDepth, snowflake-dict shape) and DSharpPlus
+    /// <c>*EventArgs</c> have no deserialization path, so a handler cannot be re-driven from it
+    /// (deferred — OrphanReplayService OD#5). <see cref="FailedEventEntity.RetryCount"/> stays
+    /// reserved for a future per-event-type replayer that re-drives from current state.
+    /// Unresolved rows are the manual-review bucket; record transient-vs-permanent context in
+    /// <paramref name="notes"/>.
+    /// </remarks>
+    public async Task<bool> ResolveAsync(Guid id, string? notes, CancellationToken cancellationToken = default)
+    {
+        var resolved = await db.FailedEvents
+            .Where(f => f.Id == id && !f.IsResolved)
+            .ExecuteUpdateAsync(s => s
+                .SetProperty(f => f.IsResolved, true)
+                .SetProperty(f => f.ResolvedAtUtc, DateTime.UtcNow)
+                .SetProperty(f => f.ResolutionNotes, notes), cancellationToken);
+
+        if (resolved > 0)
+            logger.LogInformation("Resolved failed event {FailedEventId}", id);
+
+        return resolved > 0;
     }
 }

--- a/tests/DiscordEventService.Tests/FailedEventResolveTests.cs
+++ b/tests/DiscordEventService.Tests/FailedEventResolveTests.cs
@@ -1,0 +1,114 @@
+using DiscordEventService.Data;
+using DiscordEventService.Data.Entities.Events;
+using DiscordEventService.Services;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.FileProviders;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging.Abstractions;
+using Xunit;
+
+namespace DiscordEventService.Tests;
+
+public sealed class FailedEventResolveTests(PostgresFixture fixture)
+    : IClassFixture<PostgresFixture>, IAsyncLifetime
+{
+    private DiscordDbContext _db = null!;
+
+    public async Task InitializeAsync()
+    {
+        _db = NewContext();
+        await _db.Database.MigrateAsync();
+        await _db.FailedEvents.ExecuteDeleteAsync();
+    }
+
+    public Task DisposeAsync() => _db.DisposeAsync().AsTask();
+
+    [Fact]
+    public async Task ResolveAsync_SetsResolutionFields_AndClearsHealthCheckCount()
+    {
+        var id = await SeedFailedEventAsync(DateTime.UtcNow);
+        var service = NewService();
+
+        // HealthCheckJob alert counts unresolved rows in a recent window — 1 before resolution.
+        Assert.Equal(1, await HealthCheckUnresolvedCountAsync());
+
+        var resolved = await service.ResolveAsync(id, "transient blip, acked");
+
+        Assert.True(resolved);
+        await using var verify = NewContext();
+        var row = await verify.FailedEvents.SingleAsync(f => f.Id == id);
+        Assert.True(row.IsResolved);
+        Assert.NotNull(row.ResolvedAtUtc);
+        Assert.Equal("transient blip, acked", row.ResolutionNotes);
+
+        // The discriminating proof: the alert query now excludes it (clears by resolution).
+        Assert.Equal(0, await HealthCheckUnresolvedCountAsync());
+    }
+
+    [Fact]
+    public async Task ResolveAsync_WhenAlreadyResolved_IsNoOpReturningFalse()
+    {
+        var id = await SeedFailedEventAsync(DateTime.UtcNow);
+        var service = NewService();
+
+        Assert.True(await service.ResolveAsync(id, "first"));
+        Assert.False(await service.ResolveAsync(id, "second"));
+
+        await using var verify = NewContext();
+        var row = await verify.FailedEvents.SingleAsync(f => f.Id == id);
+        Assert.Equal("first", row.ResolutionNotes); // second call did not overwrite
+    }
+
+    [Fact]
+    public async Task ResolveAsync_WhenIdUnknown_ReturnsFalse()
+    {
+        var service = NewService();
+        Assert.False(await service.ResolveAsync(Guid.NewGuid(), "nope"));
+    }
+
+    // Mirrors HealthCheckJob.CheckFailedEventsAsync's count query.
+    private async Task<int> HealthCheckUnresolvedCountAsync()
+    {
+        var windowStart = DateTime.UtcNow.AddMinutes(-60);
+        await using var verify = NewContext();
+        return await verify.FailedEvents.CountAsync(f => f.FailedAtUtc > windowStart && !f.IsResolved);
+    }
+
+    private async Task<Guid> SeedFailedEventAsync(DateTime failedAtUtc)
+    {
+        var entity = new FailedEventEntity
+        {
+            EventType = "GuildMemberUpdated",
+            HandlerName = "MemberEventHandler",
+            ExceptionType = "System.NullReferenceException",
+            ExceptionMessage = "boom",
+            FailedAtUtc = failedAtUtc,
+            EventReceivedAtUtc = failedAtUtc
+        };
+        _db.FailedEvents.Add(entity);
+        await _db.SaveChangesAsync();
+        _db.ChangeTracker.Clear();
+        return entity.Id;
+    }
+
+    private FailedEventService NewService() =>
+        new(NewContext(), NullLogger<FailedEventService>.Instance, new FakeHostEnvironment());
+
+    private DiscordDbContext NewContext()
+    {
+        var options = new DbContextOptionsBuilder<DiscordDbContext>()
+            .UseNpgsql(fixture.Container.GetConnectionString())
+            .UseSnakeCaseNamingConvention()
+            .Options;
+        return new DiscordDbContext(options);
+    }
+
+    // ResolveAsync never touches the environment (only RecordFailureAsync's JSONL fallback does).
+    private sealed class FakeHostEnvironment : IHostEnvironment
+    {
+        public string EnvironmentName { get; set; } = "Test";
+        public string ApplicationName { get; set; } = "DiscordEventService.Tests";
+        public string ContentRootPath { get; set; } = Path.GetTempPath();
+        public IFileProvider ContentRootFileProvider { get; set; } = new NullFileProvider();
+    }
+}


### PR DESCRIPTION
Closes #200 · Part of epic #194 (§B2) · depends on #195 (done).

## Problem
`FailedEventEntity` carries replay fields (`RetryCount`, `IsResolved`, `ResolvedAtUtc`, `ResolutionNotes`) but `FailedEventService` only ever **wrote** them — no resolve path. `HealthCheckJob` alerts on unresolved failed events in a window, but nothing set `IsResolved=true`, so the alert could only clear by **aging out**.

## Change — the feasible dead-letter kernel (ack/resolve, NOT auto-reconstruction)
- **`FailedEventService.ResolveAsync(id, notes)`** — set-based `ExecuteUpdate` filtered on `!IsResolved` → sets `IsResolved`/`ResolvedAtUtc`/`ResolutionNotes`. Idempotent (re-resolve or unknown id is a no-op returning `false`); single mutation, no transaction.
- **`POST /api/ops/failed-events/{id}/resolve`** (`notes` query param) — 200 on resolve; clean **404** on unknown/already-resolved id (not 500). Matches the existing unauthenticated `/api/ops` group.
- **`HealthCheckJob` unchanged** (already filters `!IsResolved`) — the resolve writer is exactly what makes its alert clearable. Confirmed no edit needed.

## Scope — retry/reconstruction stays deferred (OD#5), per the issue's verification appendix ("ack only")
Automatic `EventJson`-based replay is **not** implemented. That payload is deliberately lossy (`BypassRecursiveConverterResolver`, MaxDepth, snowflake-dict) and DSharpPlus `*EventArgs` have no deserialization path, so a handler can't be re-driven from it; no working per-type re-driver exists today (`OrphanReplayService` is scan-only). A `RetryCount` cap would be **dead scaffolding with no caller**, so it is not added — `RetryCount` stays reserved for a future per-type replayer, unresolved rows are the manual-review bucket, and transient-vs-permanent context goes in `ResolutionNotes`. Documented on `ResolveAsync`. (Prod confirms the table is operationally empty: a single 26-day-old `NullReferenceException`, retry_count=0.)

## Tests / verification
- **3 Testcontainers cases**: resolve sets the three fields **and** the `HealthCheckJob` count query (`FailedAtUtc>window && !IsResolved`) then excludes the row — the discriminating proof the alert clears via resolution, not just aging out; idempotent re-resolve returns `false` without overwriting notes; unknown id returns `false`. Build green `-warnaserror`; suite **34/34**.
- **Live-verified on the dev bot**: seeded a `failed_events` row → `POST .../resolve?notes=...` → **200** `{resolved:true}`, DB row `is_resolved=true` + `resolved_at_utc` + notes set; second POST → **404** (idempotent, notes unchanged); bogus id → **404** JSON error; 0 errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)