### PR TITLE
Tune health-check event-ratio alert for small/quiet servers

### DIFF
--- a/src/DiscordEventService/Configuration/HealthCheckOptions.cs
+++ b/src/DiscordEventService/Configuration/HealthCheckOptions.cs
@@ -10,9 +10,24 @@ public class HealthCheckOptions
     public int AlertCooldownMinutes { get; set; } = 30;
     public int EventRatioBaselineDays { get; set; } = 7;
     public int EventRatioRecentHours { get; set; } = 6;
-    public double EventRatioDropThreshold { get; set; } = 0.1;
+
+    // NOTE: the event-ratio knobs below (drop threshold, baseline floor, debounce, exclusions)
+    // are a stopgap tuned for a small/quiet server. The proper data-driven rework is tracked in #215.
+
+    // Only near-total drops fire — a small/quiet server has too few events per
+    // type for a softer ratio to be a reliable signal.
+    public double EventRatioDropThreshold { get; set; } = 0.05;
 
     // Minimum events normally seen in the same time-of-day window before a drop
-    // is worth alerting on — keeps sparse/quiet hours from tripping the alarm.
-    public double EventRatioMinWindowBaseline { get; set; } = 2.0;
+    // is worth alerting on — keeps sparse/quiet event types from tripping the alarm.
+    public double EventRatioMinWindowBaseline { get; set; } = 10.0;
+
+    // A drop must persist across this many consecutive health-check runs before it
+    // alerts — debounces transient lulls on a low-traffic server.
+    public int EventRatioConsecutiveRuns { get; set; } = 3;
+
+    // Event types excluded from the ratio-drop check entirely. Voice traffic is
+    // naturally bursty (whole quiet days are normal), so it is excluded by default.
+    public string[] EventRatioExcludedEventTypes { get; set; } =
+        ["VoiceStateUpdated", "VoiceServerUpdated"];
 }

--- a/src/DiscordEventService/Jobs/HealthCheckJob.cs
+++ b/src/DiscordEventService/Jobs/HealthCheckJob.cs
@@ -17,6 +17,7 @@ public class HealthCheckJob(
     private static DateTime _lastIngestStallAlert = DateTime.MinValue;
     private static DateTime _lastEventRatioAlert = DateTime.MinValue;
     private static DateTime _lastCrashLoopAlert = DateTime.MinValue;
+    private static readonly Dictionary<string, int> _eventRatioDropStreaks = new Dictionary<string, int>();
     private static readonly object _lock = new();
     private static readonly TimeSpan WebhookTimeout = TimeSpan.FromSeconds(10);
 
@@ -171,13 +172,36 @@ public class HealthCheckJob(
                 baselineTotals[c.EventType] = baselineTotals.GetValueOrDefault(c.EventType) + c.Count;
         }
 
+        var excluded = new HashSet<string>(opts.EventRatioExcludedEventTypes, StringComparer.OrdinalIgnoreCase);
+
         var dropped = baselineTotals
+            .Where(b => !excluded.Contains(b.Key))
             .Select(b => new { EventType = b.Key, ExpectedInWindow = (double)b.Value / opts.EventRatioBaselineDays })
             .Where(b => b.ExpectedInWindow >= opts.EventRatioMinWindowBaseline)
             .Where(b => recent.GetValueOrDefault(b.EventType, 0) < b.ExpectedInWindow * opts.EventRatioDropThreshold)
             .ToList();
 
-        if (dropped.Count == 0)
+        // A drop must persist across EventRatioConsecutiveRuns consecutive runs before it
+        // alerts; types that recover have their streak cleared. Only "confirmed" types are
+        // eligible — debounces transient lulls on a low-traffic server.
+        var droppedTypes = dropped.Select(d => d.EventType).ToHashSet();
+        List<string> confirmedTypes;
+        lock (_lock)
+        {
+            foreach (var key in _eventRatioDropStreaks.Keys.Where(k => !droppedTypes.Contains(k)).ToList())
+                _eventRatioDropStreaks.Remove(key);
+
+            foreach (var type in droppedTypes)
+                _eventRatioDropStreaks[type] = _eventRatioDropStreaks.GetValueOrDefault(type) + 1;
+
+            confirmedTypes = _eventRatioDropStreaks
+                .Where(kvp => kvp.Value >= opts.EventRatioConsecutiveRuns)
+                .Select(kvp => kvp.Key)
+                .ToList();
+        }
+
+        var confirmed = dropped.Where(d => confirmedTypes.Contains(d.EventType)).ToList();
+        if (confirmed.Count == 0)
             return;
 
         lock (_lock)
@@ -186,20 +210,20 @@ public class HealthCheckJob(
                 return;
         }
 
-        var details = string.Join("\n", dropped.Select(d =>
+        var details = string.Join("\n", confirmed.Select(d =>
         {
             var recentCount = recent.GetValueOrDefault(d.EventType, 0);
             return $"- `{d.EventType}`: {recentCount} in last {opts.EventRatioRecentHours}h (expected ~{d.ExpectedInWindow:F1} for this time of day)";
         }));
 
         if (!await SendWebhookAsync(opts.WebhookUrl!,
-            $"**Event type ratio drop** — {dropped.Count} event type(s) below {opts.EventRatioDropThreshold:P0} of baseline:\n{details}"))
+            $"**Event type ratio drop** — {confirmed.Count} event type(s) below {opts.EventRatioDropThreshold:P0} of baseline for {opts.EventRatioConsecutiveRuns}+ runs:\n{details}"))
             return;
 
         lock (_lock) { _lastEventRatioAlert = now; }
 
         logger.LogWarning("Health check alert: event type ratio drop for {Types}",
-            string.Join(", ", dropped.Select(d => d.EventType)));
+            string.Join(", ", confirmed.Select(d => d.EventType)));
     }
 
     private async Task<bool> SendWebhookAsync(string webhookUrl, string message)

