### PR TITLE
feat: event_timestamp_utc from Discord metadata for AuditLog & Invite (#201)

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -52,7 +52,7 @@ _Currently realised_: a single thread row already exists in `channels` (recovere
 
 **`received_at_utc`**: when *we* received the gateway event. Always trustworthy.
 
-**`event_timestamp_utc`**: when the underlying Discord event *occurred*. Equals `received_at_utc` only when Discord doesn't supply a distinct timestamp (voice, presence, reaction adds). For messages, this is `e.Message.Timestamp`.
+**`event_timestamp_utc`**: when the underlying Discord event *occurred*. Equals `received_at_utc` only when Discord doesn't supply a distinct timestamp (voice, presence, reaction adds). For messages, this is `e.Message.Timestamp`; for audit-log entries, the entry snowflake's `CreationTimestamp` (§B3); for invite creation, `invite.CreatedAt` (§B3).
 
 _Avoid_: "created at" / "updated at" as event-stream vocabulary — those mean entity lifecycle, not event timing.
 

--- a/src/DiscordEventService/Services/EventHandlers/AuditLogEventHandler.cs
+++ b/src/DiscordEventService/Services/EventHandlers/AuditLogEventHandler.cs
@@ -23,7 +23,11 @@ public sealed class AuditLogEventHandler(EventPipeline pipeline) :
                     Reason = e.AuditLogEntry.Reason,
                     ChangesJson = null,
                     OptionsJson = null,
-                    EventTimestampUtc = ctx.ReceivedAtUtc,
+                    // The entry's snowflake encodes the server-side action time — the true Discord
+                    // event time (CONTEXT.md). Fall back to receive time only if the Id is absent.
+                    EventTimestampUtc = e.AuditLogEntry.Id != 0
+                        ? e.AuditLogEntry.CreationTimestamp.UtcDateTime
+                        : ctx.ReceivedAtUtc,
                     ReceivedAtUtc = ctx.ReceivedAtUtc,
                     RawEventJson = ctx.RawJson
                 });

--- a/src/DiscordEventService/Services/EventHandlers/InviteEventHandler.cs
+++ b/src/DiscordEventService/Services/EventHandlers/InviteEventHandler.cs
@@ -60,7 +60,11 @@ public sealed class InviteEventHandler(EventPipeline pipeline) :
                     MaxUses = invite.MaxUses,
                     IsTemporary = invite.IsTemporary,
                     Uses = invite.Uses,
-                    EventTimestampUtc = ctx.ReceivedAtUtc,
+                    // Discord supplies the invite's creation time — the true event time for a
+                    // creation (CONTEXT.md). Fall back to receive time only if it is absent.
+                    EventTimestampUtc = invite.CreatedAt != default
+                        ? invite.CreatedAt.UtcDateTime
+                        : ctx.ReceivedAtUtc,
                     ReceivedAtUtc = ctx.ReceivedAtUtc,
                     RawEventJson = ctx.RawJson
                 });


### PR DESCRIPTION
Closes #201 · Part of epic #194 (§B3).

## Problem
`CONTEXT.md` defines `event_timestamp_utc` as when the Discord event **occurred**, equal to `received_at_utc` only when Discord supplies no distinct timestamp. Two handlers whose event row *is* the timestamped subject discarded available metadata:
- `AuditLogEventHandler` ignored `e.AuditLogEntry.Id` (a snowflake encoding the server-side action time, exposed as `CreationTimestamp`).
- `InviteEventHandler` (InviteCreated) read `invite.CreatedAt` into the core entity but set the **event row's** `EventTimestampUtc = ctx.ReceivedAtUtc`.

## Change (tiny — two guarded reads)
- **AuditLog**: `EventTimestampUtc = e.AuditLogEntry.CreationTimestamp.UtcDateTime` (guard `Id != 0` → `ReceivedAtUtc`).
- **InviteCreated**: `EventTimestampUtc = invite.CreatedAt.UtcDateTime` (guard `!= default` → `ReceivedAtUtc`).

Both source fields are non-nullable `DateTimeOffset`, so the contract's "null-coalesce" is a default-guard.

## Scope (per the verified appendix — do NOT over-reach)
Left unchanged where Discord genuinely supplies nothing: `GuildMemberRemoved`/`GuildMemberUpdated` (`JoinedAt` is join time, not event time), pins (dedicated `LastPinTimestampUtc`), and **InviteDeleted** (partial invite, no `CreatedAt` → `received_at` is contract-correct). Distinct from #48 (UUIDv7 from event time), which is downstream and assumes `EventTimestampUtc` is already correct.

## Verification
- Build green `-warnaserror`; suite **34/34** (no synthetic-`*EventArgs` unit path — verified live).
- **Live-verified on the dev bot via MCP**:
  - Created an invite → `invite_events.event_timestamp_utc` (`…31.786`) is **distinct from and earlier than** `received_at_utc` (`…31.841`) and **exactly equals** the core `invites.created_at_utc` — proving it's sourced from `invite.CreatedAt`, not receive time.
  - Created a role (and the invite) → both emitted audit-log entries (ROLE_CREATE / INVITE_CREATE); each `audit_log_events.event_timestamp_utc` is ~40–78ms **earlier** than `received_at_utc`, derived from the entry snowflake. (Cross-check: the INVITE_CREATE entry's event time ≈ the invite's `CreatedAt`, ~1ms apart — same server moment from two snowflakes.)
  - The old code would have shown `event_timestamp_utc == received_at_utc` exactly.

CONTEXT.md updated to document the two metadata sources.

🤖 Generated with [Claude Code](https://claude.com/claude-code)