### PR TITLE
feat: extract IterateWithCheckpointAsync for the history-job resume-cursor loop (#203)

### DIFF
--- a/src/DiscordEventService/Jobs/BackfillJobBase.cs
+++ b/src/DiscordEventService/Jobs/BackfillJobBase.cs
@@ -24,4 +24,79 @@ public abstract class BackfillJobBase
     {
         await db.SaveChangesAsync();
     }
+
+    /// <summary>
+    /// Drives the per-item resume-cursor loop shared by the history jobs (Messages, Reactions):
+    /// skip to the channel a genuinely-interrupted run stopped on (<c>CurrentChannelId</c>, already
+    /// reset to null by <see cref="BackfillJobExecutor"/> after a terminal run), then walk the rest,
+    /// stamping <c>CurrentChannelId</c> per item and clearing the per-channel batch cursor
+    /// (<c>LastProcessedId</c>) only AFTER an item finishes — so the resume channel still sees its
+    /// saved batch cursor on entry. A per-item failure (non-cancellation) is recorded and the loop
+    /// continues with the next item; cancellation propagates to the executor's terminal handling.
+    /// <para>
+    /// <paramref name="items"/> MUST be in a stable, deterministic order across runs (the jobs
+    /// guarantee this via <c>OrderBy(c =&gt; c.Id)</c>); otherwise resume would skip the wrong items.
+    /// The per-batch <c>LastProcessedId</c> write stays inside <paramref name="processItem"/> — the
+    /// inner paging body is job-specific and not extracted here.
+    /// </para>
+    /// </summary>
+    protected async Task IterateWithCheckpointAsync<T>(
+        DiscordDbContext db,
+        BackfillCheckpointEntity checkpoint,
+        IReadOnlyList<T> items,
+        Func<T, ulong> keyOf,
+        Func<T, Task> processItem,
+        ILogger logger,
+        CancellationToken cancellationToken)
+    {
+        var startIndex = 0;
+        if (checkpoint.CurrentChannelId is { } resumeId)
+        {
+            var found = -1;
+            for (var i = 0; i < items.Count; i++)
+            {
+                if (keyOf(items[i]) == resumeId)
+                {
+                    found = i;
+                    break;
+                }
+            }
+
+            if (found >= 0)
+            {
+                startIndex = found;
+            }
+            else
+            {
+                logger.LogWarning("Backfill resume cursor {ResumeId} not found in {Count} items, restarting from beginning",
+                    resumeId, items.Count);
+                checkpoint.CurrentChannelId = null;
+                checkpoint.LastProcessedId = null;
+            }
+        }
+
+        for (var i = startIndex; i < items.Count; i++)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+
+            var item = items[i];
+            checkpoint.CurrentChannelId = keyOf(item);
+            await db.SaveChangesAsync(cancellationToken);
+
+            try
+            {
+                await processItem(item);
+            }
+            catch (Exception ex) when (ex is not OperationCanceledException)
+            {
+                logger.LogWarning(ex, "Backfill failed for item {ItemId}, continuing with next", keyOf(item));
+                await RecordErrorAsync(db, checkpoint, ex);
+            }
+
+            // Reset the per-channel batch cursor AFTER the item, so the resume channel saw its saved
+            // LastProcessedId on entry and the next channel starts from the newest message.
+            checkpoint.LastProcessedId = null;
+            await db.SaveChangesAsync(cancellationToken);
+        }
+    }
 }