--- a/src/DiscordEventService/appsettings.json
+++ b/src/DiscordEventService/appsettings.json
@@ -27,6 +27,10 @@
     "WebhookUrl": "",
     "FailedEventWindowMinutes": 5,
     "IngestStallMinutes": 360,
-    "AlertCooldownMinutes": 30
+    "AlertCooldownMinutes": 30,
+    "EventRatioMinWindowBaseline": 10,
+    "EventRatioDropThreshold": 0.05,
+    "EventRatioConsecutiveRuns": 3,
+    "EventRatioExcludedEventTypes": [ "VoiceStateUpdated", "VoiceServerUpdated" ]
   }
 }

--- a/tests/DiscordEventService.Tests/HealthCheckEventRatioTests.cs
+++ b/tests/DiscordEventService.Tests/HealthCheckEventRatioTests.cs
@@ -1,0 +1,112 @@
+using System.Net;
+using DiscordEventService.Configuration;
+using DiscordEventService.Data;
+using DiscordEventService.Data.Entities.Events;
+using DiscordEventService.Jobs;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using Xunit;
+
+namespace DiscordEventService.Tests;
+
+public sealed class HealthCheckEventRatioTests(PostgresFixture fixture)
+    : IClassFixture<PostgresFixture>, IAsyncLifetime
+{
+    private DiscordDbContext _db = null!;
+
+    public async Task InitializeAsync()
+    {
+        _db = NewContext();
+        await _db.Database.MigrateAsync();
+        await _db.RawEventLogs.ExecuteDeleteAsync();
+    }
+
+    public Task DisposeAsync() => _db.DisposeAsync().AsTask();
+
+    /// <summary>
+    /// A type whose recent count collapses against its time-of-day baseline only alerts once the
+    /// drop has persisted for EventRatioConsecutiveRuns runs (debounce), and excluded voice types
+    /// never alert at all — even when their counts collapse identically.
+    /// </summary>
+    [Fact]
+    public async Task EventRatioDrop_DebouncesAcrossRuns_AndExcludesVoice()
+    {
+        var now = DateTime.UtcNow;
+
+        // Baseline: 20 events/day for each of the previous 7 days, ~1h before "now" so they land
+        // inside the 6h time-of-day baseline window. One normal type and one excluded voice type.
+        foreach (var type in new[] { "MessageCreated", "VoiceStateUpdated" })
+            for (var day = 1; day <= 7; day++)
+                for (var i = 0; i < 20; i++)
+                    _db.RawEventLogs.Add(new RawEventLogEntity
+                    {
+                        Id = Guid.NewGuid(),
+                        EventType = type,
+                        EventJson = "{}",
+                        ReceivedAtUtc = now.AddDays(-day).AddHours(-1).AddSeconds(i),
+                    });
+        // Recent 6h window: nothing seeded for either type -> both read as a near-total drop.
+        await _db.SaveChangesAsync();
+
+        var handler = new CapturingHandler();
+        await using var provider = new ServiceCollection()
+            .AddDbContext<DiscordDbContext>(o => o
+                .UseNpgsql(fixture.Container.GetConnectionString())
+                .UseSnakeCaseNamingConvention())
+            .BuildServiceProvider();
+
+        var opts = Options.Create(new HealthCheckOptions
+        {
+            WebhookUrl = "https://example.test/webhook",
+            EventRatioConsecutiveRuns = 3,
+        });
+        var job = new HealthCheckJob(
+            provider.GetRequiredService<IServiceScopeFactory>(),
+            new StubHttpClientFactory(handler),
+            opts,
+            NullLogger<HealthCheckJob>.Instance);
+
+        // Runs 1 & 2: drop detected but below the consecutive-run threshold -> stays silent.
+        await job.ExecuteAsync();
+        await job.ExecuteAsync();
+        Assert.Empty(handler.Bodies);
+
+        // Run 3: streak reaches 3 -> alert fires. MessageCreated has an identical baseline/recent
+        // profile to the voice type, so its presence proves the collapse *would* trip an alert —
+        // the voice type's absence is therefore solely due to the exclusion list, not quiet data.
+        await job.ExecuteAsync();
+        var body = Assert.Single(handler.Bodies);
+        Assert.Contains("MessageCreated", body);
+        Assert.Contains("1 event type(s)", body);     // exactly one type reported...
+        Assert.DoesNotContain("VoiceStateUpdated", body); // ...and the excluded voice type is never it
+    }
+
+    private DiscordDbContext NewContext()
+    {
+        var options = new DbContextOptionsBuilder<DiscordDbContext>()
+            .UseNpgsql(fixture.Container.GetConnectionString())
+            .UseSnakeCaseNamingConvention()
+            .Options;
+        return new DiscordDbContext(options);
+    }
+
+    private sealed class CapturingHandler : HttpMessageHandler
+    {
+        public List<string> Bodies { get; } = [];
+
+        protected override async Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            if (request.Content is not null)
+                Bodies.Add(await request.Content.ReadAsStringAsync(cancellationToken));
+            return new HttpResponseMessage(HttpStatusCode.OK);
+        }
+    }
+
+    private sealed class StubHttpClientFactory(HttpMessageHandler handler) : IHttpClientFactory
+    {
+        public HttpClient CreateClient(string name) => new HttpClient(handler, disposeHandler: false);
+    }
+}


