### PR TITLE
feat: extract BackfillJobExecutor owning scope, checkpoint transitions & exception routing (#202)

### DIFF
--- a/src/DiscordEventService/Jobs/BackfillJobBase.cs
+++ b/src/DiscordEventService/Jobs/BackfillJobBase.cs
@@ -1,50 +1,16 @@
 using DiscordEventService.Data;
 using DiscordEventService.Data.Entities.Core;
-using Microsoft.EntityFrameworkCore;
 
 namespace DiscordEventService.Jobs;
 
+/// <summary>
+/// Per-item progress helpers shared by every backfill job. The job lifecycle (scope, checkpoint
+/// get-or-create, status transitions) lives in <see cref="BackfillJobExecutor"/>; only the
+/// mid-loop progress/error book-keeping that runs inside a job's work delegate stays here.
+/// </summary>
 public abstract class BackfillJobBase
 {
     protected abstract BackfillType BackfillType { get; }
-
-    protected async Task<BackfillCheckpointEntity> GetOrCreateCheckpointAsync(
-        DiscordDbContext db, ulong guildId)
-    {
-        var checkpoint = await db.BackfillCheckpoints
-            .FirstOrDefaultAsync(c => c.GuildDiscordId == guildId && c.Type == BackfillType);
-
-        if (checkpoint is null)
-        {
-            checkpoint = new BackfillCheckpointEntity
-            {
-                GuildDiscordId = guildId,
-                Type = BackfillType,
-                Status = BackfillStatus.Pending,
-                StartedAtUtc = DateTime.UtcNow
-            };
-            db.BackfillCheckpoints.Add(checkpoint);
-            await db.SaveChangesAsync();
-        }
-
-        return checkpoint;
-    }
-
-    protected async Task MarkCompletedAsync(DiscordDbContext db, BackfillCheckpointEntity checkpoint)
-    {
-        checkpoint.Status = BackfillStatus.Completed;
-        checkpoint.CompletedAtUtc = DateTime.UtcNow;
-        await db.SaveChangesAsync();
-    }
-
-    protected async Task MarkFailedAsync(DiscordDbContext db, BackfillCheckpointEntity checkpoint, Exception ex)
-    {
-        checkpoint.Status = BackfillStatus.Failed;
-        checkpoint.ErrorCount++;
-        checkpoint.LastError = $"{ex.GetType().Name}: {ex.Message}";
-        checkpoint.LastErrorAtUtc = DateTime.UtcNow;
-        await db.SaveChangesAsync();
-    }
 
     protected async Task RecordErrorAsync(DiscordDbContext db, BackfillCheckpointEntity checkpoint, Exception ex)
     {

--- a/src/DiscordEventService/Jobs/BackfillJobExecutor.cs
+++ b/src/DiscordEventService/Jobs/BackfillJobExecutor.cs
@@ -1,0 +1,128 @@
+using DiscordEventService.Data;
+using DiscordEventService.Data.Entities.Core;
+using Microsoft.EntityFrameworkCore;
+
+namespace DiscordEventService.Jobs;
+
+/// <summary>
+/// Owns the lifecycle every backfill job shares: a fresh DI scope + DbContext, checkpoint
+/// get-or-create, the InProgress flip (with resume-cursor reset), and the four terminal
+/// transitions — Completed, short-circuit→Failed, cancelled→Failed (no rethrow), faulted→Failed
+/// (rethrow). Jobs supply only guild resolution + per-item work as a delegate, keeping
+/// <c>DiscordClient</c> out of the executor so its transitions are unit-testable against a real
+/// DbContext with no gateway.
+/// </summary>
+public sealed class BackfillJobExecutor(
+    IServiceScopeFactory scopeFactory,
+    ILogger<BackfillJobExecutor> logger)
+{
+    public async Task RunAsync(
+        BackfillType type,
+        ulong guildId,
+        Func<BackfillContext, Task<BackfillOutcome>> work,
+        CancellationToken cancellationToken)
+    {
+        using var scope = scopeFactory.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<DiscordDbContext>();
+
+        var checkpoint = await GetOrCreateCheckpointAsync(db, guildId, type);
+
+        // Only honor CurrentChannelId / LastProcessedId as a resume cursor when the previous run
+        // was interrupted mid-flight (Status==InProgress). After a terminal status the cursor points
+        // at the last channel processed; carrying it over would Skip all-but-the-last channel and
+        // silently mask gap events. Cleared atomically with the InProgress flip so no crash window
+        // leaves {InProgress, stale cursor}. No-op for the cursor-less jobs (fields stay null).
+        if (checkpoint.Status != BackfillStatus.InProgress)
+        {
+            checkpoint.CurrentChannelId = null;
+            checkpoint.LastProcessedId = null;
+        }
+        checkpoint.Status = BackfillStatus.InProgress;
+        await db.SaveChangesAsync(cancellationToken);
+
+        try
+        {
+            var outcome = await work(new BackfillContext(db, scope.ServiceProvider, checkpoint));
+
+            if (outcome.IsShortCircuit)
+            {
+                logger.LogWarning("{BackfillType} backfill short-circuited for guild {GuildId}: {Reason}",
+                    type, guildId, outcome.Reason);
+                await MarkFailedAsync(db, checkpoint, new InvalidOperationException(outcome.Reason));
+                return;
+            }
+
+            await MarkCompletedAsync(db, checkpoint);
+            logger.LogInformation("{BackfillType} backfill completed for guild {GuildId}: {Count} processed",
+                type, guildId, checkpoint.ProcessedCount);
+        }
+        catch (OperationCanceledException ex)
+        {
+            logger.LogWarning("{BackfillType} backfill cancelled for guild {GuildId} (likely deploy restart)",
+                type, guildId);
+            await MarkFailedAsync(db, checkpoint, ex);
+        }
+        catch (Exception ex)
+        {
+            logger.LogError(ex, "{BackfillType} backfill failed for guild {GuildId}", type, guildId);
+            await MarkFailedAsync(db, checkpoint, ex);
+            throw;
+        }
+    }
+
+    private static async Task<BackfillCheckpointEntity> GetOrCreateCheckpointAsync(
+        DiscordDbContext db, ulong guildId, BackfillType type)
+    {
+        var checkpoint = await db.BackfillCheckpoints
+            .FirstOrDefaultAsync(c => c.GuildDiscordId == guildId && c.Type == type);
+
+        if (checkpoint is null)
+        {
+            checkpoint = new BackfillCheckpointEntity
+            {
+                GuildDiscordId = guildId,
+                Type = type,
+                Status = BackfillStatus.Pending,
+                StartedAtUtc = DateTime.UtcNow
+            };
+            db.BackfillCheckpoints.Add(checkpoint);
+            // Terminal/lifecycle saves are arg-less so they still land if the run's token is
+            // already cancelled (the cancelled path must persist a Failed status).
+            await db.SaveChangesAsync();
+        }
+
+        return checkpoint;
+    }
+
+    private static async Task MarkCompletedAsync(DiscordDbContext db, BackfillCheckpointEntity checkpoint)
+    {
+        checkpoint.Status = BackfillStatus.Completed;
+        checkpoint.CompletedAtUtc = DateTime.UtcNow;
+        await db.SaveChangesAsync();
+    }
+
+    private static async Task MarkFailedAsync(DiscordDbContext db, BackfillCheckpointEntity checkpoint, Exception ex)
+    {
+        checkpoint.Status = BackfillStatus.Failed;
+        checkpoint.ErrorCount++;
+        checkpoint.LastError = $"{ex.GetType().Name}: {ex.Message}";
+        checkpoint.LastErrorAtUtc = DateTime.UtcNow;
+        await db.SaveChangesAsync();
+    }
+}
+
+public sealed record BackfillContext(
+    DiscordDbContext Db,
+    IServiceProvider Services,
+    BackfillCheckpointEntity Checkpoint);
+
+public sealed record BackfillOutcome
+{
+    public required bool IsShortCircuit { get; init; }
+    public string? Reason { get; init; }
+
+    public static BackfillOutcome Completed { get; } = new BackfillOutcome { IsShortCircuit = false };
+
+    public static BackfillOutcome ShortCircuit(string reason) =>
+        new BackfillOutcome { IsShortCircuit = true, Reason = reason };
+}

--- a/src/DiscordEventService/Jobs/ChannelsBackfillJob.cs
+++ b/src/DiscordEventService/Jobs/ChannelsBackfillJob.cs
@@ -5,43 +5,30 @@ using Microsoft.EntityFrameworkCore;
 
 namespace DiscordEventService.Jobs;
 
-public class ChannelsBackfillJob(
-    IServiceScopeFactory scopeFactory,
+public sealed class ChannelsBackfillJob(
     DiscordClient discordClient,
-    ILogger<ChannelsBackfillJob> logger) : BackfillJobBase, IBackfillJob
+    BackfillJobExecutor executor) : BackfillJobBase, IBackfillJob
 {
     protected override BackfillType BackfillType => BackfillType.Channels;
 
-    public async Task ExecuteAsync(ulong guildId, CancellationToken cancellationToken)
-    {
-        using var scope = scopeFactory.CreateScope();
-        var db = scope.ServiceProvider.GetRequiredService<DiscordDbContext>();
-
-        var checkpoint = await GetOrCreateCheckpointAsync(db, guildId);
-        checkpoint.Status = BackfillStatus.InProgress;
-        await db.SaveChangesAsync(cancellationToken);
-
-        try
+    public Task ExecuteAsync(ulong guildId, CancellationToken cancellationToken)
+        => executor.RunAsync(BackfillType, guildId, async ctx =>
         {
             var guild = await discordClient.GetGuildAsync(guildId);
             var channels = await guild.GetChannelsAsync();
-            var guildEntity = await db.Guilds.FirstOrDefaultAsync(g => g.DiscordId == guildId, cancellationToken);
+            var guildEntity = await ctx.Db.Guilds.FirstOrDefaultAsync(g => g.DiscordId == guildId, cancellationToken);
 
             if (guildEntity is null)
-            {
-                logger.LogWarning("Guild {GuildId} not found in database, cannot backfill channels", guildId);
-                await MarkFailedAsync(db, checkpoint, new InvalidOperationException($"Guild {guildId} not found in database"));
-                return;
-            }
+                return BackfillOutcome.ShortCircuit($"Guild {guildId} not found in database");
 
-            checkpoint.TotalCount = channels.Count;
-            await db.SaveChangesAsync(cancellationToken);
+            ctx.Checkpoint.TotalCount = channels.Count;
+            await ctx.Db.SaveChangesAsync(cancellationToken);
 
             foreach (var channel in channels)
             {
                 cancellationToken.ThrowIfCancellationRequested();
 
-                await db.Channels.UpsertAsync(
+                await ctx.Db.Channels.UpsertAsync(
                     c => c.DiscordId == channel.Id,
                     s => s
                         .SetProperty(c => c.Name, channel.Name)
@@ -72,27 +59,12 @@ public class ChannelsBackfillJob(
                     c => c.Id,
                     cancellationToken);
 
-                checkpoint.ProcessedCount++;
+                ctx.Checkpoint.ProcessedCount++;
 
-                if (checkpoint.ProcessedCount % 50 == 0)
-                {
-                    await SaveProgressAsync(db, checkpoint);
-                }
+                if (ctx.Checkpoint.ProcessedCount % 50 == 0)
+                    await SaveProgressAsync(ctx.Db, ctx.Checkpoint);
             }
 
-            await MarkCompletedAsync(db, checkpoint);
-            logger.LogInformation("Channels backfill completed for guild {GuildId}: {Count} channels", guildId, checkpoint.ProcessedCount);
-        }
-        catch (OperationCanceledException ex)
-        {
-            logger.LogWarning("Channels backfill cancelled for guild {GuildId} (likely deploy restart)", guildId);
-            await MarkFailedAsync(db, checkpoint, ex);
-        }
-        catch (Exception ex)
-        {
-            logger.LogError(ex, "Channels backfill failed for guild {GuildId}", guildId);
-            await MarkFailedAsync(db, checkpoint, ex);
-            throw;
-        }
-    }
+            return BackfillOutcome.Completed;
+        }, cancellationToken);
 }

--- a/src/DiscordEventService/Jobs/EmojisBackfillJob.cs
+++ b/src/DiscordEventService/Jobs/EmojisBackfillJob.cs
@@ -5,42 +5,29 @@ using Microsoft.EntityFrameworkCore;
 
 namespace DiscordEventService.Jobs;
 
-public class EmojisBackfillJob(
-    IServiceScopeFactory scopeFactory,
+public sealed class EmojisBackfillJob(
     DiscordClient discordClient,
-    ILogger<EmojisBackfillJob> logger) : BackfillJobBase, IBackfillJob
+    BackfillJobExecutor executor) : BackfillJobBase, IBackfillJob
 {
     protected override BackfillType BackfillType => BackfillType.Emojis;
 
-    public async Task ExecuteAsync(ulong guildId, CancellationToken cancellationToken)
-    {
-        using var scope = scopeFactory.CreateScope();
-        var db = scope.ServiceProvider.GetRequiredService<DiscordDbContext>();
-
-        var checkpoint = await GetOrCreateCheckpointAsync(db, guildId);
-        checkpoint.Status = BackfillStatus.InProgress;
-        await db.SaveChangesAsync(cancellationToken);
-
-        try
+    public Task ExecuteAsync(ulong guildId, CancellationToken cancellationToken)
+        => executor.RunAsync(BackfillType, guildId, async ctx =>
         {
             var guild = await discordClient.GetGuildAsync(guildId);
-            var guildEntity = await db.Guilds.FirstOrDefaultAsync(g => g.DiscordId == guildId, cancellationToken);
+            var guildEntity = await ctx.Db.Guilds.FirstOrDefaultAsync(g => g.DiscordId == guildId, cancellationToken);
 
             if (guildEntity is null)
-            {
-                logger.LogWarning("Guild {GuildId} not found in database, cannot backfill emojis", guildId);
-                await MarkFailedAsync(db, checkpoint, new InvalidOperationException($"Guild {guildId} not found in database"));
-                return;
-            }
+                return BackfillOutcome.ShortCircuit($"Guild {guildId} not found in database");
 
-            checkpoint.TotalCount = guild.Emojis.Count;
-            await db.SaveChangesAsync(cancellationToken);
+            ctx.Checkpoint.TotalCount = guild.Emojis.Count;
+            await ctx.Db.SaveChangesAsync(cancellationToken);
 
             foreach (var emoji in guild.Emojis.Values)
             {
                 cancellationToken.ThrowIfCancellationRequested();
 
-                await db.Emotes.UpsertAsync(
+                await ctx.Db.Emotes.UpsertAsync(
                     e => e.DiscordId == emoji.Id,
                     s => s
                         .SetProperty(e => e.Name, emoji.Name)
@@ -59,27 +46,12 @@ public class EmojisBackfillJob(
                     e => e.Id,
                     cancellationToken);
 
-                checkpoint.ProcessedCount++;
+                ctx.Checkpoint.ProcessedCount++;
 
-                if (checkpoint.ProcessedCount % 50 == 0)
-                {
-                    await SaveProgressAsync(db, checkpoint);
-                }
+                if (ctx.Checkpoint.ProcessedCount % 50 == 0)
+                    await SaveProgressAsync(ctx.Db, ctx.Checkpoint);
             }
 
-            await MarkCompletedAsync(db, checkpoint);
-            logger.LogInformation("Emojis backfill completed for guild {GuildId}: {Count} emojis", guildId, checkpoint.ProcessedCount);
-        }
-        catch (OperationCanceledException ex)
-        {
-            logger.LogWarning("Emojis backfill cancelled for guild {GuildId} (likely deploy restart)", guildId);
-            await MarkFailedAsync(db, checkpoint, ex);
-        }
-        catch (Exception ex)
-        {
-            logger.LogError(ex, "Emojis backfill failed for guild {GuildId}", guildId);
-            await MarkFailedAsync(db, checkpoint, ex);
-            throw;
-        }
-    }
+            return BackfillOutcome.Completed;
+        }, cancellationToken);
 }

--- a/src/DiscordEventService/Jobs/MembersBackfillJob.cs
+++ b/src/DiscordEventService/Jobs/MembersBackfillJob.cs
@@ -1,4 +1,3 @@
-using DiscordEventService.Data;
 using DiscordEventService.Data.Entities.Core;
 using DiscordEventService.Services;
 using DSharpPlus;
@@ -6,34 +5,23 @@ using Microsoft.EntityFrameworkCore;
 
 namespace DiscordEventService.Jobs;
 
-public class MembersBackfillJob(
-    IServiceScopeFactory scopeFactory,
+public sealed class MembersBackfillJob(
     DiscordClient discordClient,
+    BackfillJobExecutor executor,
     ILogger<MembersBackfillJob> logger) : BackfillJobBase, IBackfillJob
 {
     protected override BackfillType BackfillType => BackfillType.Members;
 
-    public async Task ExecuteAsync(ulong guildId, CancellationToken cancellationToken)
-    {
-        using var scope = scopeFactory.CreateScope();
-        var db = scope.ServiceProvider.GetRequiredService<DiscordDbContext>();
-        var userService = scope.ServiceProvider.GetRequiredService<UserService>();
-
-        var checkpoint = await GetOrCreateCheckpointAsync(db, guildId);
-        checkpoint.Status = BackfillStatus.InProgress;
-        await db.SaveChangesAsync(cancellationToken);
-
-        try
+    public Task ExecuteAsync(ulong guildId, CancellationToken cancellationToken)
+        => executor.RunAsync(BackfillType, guildId, async ctx =>
         {
+            var userService = ctx.Services.GetRequiredService<UserService>();
+
             var guild = await discordClient.GetGuildAsync(guildId);
-            var guildEntity = await db.Guilds.FirstOrDefaultAsync(g => g.DiscordId == guildId, cancellationToken);
+            var guildEntity = await ctx.Db.Guilds.FirstOrDefaultAsync(g => g.DiscordId == guildId, cancellationToken);
 
             if (guildEntity is null)
-            {
-                logger.LogWarning("Guild {GuildId} not found in database, cannot backfill members", guildId);
-                await MarkFailedAsync(db, checkpoint, new InvalidOperationException($"Guild {guildId} not found in database"));
-                return;
-            }
+                return BackfillOutcome.ShortCircuit($"Guild {guildId} not found in database");
 
             // Get all members - requires GUILD_MEMBERS privileged intent
             // DSharpPlus v5 returns IAsyncEnumerable
@@ -43,8 +31,8 @@ public class MembersBackfillJob(
                 membersList.Add(member);
             }
 
-            checkpoint.TotalCount = membersList.Count;
-            await db.SaveChangesAsync(cancellationToken);
+            ctx.Checkpoint.TotalCount = membersList.Count;
+            await ctx.Db.SaveChangesAsync(cancellationToken);
 
             foreach (var member in membersList)
             {
@@ -53,34 +41,19 @@ public class MembersBackfillJob(
                 try
                 {
                     await userService.UpsertMemberAsync(member);
-                    checkpoint.ProcessedCount++;
+                    ctx.Checkpoint.ProcessedCount++;
                 }
                 catch (Exception ex)
                 {
                     logger.LogWarning(ex, "Failed to upsert member {MemberId} in guild {GuildId}", member.Id, guildId);
-                    await RecordErrorAsync(db, checkpoint, ex);
+                    await RecordErrorAsync(ctx.Db, ctx.Checkpoint, ex);
                 }
 
                 // Save progress periodically (every 100 members)
-                if (checkpoint.ProcessedCount % 100 == 0)
-                {
-                    await db.SaveChangesAsync(cancellationToken);
-                }
+                if (ctx.Checkpoint.ProcessedCount % 100 == 0)
+                    await ctx.Db.SaveChangesAsync(cancellationToken);
             }
 
-            await MarkCompletedAsync(db, checkpoint);
-            logger.LogInformation("Members backfill completed for guild {GuildId}: {Count} members", guildId, checkpoint.ProcessedCount);
-        }
-        catch (OperationCanceledException ex)
-        {
-            logger.LogWarning("Members backfill cancelled for guild {GuildId} (likely deploy restart)", guildId);
-            await MarkFailedAsync(db, checkpoint, ex);
-        }
-        catch (Exception ex)
-        {
-            logger.LogError(ex, "Members backfill failed for guild {GuildId}", guildId);
-            await MarkFailedAsync(db, checkpoint, ex);
-            throw;
-        }
-    }
+            return BackfillOutcome.Completed;
+        }, cancellationToken);
 }

--- a/src/DiscordEventService/Jobs/MessagesBackfillJob.cs
+++ b/src/DiscordEventService/Jobs/MessagesBackfillJob.cs
@@ -9,9 +9,9 @@ using Microsoft.EntityFrameworkCore;
 
 namespace DiscordEventService.Jobs;
 
-public class MessagesBackfillJob(
-    IServiceScopeFactory scopeFactory,
+public sealed class MessagesBackfillJob(
     DiscordClient discordClient,
+    BackfillJobExecutor executor,
     ILogger<MessagesBackfillJob> logger) : BackfillJobBase, IBackfillJob
 {
     protected override BackfillType BackfillType => BackfillType.Messages;
@@ -22,40 +22,17 @@ public class MessagesBackfillJob(
     public Task ExecuteAsync(ulong guildId, CancellationToken cancellationToken)
         => ExecuteAsync(guildId, null, cancellationToken);
 
-    public async Task ExecuteAsync(ulong guildId, DateTime? afterTimestampUtc, CancellationToken cancellationToken)
-    {
-        using var scope = scopeFactory.CreateScope();
-        var db = scope.ServiceProvider.GetRequiredService<DiscordDbContext>();
-        var userService = scope.ServiceProvider.GetRequiredService<UserService>();
-
-        var checkpoint = await GetOrCreateCheckpointAsync(db, guildId);
-        // Only honor CurrentChannelId / LastProcessedId as a resume cursor when
-        // the previous run was actually interrupted mid-flight (Status==InProgress).
-        // After a Completed/Failed/Cancelled run the cursor points at the last
-        // channel processed; carrying it over would Skip(channels.Length-1) and
-        // silently scan only the final channel — masking gap events in every
-        // other channel.
-        var isResume = checkpoint.Status == BackfillStatus.InProgress;
-        if (!isResume)
+    public Task ExecuteAsync(ulong guildId, DateTime? afterTimestampUtc, CancellationToken cancellationToken)
+        => executor.RunAsync(BackfillType, guildId, async ctx =>
         {
-            checkpoint.CurrentChannelId = null;
-            checkpoint.LastProcessedId = null;
-        }
-        checkpoint.Status = BackfillStatus.InProgress;
-        await db.SaveChangesAsync(cancellationToken);
+            var userService = ctx.Services.GetRequiredService<UserService>();
 
-        try
-        {
             var guild = await discordClient.GetGuildAsync(guildId);
             var channels = await guild.GetChannelsAsync();
-            var guildEntity = await db.Guilds.FirstOrDefaultAsync(g => g.DiscordId == guildId, cancellationToken);
+            var guildEntity = await ctx.Db.Guilds.FirstOrDefaultAsync(g => g.DiscordId == guildId, cancellationToken);
 
             if (guildEntity is null)
-            {
-                logger.LogWarning("Guild {GuildId} not found in database, cannot backfill messages", guildId);
-                await MarkFailedAsync(db, checkpoint, new InvalidOperationException($"Guild {guildId} not found in database"));
-                return;
-            }
+                return BackfillOutcome.ShortCircuit($"Guild {guildId} not found in database");
 
             // Filter to text-based channels
             var textChannels = channels
@@ -67,10 +44,13 @@ public class MessagesBackfillJob(
                 .OrderBy(c => c.Id)
                 .ToList();
 
-            // Resume from checkpoint channel if exists
-            if (checkpoint.CurrentChannelId.HasValue)
+            // Resume from checkpoint channel if exists. The cursor reset (clear when the prior run
+            // was not InProgress) is owned by BackfillJobExecutor, so CurrentChannelId here is either
+            // null (fresh run) or the channel a genuinely-interrupted run stopped on. Carrying a
+            // stale cursor over a completed run would Skip all-but-the-last channel and mask gaps.
+            if (ctx.Checkpoint.CurrentChannelId.HasValue)
             {
-                var checkpointChannelIndex = textChannels.FindIndex(c => c.Id == checkpoint.CurrentChannelId.Value);
+                var checkpointChannelIndex = textChannels.FindIndex(c => c.Id == ctx.Checkpoint.CurrentChannelId.Value);
                 if (checkpointChannelIndex >= 0)
                 {
                     textChannels = textChannels.Skip(checkpointChannelIndex).ToList();
@@ -78,9 +58,9 @@ public class MessagesBackfillJob(
                 else
                 {
                     logger.LogWarning("Checkpoint channel {ChannelId} not found in guild {GuildId}, restarting from beginning",
-                        checkpoint.CurrentChannelId.Value, guildId);
-                    checkpoint.CurrentChannelId = null;
-                    checkpoint.LastProcessedId = null;
+                        ctx.Checkpoint.CurrentChannelId.Value, guildId);
+                    ctx.Checkpoint.CurrentChannelId = null;
+                    ctx.Checkpoint.LastProcessedId = null;
                 }
             }
 
@@ -88,42 +68,29 @@ public class MessagesBackfillJob(
             {
                 cancellationToken.ThrowIfCancellationRequested();
 
-                checkpoint.CurrentChannelId = channel.Id;
-                await db.SaveChangesAsync(cancellationToken);
+                ctx.Checkpoint.CurrentChannelId = channel.Id;
+                await ctx.Db.SaveChangesAsync(cancellationToken);
 
                 logger.LogInformation("Backfilling messages for channel {ChannelName} ({ChannelId}) in guild {GuildId}",
                     channel.Name, channel.Id, guildId);
 
                 try
                 {
-                    await BackfillChannelMessagesAsync(db, userService, guildEntity, channel, checkpoint, afterTimestampUtc, cancellationToken);
+                    await BackfillChannelMessagesAsync(ctx.Db, userService, guildEntity, channel, ctx.Checkpoint, afterTimestampUtc, cancellationToken);
                 }
                 catch (Exception ex) when (ex is not OperationCanceledException)
                 {
                     logger.LogWarning(ex, "Failed to backfill messages for channel {ChannelId}, continuing with next channel", channel.Id);
-                    await RecordErrorAsync(db, checkpoint, ex);
+                    await RecordErrorAsync(ctx.Db, ctx.Checkpoint, ex);
                 }
 
                 // Reset for next channel
-                checkpoint.LastProcessedId = null;
-                await db.SaveChangesAsync(cancellationToken);
+                ctx.Checkpoint.LastProcessedId = null;
+                await ctx.Db.SaveChangesAsync(cancellationToken);
             }
 
-            await MarkCompletedAsync(db, checkpoint);
-            logger.LogInformation("Messages backfill completed for guild {GuildId}: {Count} messages", guildId, checkpoint.ProcessedCount);
-        }
-        catch (OperationCanceledException ex)
-        {
-            logger.LogWarning("Messages backfill cancelled for guild {GuildId} (likely deploy restart)", guildId);
-            await MarkFailedAsync(db, checkpoint, ex);
-        }
-        catch (Exception ex)
-        {
-            logger.LogError(ex, "Messages backfill failed for guild {GuildId}", guildId);
-            await MarkFailedAsync(db, checkpoint, ex);
-            throw;
-        }
-    }
+            return BackfillOutcome.Completed;
+        }, cancellationToken);
 
     private async Task BackfillChannelMessagesAsync(
         DiscordDbContext db,

--- a/src/DiscordEventService/Jobs/ReactionsBackfillJob.cs
+++ b/src/DiscordEventService/Jobs/ReactionsBackfillJob.cs
@@ -8,9 +8,9 @@ using Microsoft.EntityFrameworkCore;
 
 namespace DiscordEventService.Jobs;
 
-public class ReactionsBackfillJob(
-    IServiceScopeFactory scopeFactory,
+public sealed class ReactionsBackfillJob(
     DiscordClient discordClient,
+    BackfillJobExecutor executor,
     ILogger<ReactionsBackfillJob> logger) : BackfillJobBase, IBackfillJob
 {
     protected override BackfillType BackfillType => BackfillType.Reactions;
@@ -20,37 +20,17 @@ public class ReactionsBackfillJob(
     public Task ExecuteAsync(ulong guildId, CancellationToken cancellationToken)
         => ExecuteAsync(guildId, null, cancellationToken);
 
-    public async Task ExecuteAsync(ulong guildId, DateTime? afterTimestampUtc, CancellationToken cancellationToken)
-    {
-        using var scope = scopeFactory.CreateScope();
-        var db = scope.ServiceProvider.GetRequiredService<DiscordDbContext>();
-        var userService = scope.ServiceProvider.GetRequiredService<UserService>();
-
-        var checkpoint = await GetOrCreateCheckpointAsync(db, guildId);
-        // Only honor CurrentChannelId / LastProcessedId as a resume cursor when
-        // the previous run was actually interrupted mid-flight (Status==InProgress).
-        // See MessagesBackfillJob for the full rationale.
-        var isResume = checkpoint.Status == BackfillStatus.InProgress;
-        if (!isResume)
+    public Task ExecuteAsync(ulong guildId, DateTime? afterTimestampUtc, CancellationToken cancellationToken)
+        => executor.RunAsync(BackfillType, guildId, async ctx =>
         {
-            checkpoint.CurrentChannelId = null;
-            checkpoint.LastProcessedId = null;
-        }
-        checkpoint.Status = BackfillStatus.InProgress;
-        await db.SaveChangesAsync(cancellationToken);
+            var userService = ctx.Services.GetRequiredService<UserService>();
 
-        try
-        {
             var guild = await discordClient.GetGuildAsync(guildId);
             var channels = await guild.GetChannelsAsync();
-            var guildEntity = await db.Guilds.FirstOrDefaultAsync(g => g.DiscordId == guildId, cancellationToken);
+            var guildEntity = await ctx.Db.Guilds.FirstOrDefaultAsync(g => g.DiscordId == guildId, cancellationToken);
 
             if (guildEntity is null)
-            {
-                logger.LogWarning("Guild {GuildId} not found in database, cannot backfill reactions", guildId);
-                await MarkFailedAsync(db, checkpoint, new InvalidOperationException($"Guild {guildId} not found in database"));
-                return;
-            }
+                return BackfillOutcome.ShortCircuit($"Guild {guildId} not found in database");
 
             // Get all text channels
             var textChannels = channels
@@ -62,10 +42,12 @@ public class ReactionsBackfillJob(
                 .OrderBy(c => c.Id)
                 .ToList();
 
-            // Resume from checkpoint channel if exists
-            if (checkpoint.CurrentChannelId.HasValue)
+            // Resume from checkpoint channel if exists. The cursor reset (clear when the prior run
+            // was not InProgress) is owned by BackfillJobExecutor, so CurrentChannelId here is either
+            // null (fresh run) or the channel a genuinely-interrupted run stopped on.
+            if (ctx.Checkpoint.CurrentChannelId.HasValue)
             {
-                var checkpointChannelIndex = textChannels.FindIndex(c => c.Id == checkpoint.CurrentChannelId.Value);
+                var checkpointChannelIndex = textChannels.FindIndex(c => c.Id == ctx.Checkpoint.CurrentChannelId.Value);
                 if (checkpointChannelIndex >= 0)
                 {
                     textChannels = textChannels.Skip(checkpointChannelIndex).ToList();
@@ -73,9 +55,9 @@ public class ReactionsBackfillJob(
                 else
                 {
                     logger.LogWarning("Checkpoint channel {ChannelId} not found in guild {GuildId}, restarting from beginning",
-                        checkpoint.CurrentChannelId.Value, guildId);
-                    checkpoint.CurrentChannelId = null;
-                    checkpoint.LastProcessedId = null;
+                        ctx.Checkpoint.CurrentChannelId.Value, guildId);
+                    ctx.Checkpoint.CurrentChannelId = null;
+                    ctx.Checkpoint.LastProcessedId = null;
                 }
             }
 
@@ -83,42 +65,29 @@ public class ReactionsBackfillJob(
             {
                 cancellationToken.ThrowIfCancellationRequested();
 
-                checkpoint.CurrentChannelId = channel.Id;
-                await db.SaveChangesAsync(cancellationToken);
+                ctx.Checkpoint.CurrentChannelId = channel.Id;
+                await ctx.Db.SaveChangesAsync(cancellationToken);
 
                 logger.LogInformation("Backfilling reactions for channel {ChannelName} ({ChannelId}) in guild {GuildId}",
                     channel.Name, channel.Id, guildId);
 
                 try
                 {
-                    await BackfillChannelReactionsAsync(db, userService, guildEntity, channel, checkpoint, afterTimestampUtc, cancellationToken);
+                    await BackfillChannelReactionsAsync(ctx.Db, userService, guildEntity, channel, ctx.Checkpoint, afterTimestampUtc, cancellationToken);
                 }
                 catch (Exception ex) when (ex is not OperationCanceledException)
                 {
                     logger.LogWarning(ex, "Failed to backfill reactions for channel {ChannelId}, continuing with next channel", channel.Id);
-                    await RecordErrorAsync(db, checkpoint, ex);
+                    await RecordErrorAsync(ctx.Db, ctx.Checkpoint, ex);
                 }
 
                 // Reset for next channel
-                checkpoint.LastProcessedId = null;
-                await db.SaveChangesAsync(cancellationToken);
+                ctx.Checkpoint.LastProcessedId = null;
+                await ctx.Db.SaveChangesAsync(cancellationToken);
             }
 
-            await MarkCompletedAsync(db, checkpoint);
-            logger.LogInformation("Reactions backfill completed for guild {GuildId}: {Count} reactions", guildId, checkpoint.ProcessedCount);
-        }
-        catch (OperationCanceledException ex)
-        {
-            logger.LogWarning("Reactions backfill cancelled for guild {GuildId} (likely deploy restart)", guildId);
-            await MarkFailedAsync(db, checkpoint, ex);
-        }
-        catch (Exception ex)
-        {
-            logger.LogError(ex, "Reactions backfill failed for guild {GuildId}", guildId);
-            await MarkFailedAsync(db, checkpoint, ex);
-            throw;
-        }
-    }
+            return BackfillOutcome.Completed;
+        }, cancellationToken);
 
     private async Task BackfillChannelReactionsAsync(
         DiscordDbContext db,

--- a/src/DiscordEventService/Jobs/RolesBackfillJob.cs
+++ b/src/DiscordEventService/Jobs/RolesBackfillJob.cs
@@ -5,36 +5,23 @@ using Microsoft.EntityFrameworkCore;
 
 namespace DiscordEventService.Jobs;
 
-public class RolesBackfillJob(
-    IServiceScopeFactory scopeFactory,
+public sealed class RolesBackfillJob(
     DiscordClient discordClient,
-    ILogger<RolesBackfillJob> logger) : BackfillJobBase, IBackfillJob
+    BackfillJobExecutor executor) : BackfillJobBase, IBackfillJob
 {
     protected override BackfillType BackfillType => BackfillType.Roles;
 
-    public async Task ExecuteAsync(ulong guildId, CancellationToken cancellationToken)
-    {
-        using var scope = scopeFactory.CreateScope();
-        var db = scope.ServiceProvider.GetRequiredService<DiscordDbContext>();
-
-        var checkpoint = await GetOrCreateCheckpointAsync(db, guildId);
-        checkpoint.Status = BackfillStatus.InProgress;
-        await db.SaveChangesAsync(cancellationToken);
-
-        try
+    public Task ExecuteAsync(ulong guildId, CancellationToken cancellationToken)
+        => executor.RunAsync(BackfillType, guildId, async ctx =>
         {
             var guild = await discordClient.GetGuildAsync(guildId);
-            var guildEntity = await db.Guilds.FirstOrDefaultAsync(g => g.DiscordId == guildId, cancellationToken);
+            var guildEntity = await ctx.Db.Guilds.FirstOrDefaultAsync(g => g.DiscordId == guildId, cancellationToken);
 
             if (guildEntity is null)
-            {
-                logger.LogWarning("Guild {GuildId} not found in database, cannot backfill roles", guildId);
-                await MarkFailedAsync(db, checkpoint, new InvalidOperationException($"Guild {guildId} not found in database"));
-                return;
-            }
+                return BackfillOutcome.ShortCircuit($"Guild {guildId} not found in database");
 
-            checkpoint.TotalCount = guild.Roles.Count;
-            await db.SaveChangesAsync(cancellationToken);
+            ctx.Checkpoint.TotalCount = guild.Roles.Count;
+            await ctx.Db.SaveChangesAsync(cancellationToken);
 
             foreach (var role in guild.Roles.Values)
             {
@@ -42,7 +29,7 @@ public class RolesBackfillJob(
 
                 var permissions = long.TryParse(role.Permissions.ToString(), out var perm) ? perm : 0;
 
-                await db.Roles.UpsertAsync(
+                await ctx.Db.Roles.UpsertAsync(
                     r => r.DiscordId == role.Id,
                     s => s
                         .SetProperty(r => r.Name, role.Name)
@@ -69,27 +56,12 @@ public class RolesBackfillJob(
                     r => r.Id,
                     cancellationToken);
 
-                checkpoint.ProcessedCount++;
+                ctx.Checkpoint.ProcessedCount++;
 
-                if (checkpoint.ProcessedCount % 50 == 0)
-                {
-                    await SaveProgressAsync(db, checkpoint);
-                }
+                if (ctx.Checkpoint.ProcessedCount % 50 == 0)
+                    await SaveProgressAsync(ctx.Db, ctx.Checkpoint);
             }
 
-            await MarkCompletedAsync(db, checkpoint);
-            logger.LogInformation("Roles backfill completed for guild {GuildId}: {Count} roles", guildId, checkpoint.ProcessedCount);
-        }
-        catch (OperationCanceledException ex)
-        {
-            logger.LogWarning("Roles backfill cancelled for guild {GuildId} (likely deploy restart)", guildId);
-            await MarkFailedAsync(db, checkpoint, ex);
-        }
-        catch (Exception ex)
-        {
-            logger.LogError(ex, "Roles backfill failed for guild {GuildId}", guildId);
-            await MarkFailedAsync(db, checkpoint, ex);
-            throw;
-        }
-    }
+            return BackfillOutcome.Completed;
+        }, cancellationToken);
 }

--- a/src/DiscordEventService/Jobs/StickersBackfillJob.cs
+++ b/src/DiscordEventService/Jobs/StickersBackfillJob.cs
@@ -5,36 +5,23 @@ using Microsoft.EntityFrameworkCore;
 
 namespace DiscordEventService.Jobs;
 
-public class StickersBackfillJob(
-    IServiceScopeFactory scopeFactory,
+public sealed class StickersBackfillJob(
     DiscordClient discordClient,
-    ILogger<StickersBackfillJob> logger) : BackfillJobBase, IBackfillJob
+    BackfillJobExecutor executor) : BackfillJobBase, IBackfillJob
 {
     protected override BackfillType BackfillType => BackfillType.Stickers;
 
-    public async Task ExecuteAsync(ulong guildId, CancellationToken cancellationToken)
-    {
-        using var scope = scopeFactory.CreateScope();
-        var db = scope.ServiceProvider.GetRequiredService<DiscordDbContext>();
-
-        var checkpoint = await GetOrCreateCheckpointAsync(db, guildId);
-        checkpoint.Status = BackfillStatus.InProgress;
-        await db.SaveChangesAsync(cancellationToken);
-
-        try
+    public Task ExecuteAsync(ulong guildId, CancellationToken cancellationToken)
+        => executor.RunAsync(BackfillType, guildId, async ctx =>
         {
             var guild = await discordClient.GetGuildAsync(guildId);
-            var guildEntity = await db.Guilds.FirstOrDefaultAsync(g => g.DiscordId == guildId, cancellationToken);
+            var guildEntity = await ctx.Db.Guilds.FirstOrDefaultAsync(g => g.DiscordId == guildId, cancellationToken);
 
             if (guildEntity is null)
-            {
-                logger.LogWarning("Guild {GuildId} not found in database, cannot backfill stickers", guildId);
-                await MarkFailedAsync(db, checkpoint, new InvalidOperationException($"Guild {guildId} not found in database"));
-                return;
-            }
+                return BackfillOutcome.ShortCircuit($"Guild {guildId} not found in database");
 
-            checkpoint.TotalCount = guild.Stickers.Count;
-            await db.SaveChangesAsync(cancellationToken);
+            ctx.Checkpoint.TotalCount = guild.Stickers.Count;
+            await ctx.Db.SaveChangesAsync(cancellationToken);
 
             foreach (var sticker in guild.Stickers.Values)
             {
@@ -42,7 +29,7 @@ public class StickersBackfillJob(
 
                 var tags = sticker.Tags != null ? string.Join(",", sticker.Tags) : null;
 
-                await db.Stickers.UpsertAsync(
+                await ctx.Db.Stickers.UpsertAsync(
                     s => s.DiscordId == sticker.Id,
                     s => s
                         .SetProperty(st => st.Name, sticker.Name ?? string.Empty)
@@ -68,27 +55,12 @@ public class StickersBackfillJob(
                     s => s.Id,
                     cancellationToken);
 
-                checkpoint.ProcessedCount++;
+                ctx.Checkpoint.ProcessedCount++;
 
-                if (checkpoint.ProcessedCount % 50 == 0)
-                {
-                    await SaveProgressAsync(db, checkpoint);
-                }
+                if (ctx.Checkpoint.ProcessedCount % 50 == 0)
+                    await SaveProgressAsync(ctx.Db, ctx.Checkpoint);
             }
 
-            await MarkCompletedAsync(db, checkpoint);
-            logger.LogInformation("Stickers backfill completed for guild {GuildId}: {Count} stickers", guildId, checkpoint.ProcessedCount);
-        }
-        catch (OperationCanceledException ex)
-        {
-            logger.LogWarning("Stickers backfill cancelled for guild {GuildId} (likely deploy restart)", guildId);
-            await MarkFailedAsync(db, checkpoint, ex);
-        }
-        catch (Exception ex)
-        {
-            logger.LogError(ex, "Stickers backfill failed for guild {GuildId}", guildId);
-            await MarkFailedAsync(db, checkpoint, ex);
-            throw;
-        }
-    }
+            return BackfillOutcome.Completed;
+        }, cancellationToken);
 }

--- a/src/DiscordEventService/Program.cs
+++ b/src/DiscordEventService/Program.cs
@@ -181,6 +181,7 @@ builder.Services.AddHangfireServer(options =>
 });
 
 // Backfill jobs
+builder.Services.AddScoped<BackfillJobExecutor>();
 builder.Services.AddScoped<RolesBackfillJob>();
 builder.Services.AddScoped<EmojisBackfillJob>();
 builder.Services.AddScoped<StickersBackfillJob>();

--- a/tests/DiscordEventService.Tests/BackfillJobExecutorTests.cs
+++ b/tests/DiscordEventService.Tests/BackfillJobExecutorTests.cs
@@ -1,0 +1,150 @@
+using DiscordEventService.Data;
+using DiscordEventService.Data.Entities.Core;
+using DiscordEventService.Jobs;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging.Abstractions;
+using Xunit;
+
+namespace DiscordEventService.Tests;
+
+public sealed class BackfillJobExecutorTests(PostgresFixture fixture)
+    : IClassFixture<PostgresFixture>, IAsyncLifetime
+{
+    private const ulong GuildId = 555_000_001UL;
+    private const BackfillType Type = BackfillType.Roles;
+
+    private ServiceProvider _provider = null!;
+    private BackfillJobExecutor _executor = null!;
+
+    public async Task InitializeAsync()
+    {
+        await using var db = NewContext();
+        await db.Database.MigrateAsync();
+        await db.BackfillCheckpoints.ExecuteDeleteAsync();
+
+        _provider = new ServiceCollection()
+            .AddDbContext<DiscordDbContext>(o => o
+                .UseNpgsql(fixture.Container.GetConnectionString())
+                .UseSnakeCaseNamingConvention())
+            .BuildServiceProvider();
+
+        _executor = new BackfillJobExecutor(
+            _provider.GetRequiredService<IServiceScopeFactory>(),
+            NullLogger<BackfillJobExecutor>.Instance);
+    }
+
+    public async Task DisposeAsync() => await _provider.DisposeAsync();
+
+    [Fact]
+    public async Task RunAsync_WhenWorkCompletes_MarksCompleted()
+    {
+        await _executor.RunAsync(Type, GuildId, _ => Task.FromResult(BackfillOutcome.Completed), default);
+
+        var row = await ReadCheckpointAsync();
+        Assert.Equal(BackfillStatus.Completed, row.Status);
+        Assert.NotNull(row.CompletedAtUtc);
+    }
+
+    [Fact]
+    public async Task RunAsync_WhenWorkShortCircuits_MarksFailedNotCompleted()
+    {
+        await _executor.RunAsync(Type, GuildId,
+            _ => Task.FromResult(BackfillOutcome.ShortCircuit("guild missing")), default);
+
+        var row = await ReadCheckpointAsync();
+        Assert.Equal(BackfillStatus.Failed, row.Status);
+        Assert.Null(row.CompletedAtUtc);
+        Assert.Equal(1, row.ErrorCount);
+        Assert.Contains("guild missing", row.LastError);
+    }
+
+    [Fact]
+    public async Task RunAsync_WhenCancelled_MarksFailedAndSwallows()
+    {
+        // OperationCanceledException is the deploy-restart path: persist Failed, do not rethrow.
+        await _executor.RunAsync(Type, GuildId,
+            _ => throw new OperationCanceledException("restart"), default);
+
+        var row = await ReadCheckpointAsync();
+        Assert.Equal(BackfillStatus.Failed, row.Status);
+        Assert.Null(row.CompletedAtUtc);
+    }
+
+    [Fact]
+    public async Task RunAsync_WhenWorkThrows_MarksFailedAndRethrows()
+    {
+        await Assert.ThrowsAsync<InvalidOperationException>(() =>
+            _executor.RunAsync(Type, GuildId,
+                _ => throw new InvalidOperationException("boom"), default));
+
+        var row = await ReadCheckpointAsync();
+        Assert.Equal(BackfillStatus.Failed, row.Status);
+        Assert.Contains("boom", row.LastError);
+    }
+
+    [Fact]
+    public async Task RunAsync_WhenPriorRunNotInProgress_ClearsResumeCursorAtomically()
+    {
+        await SeedCheckpointAsync(BackfillStatus.Completed, currentChannelId: 999UL, lastProcessedId: 888UL);
+
+        ulong? cursorSeenInWork = 12345UL;
+        await _executor.RunAsync(Type, GuildId, ctx =>
+        {
+            cursorSeenInWork = ctx.Checkpoint.CurrentChannelId;
+            return Task.FromResult(BackfillOutcome.Completed);
+        }, default);
+
+        // Reset is visible to the work delegate (it runs against the flipped checkpoint) ...
+        Assert.Null(cursorSeenInWork);
+        // ... and persisted, so a crash mid-work cannot leave {InProgress, stale cursor}.
+        var row = await ReadCheckpointAsync();
+        Assert.Null(row.CurrentChannelId);
+        Assert.Null(row.LastProcessedId);
+    }
+
+    [Fact]
+    public async Task RunAsync_WhenPriorRunInterrupted_PreservesResumeCursor()
+    {
+        await SeedCheckpointAsync(BackfillStatus.InProgress, currentChannelId: 999UL, lastProcessedId: 888UL);
+
+        ulong? cursorSeenInWork = null;
+        await _executor.RunAsync(Type, GuildId, ctx =>
+        {
+            cursorSeenInWork = ctx.Checkpoint.CurrentChannelId;
+            return Task.FromResult(BackfillOutcome.Completed);
+        }, default);
+
+        Assert.Equal(999UL, cursorSeenInWork);
+    }
+
+    private async Task SeedCheckpointAsync(BackfillStatus status, ulong currentChannelId, ulong lastProcessedId)
+    {
+        await using var db = NewContext();
+        db.BackfillCheckpoints.Add(new BackfillCheckpointEntity
+        {
+            GuildDiscordId = GuildId,
+            Type = Type,
+            Status = status,
+            CurrentChannelId = currentChannelId,
+            LastProcessedId = lastProcessedId,
+            StartedAtUtc = DateTime.UtcNow
+        });
+        await db.SaveChangesAsync();
+    }
+
+    private async Task<BackfillCheckpointEntity> ReadCheckpointAsync()
+    {
+        await using var db = NewContext();
+        return await db.BackfillCheckpoints.SingleAsync(c => c.GuildDiscordId == GuildId && c.Type == Type);
+    }
+
+    private DiscordDbContext NewContext()
+    {
+        var options = new DbContextOptionsBuilder<DiscordDbContext>()
+            .UseNpgsql(fixture.Container.GetConnectionString())
+            .UseSnakeCaseNamingConvention()
+            .Options;
+        return new DiscordDbContext(options);
+    }
+}


### PR DESCRIPTION
Closes #202 (epic #194 §C1).

## What
Extracts the lifecycle ceremony repeated across all 7 backfill jobs into a single `BackfillJobExecutor`. Jobs now supply only **guild resolution + per-item work** as a delegate; the executor owns the rest.

`BackfillJobExecutor.RunAsync(type, guildId, work, ct)`:
- creates the DI scope + `DiscordDbContext`
- get-or-creates the checkpoint
- resets the resume cursor (when prior status ≠ `InProgress`) **atomically with the `InProgress` flip** — one `SaveChanges`, so no crash window can leave `{InProgress, stale cursor}`; a no-op for the 5 cursor-less jobs
- routes the 4 terminal transitions:
  - work returns `Completed` → `Completed`
  - work returns `ShortCircuit(reason)` (e.g. guild not in DB) → `Failed` (not Completed)
  - `OperationCanceledException` (deploy restart) → `Failed`, **no rethrow**
  - any other exception → `Failed`, **rethrow**

The work delegate returns a `BackfillOutcome` (`Completed` | `ShortCircuit(reason)`).

## Why this shape
`DiscordClient` is deliberately **kept out of the executor** — it stays in each job's closure. That's what makes the executor's transitions unit-testable against a real `DbContext` with no gateway, which is the §C testability goal. Guild resolution stays in the lambda for the same reason.

## Boundaries (vs #203/#204)
- The per-channel `Skip` + batch resume loop for Messages/Reactions stays **in the job** — that's #203's turf. Only the cursor *reset* (a status transition) moved.
- `BackfillJobBase` keeps the mid-loop helpers (`RecordErrorAsync`, `SaveProgressAsync`) + abstract `BackfillType`; the lifecycle methods (`GetOrCreate`/`MarkCompleted`/`MarkFailed`/InProgress-flip) moved to the executor.
- Terminal log lines now key off `{BackfillType}` uniformly (audited all changed paths).

## Verification
- **6 Testcontainers tests** (`BackfillJobExecutorTests`): all 4 terminal paths + both resume-cursor branches (reset-on-terminal, preserve-on-interrupted), asserting via a fresh context (the executor disposes its own scope).
- **Live on the dev guild**: full backfill → all 7 jobs `Completed` (Messages 6797, Reactions 25, 0 errors); idempotent **re-run** from `Completed` re-scanned **14 channels** (not 1) — confirming the cursor reset clears the stale cursor instead of skipping to the last channel. 0 exceptions / disposal / concurrency errors in the log.
- `dotnet build -warnaserror` clean, `dotnet format --verify-no-changes` clean, full suite 40/40.

🤖 Generated with [Claude Code](https://claude.com/claude-code)