--- a/src/DiscordEventService/Jobs/MessagesBackfillJob.cs
+++ b/src/DiscordEventService/Jobs/MessagesBackfillJob.cs
@@ -44,50 +44,16 @@ public sealed class MessagesBackfillJob(
                 .OrderBy(c => c.Id)
                 .ToList();
 
-            // Resume from checkpoint channel if exists. The cursor reset (clear when the prior run
-            // was not InProgress) is owned by BackfillJobExecutor, so CurrentChannelId here is either
-            // null (fresh run) or the channel a genuinely-interrupted run stopped on. Carrying a
-            // stale cursor over a completed run would Skip all-but-the-last channel and mask gaps.
-            if (ctx.Checkpoint.CurrentChannelId.HasValue)
-            {
-                var checkpointChannelIndex = textChannels.FindIndex(c => c.Id == ctx.Checkpoint.CurrentChannelId.Value);
-                if (checkpointChannelIndex >= 0)
+            // The per-channel resume-cursor loop (skip-to-resume + per-channel cursor management)
+            // lives in BackfillJobBase; only this job's inner per-channel paging body is passed in.
+            await IterateWithCheckpointAsync(ctx.Db, ctx.Checkpoint, textChannels, c => c.Id,
+                async channel =>
                 {
-                    textChannels = textChannels.Skip(checkpointChannelIndex).ToList();
-                }
-                else
-                {
-                    logger.LogWarning("Checkpoint channel {ChannelId} not found in guild {GuildId}, restarting from beginning",
-                        ctx.Checkpoint.CurrentChannelId.Value, guildId);
-                    ctx.Checkpoint.CurrentChannelId = null;
-                    ctx.Checkpoint.LastProcessedId = null;
-                }
-            }
-
-            foreach (var channel in textChannels)
-            {
-                cancellationToken.ThrowIfCancellationRequested();
-
-                ctx.Checkpoint.CurrentChannelId = channel.Id;
-                await ctx.Db.SaveChangesAsync(cancellationToken);
-
-                logger.LogInformation("Backfilling messages for channel {ChannelName} ({ChannelId}) in guild {GuildId}",
-                    channel.Name, channel.Id, guildId);
-
-                try
-                {
+                    logger.LogInformation("Backfilling messages for channel {ChannelName} ({ChannelId}) in guild {GuildId}",
+                        channel.Name, channel.Id, guildId);
                     await BackfillChannelMessagesAsync(ctx.Db, userService, guildEntity, channel, ctx.Checkpoint, afterTimestampUtc, cancellationToken);
-                }
-                catch (Exception ex) when (ex is not OperationCanceledException)
-                {
-                    logger.LogWarning(ex, "Failed to backfill messages for channel {ChannelId}, continuing with next channel", channel.Id);
-                    await RecordErrorAsync(ctx.Db, ctx.Checkpoint, ex);
-                }
-
-                // Reset for next channel
-                ctx.Checkpoint.LastProcessedId = null;
-                await ctx.Db.SaveChangesAsync(cancellationToken);
-            }
+                },
+                logger, cancellationToken);
 
             return BackfillOutcome.Completed;
         }, cancellationToken);

--- a/src/DiscordEventService/Jobs/ReactionsBackfillJob.cs
+++ b/src/DiscordEventService/Jobs/ReactionsBackfillJob.cs
@@ -42,49 +42,16 @@ public sealed class ReactionsBackfillJob(
                 .OrderBy(c => c.Id)
                 .ToList();
 
-            // Resume from checkpoint channel if exists. The cursor reset (clear when the prior run
-            // was not InProgress) is owned by BackfillJobExecutor, so CurrentChannelId here is either
-            // null (fresh run) or the channel a genuinely-interrupted run stopped on.
-            if (ctx.Checkpoint.CurrentChannelId.HasValue)
-            {
-                var checkpointChannelIndex = textChannels.FindIndex(c => c.Id == ctx.Checkpoint.CurrentChannelId.Value);
-                if (checkpointChannelIndex >= 0)
+            // The per-channel resume-cursor loop (skip-to-resume + per-channel cursor management)
+            // lives in BackfillJobBase; only this job's inner per-channel paging body is passed in.
+            await IterateWithCheckpointAsync(ctx.Db, ctx.Checkpoint, textChannels, c => c.Id,
+                async channel =>
                 {
-                    textChannels = textChannels.Skip(checkpointChannelIndex).ToList();
-                }
-                else
-                {
-                    logger.LogWarning("Checkpoint channel {ChannelId} not found in guild {GuildId}, restarting from beginning",
-                        ctx.Checkpoint.CurrentChannelId.Value, guildId);
-                    ctx.Checkpoint.CurrentChannelId = null;
-                    ctx.Checkpoint.LastProcessedId = null;
-                }
-            }
-
-            foreach (var channel in textChannels)
-            {
-                cancellationToken.ThrowIfCancellationRequested();
-
-                ctx.Checkpoint.CurrentChannelId = channel.Id;
-                await ctx.Db.SaveChangesAsync(cancellationToken);
-
-                logger.LogInformation("Backfilling reactions for channel {ChannelName} ({ChannelId}) in guild {GuildId}",
-                    channel.Name, channel.Id, guildId);
-
-                try
-                {
+                    logger.LogInformation("Backfilling reactions for channel {ChannelName} ({ChannelId}) in guild {GuildId}",
+                        channel.Name, channel.Id, guildId);
                     await BackfillChannelReactionsAsync(ctx.Db, userService, guildEntity, channel, ctx.Checkpoint, afterTimestampUtc, cancellationToken);
-                }
-                catch (Exception ex) when (ex is not OperationCanceledException)
-                {
-                    logger.LogWarning(ex, "Failed to backfill reactions for channel {ChannelId}, continuing with next channel", channel.Id);
-                    await RecordErrorAsync(ctx.Db, ctx.Checkpoint, ex);
-                }
-
-                // Reset for next channel
-                ctx.Checkpoint.LastProcessedId = null;
-                await ctx.Db.SaveChangesAsync(cancellationToken);
-            }
+                },
+                logger, cancellationToken);
 
             return BackfillOutcome.Completed;
         }, cancellationToken);