### PR DESCRIPTION
## Why

The event-type ratio-drop alert (`CheckEventTypeRatioAsync`) false-positives on this small private server. Voice/VC traffic is bursty and whole quiet days are normal, so a single busy session lifts the time-of-day baseline above the floor and the following quiet days read as a 90%+ drop → spurious alert. The other three checks (failed events, ingest stall, crash loop) are activity-independent and untouched.

This is a **stopgap**. The proper data-driven rework (gather per-event-type activity history, then redesign the model) is tracked in #215; a code comment in `HealthCheckOptions` points there.

## What

Four tweaks to the ratio-drop check, all configurable:

| Knob | Old | New | Effect |
|---|---|---|---|
| `EventRatioMinWindowBaseline` | 2 | **10** | sparse types never qualify |
| `EventRatioDropThreshold` | 0.1 | **0.05** | only near-total drops fire |
| `EventRatioConsecutiveRuns` | — | **3** (new) | drop must persist N runs (debounce) |
| `EventRatioExcludedEventTypes` | — | **`[VoiceStateUpdated, VoiceServerUpdated]`** (new) | voice excluded entirely |

The debounce keeps a per-type streak counter, incremented while a type is dropped and cleared on recovery; only types whose streak ≥ N are reported. The existing 30-min cooldown still governs re-alert cadence.

## Tradeoff (intentional)

The streak counters live in static in-memory state, so they reset on restart — same limitation as the alert cooldown (#150). A persistent drop simply takes N runs to re-confirm after a restart. This is the safe direction (delays an alert, never spuriously fires), acceptable for a stopgap.

## Tests

- New Testcontainers integration test (`HealthCheckEventRatioTests`, real Postgres, no DB mocking): seeds identical baseline/recent profiles for `MessageCreated` and `VoiceStateUpdated`; asserts no alert on runs 1–2 (debounce), an alert naming exactly one type on run 3, and that the excluded voice type is never reported. `MessageCreated` firing on identical numbers is the positive control proving voice's absence is due to exclusion, not quiet data.
- Full suite green (45/45). `dotnet build` clean (0/0).

Closes nothing — see #215 for the follow-up rework.

🤖 Generated with [Claude Code](https://claude.com/claude-code)