--- a/tests/DiscordEventService.Tests/BackfillIterateWithCheckpointTests.cs
+++ b/tests/DiscordEventService.Tests/BackfillIterateWithCheckpointTests.cs
@@ -1,0 +1,135 @@
+using DiscordEventService.Data;
+using DiscordEventService.Data.Entities.Core;
+using DiscordEventService.Jobs;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+using Xunit;
+
+namespace DiscordEventService.Tests;
+
+public sealed class BackfillIterateWithCheckpointTests(PostgresFixture fixture)
+    : IClassFixture<PostgresFixture>, IAsyncLifetime
+{
+    private const ulong GuildId = 556_000_001UL;
+    private static readonly ulong[] Items = [10UL, 20UL, 30UL, 40UL];
+
+    private DiscordDbContext _db = null!;
+
+    public async Task InitializeAsync()
+    {
+        _db = NewContext();
+        await _db.Database.MigrateAsync();
+        await _db.BackfillCheckpoints.ExecuteDeleteAsync();
+    }
+
+    public Task DisposeAsync() => _db.DisposeAsync().AsTask();
+
+    [Fact]
+    public async Task FreshRun_VisitsAllItemsInOrder_AllWithNullCursor()
+    {
+        var checkpoint = await SeedAsync(currentChannelId: null, lastProcessedId: null);
+
+        var observed = await RunAsync(checkpoint, Items);
+
+        Assert.Equal([(10UL, null), (20UL, null), (30UL, null), (40UL, null)], observed);
+        Assert.Equal(40UL, checkpoint.CurrentChannelId);
+        Assert.Null(checkpoint.LastProcessedId);
+    }
+
+    [Fact]
+    public async Task ResumeMidList_SkipsToCursor_ResumeItemSeesSavedBatchCursor()
+    {
+        // The discriminating assertion: item 30 must observe LastProcessedId=777 on entry (its saved
+        // batch cursor) and 40 must observe null. Final state is identical whether or not the reset
+        // is correctly ordered, so only the per-item observation catches the off-by-one.
+        var checkpoint = await SeedAsync(currentChannelId: 30UL, lastProcessedId: 777UL);
+
+        var observed = await RunAsync(checkpoint, Items);
+
+        Assert.Equal([(30UL, (ulong?)777UL), (40UL, null)], observed);
+        Assert.Equal(40UL, checkpoint.CurrentChannelId);
+    }
+
+    [Fact]
+    public async Task ResumeCursorNotInList_RestartsFromBeginning_DiscardsBatchCursor()
+    {
+        var checkpoint = await SeedAsync(currentChannelId: 999UL, lastProcessedId: 777UL);
+
+        var observed = await RunAsync(checkpoint, Items);
+
+        Assert.Equal([(10UL, null), (20UL, null), (30UL, null), (40UL, null)], observed);
+    }
+
+    [Fact]
+    public async Task PerItemFailure_RecordsErrorAndContinues()
+    {
+        var checkpoint = await SeedAsync(currentChannelId: null, lastProcessedId: null);
+        var visited = new List<ulong>();
+
+        var job = new HarnessJob();
+        await job.IterateAsync(_db, checkpoint, [10UL, 20UL, 30UL], x => x, item =>
+        {
+            visited.Add(item);
+            return item == 20UL ? throw new InvalidOperationException("boom") : Task.CompletedTask;
+        }, default);
+
+        Assert.Equal([10UL, 20UL, 30UL], visited);
+        Assert.Equal(1, checkpoint.ErrorCount);
+        Assert.Contains("boom", checkpoint.LastError);
+        Assert.Equal(30UL, checkpoint.CurrentChannelId);
+    }
+
+    private async Task<List<(ulong item, ulong? cursorAtEntry)>> RunAsync(
+        BackfillCheckpointEntity checkpoint, IReadOnlyList<ulong> items)
+    {
+        var observed = new List<(ulong, ulong?)>();
+        var job = new HarnessJob();
+        await job.IterateAsync(_db, checkpoint, items, x => x, item =>
+        {
+            observed.Add((item, checkpoint.LastProcessedId));
+            return Task.CompletedTask;
+        }, default);
+        return observed;
+    }
+
+    private async Task<BackfillCheckpointEntity> SeedAsync(ulong? currentChannelId, ulong? lastProcessedId)
+    {
+        var checkpoint = new BackfillCheckpointEntity
+        {
+            GuildDiscordId = GuildId,
+            Type = BackfillType.Messages,
+            Status = BackfillStatus.InProgress,
+            CurrentChannelId = currentChannelId,
+            LastProcessedId = lastProcessedId,
+            StartedAtUtc = DateTime.UtcNow
+        };
+        _db.BackfillCheckpoints.Add(checkpoint);
+        await _db.SaveChangesAsync();
+        return checkpoint;
+    }
+
+    private DiscordDbContext NewContext()
+    {
+        var options = new DbContextOptionsBuilder<DiscordDbContext>()
+            .UseNpgsql(fixture.Container.GetConnectionString())
+            .UseSnakeCaseNamingConvention()
+            .Options;
+        return new DiscordDbContext(options);
+    }
+
+    // Minimal concrete subclass to exercise the protected IterateWithCheckpointAsync helper.
+    private sealed class HarnessJob : BackfillJobBase
+    {
+        protected override BackfillType BackfillType => BackfillType.Messages;
+
+        public Task IterateAsync<T>(
+            DiscordDbContext db,
+            BackfillCheckpointEntity checkpoint,
+            IReadOnlyList<T> items,
+            Func<T, ulong> keyOf,
+            Func<T, Task> processItem,
+            CancellationToken cancellationToken)
+            => IterateWithCheckpointAsync(db, checkpoint, items, keyOf, processItem, NullLogger.Instance, cancellationToken);
+    }
+}


### PR DESCRIPTION
Closes #203 (epic #194 §C2). Follows #202.

## What
`MessagesBackfillJob` and `ReactionsBackfillJob` duplicated the per-channel resume-cursor loop character-for-character (Reactions' comment literally pointed at Messages "for the full rationale"). Extracts it into:

```csharp
BackfillJobBase.IterateWithCheckpointAsync<T>(db, checkpoint, items, keyOf, processItem, logger, ct)
```

Each job now passes only its filtered+ordered channel list and its per-channel paging body (`BackfillChannel*Async`) as a delegate. The helper owns: skip-to-resume (`CurrentChannelId`, else warn+restart), per-channel `CurrentChannelId` stamping, per-item failure→`RecordError`+continue, and the `LastProcessedId` reset.

## The cursor invariant (and why the test asserts observations, not final state)
The reset of `LastProcessedId` happens **after** `processItem`, so the resume channel still sees its **saved batch cursor** on entry. The off-by-one (resetting before) would silently re-scan the resume channel from newest — and that's **invisible in the final checkpoint row** (`CurrentChannelId`=last, `LastProcessedId`=null either way). So the discriminating test records what `processItem` *observed* (`item` + `LastProcessedId` at entry) per call:
- fresh → all items in order, all null cursor
- **resume mid-list → the resume item observes its saved cursor (777), every later item observes null**
- cursor not in list → warn, restart from beginning, saved cursor discarded
- per-item failure → `ErrorCount++`, loop continues

## Scope boundary
Outer per-channel loop only. The inner batch paging body (per-batch `LastProcessedId` write) stays in each job — the two bodies differ materially (Messages inserts `MessageEntity`+`MessageEventEntity` with FK-presence guards; Reactions does nested `GetReactionsAsync`), so unifying them would be over-abstraction. `items` ordering is a documented contract (jobs guarantee `OrderBy(c => c.Id)`).

## Verification
- **4 Testcontainers tests** (`BackfillIterateWithCheckpointTests`) via a minimal `BackfillJobBase` subclass + real DbContext + seeded checkpoint, asserting per-item observations. Suite 44/44.
- **Live on the dev guild**: full backfill + idempotent re-run, both scanned **all 14 channels** (the helper drives the loop; the #202 executor cursor-reset + this helper's from-start interplay confirmed). 0 exceptions/disposal.
- `dotnet build -warnaserror` clean, `dotnet format --verify-no-changes` clean (src + tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)