### PR TITLE
fix: sliding Hangfire invisibility heartbeat instead of fixed 6h timeout

### DIFF
--- a/src/DiscordEventService/Program.cs
+++ b/src/DiscordEventService/Program.cs
@@ -223,11 +223,14 @@ builder.Services.AddScoped<MemeSampleService>();
 builder.Services.AddScoped<AttachmentUrlRefreshService>();
 builder.Services.AddScoped<MemeBenchmarkJob>();
 
-// Hangfire. InvisibilityTimeout must exceed the longest-running job: at the
-// default (~30 min) a long benchmark/indexing run gets presumed dead near the
-// end, re-queued, and the original execution cancelled — observed live on the
-// 100-image meme benchmark (#219), restarting it from scratch in a pay-per-run
-// loop. Meme indexing over the full corpus (#221) runs even longer.
+// Hangfire. With a fixed InvisibilityTimeout a job outliving it gets presumed
+// dead, re-queued, and the original execution cancelled — observed live on the
+// 28-min meme benchmark (#219), restarting it from scratch in a pay-per-run
+// loop. Sliding mode instead heartbeats the fetched timestamp while the worker
+// is alive, so arbitrarily long jobs (full-corpus indexing, #221) are safe and
+// the timeout only governs how fast a genuinely crashed worker's job is
+// re-picked. Sliding requires the storage background processes — incompatible
+// with BackgroundJobServerOptions.IsLightweightServer.
 builder.Services.AddHangfire(config => config
     .SetDataCompatibilityLevel(CompatibilityLevel.Version_180)
     .UseSimpleAssemblyNameTypeSerializer()
@@ -236,7 +239,8 @@ builder.Services.AddHangfire(config => config
         options => options.UseNpgsqlConnection(connectionString),
         new Hangfire.PostgreSql.PostgreSqlStorageOptions
         {
-            InvisibilityTimeout = TimeSpan.FromHours(6)
+            UseSlidingInvisibilityTimeout = true,
+            InvisibilityTimeout = TimeSpan.FromMinutes(15)
         }));
 
 builder.Services.AddHangfireServer(options =>

--- a/tests/DiscordEventService.Tests/HangfireSlidingInvisibilityTests.cs
+++ b/tests/DiscordEventService.Tests/HangfireSlidingInvisibilityTests.cs
@@ -1,0 +1,109 @@
+using System.Collections.Concurrent;
+using System.Diagnostics;
+using Hangfire;
+using Hangfire.PostgreSql;
+using Hangfire.PostgreSql.Factories;
+using Xunit;
+
+namespace DiscordEventService.Tests;
+
+// Regression contract for the #219 benchmark incident: a job outliving the
+// fixed InvisibilityTimeout was presumed dead, re-fetched by another worker,
+// and a pay-per-run job restarted in a loop. UseSlidingInvisibilityTimeout
+// heartbeats fetchedat (every InvisibilityTimeout/5) while the worker is
+// alive, so a long job runs exactly once and the timeout only governs how
+// fast a genuinely dead worker's job is re-picked.
+public sealed class HangfireSlidingInvisibilityTests(PostgresFixture fixture) : IClassFixture<PostgresFixture>
+{
+    private static readonly TimeSpan InvisibilityTimeout = TimeSpan.FromSeconds(5);
+
+    [Fact]
+    public async Task SlidingInvisibility_JobOutlivingTimeout_ExecutesExactlyOnce()
+    {
+        using var server = StartServer("hangfire_sliding", useSliding: true, out var storage);
+
+        new BackgroundJobClient(storage).Enqueue(() => SlowJobProbe.Run("sliding", 12_000));
+
+        Assert.True(await WaitFor(() => SlowJobProbe.ExecutionCount("sliding") >= 1, TimeSpan.FromSeconds(10)));
+        // Cover the rest of the job's runtime plus two invisibility windows —
+        // the span where fixed mode demonstrably re-fetches.
+        await Task.Delay(TimeSpan.FromSeconds(16));
+
+        Assert.Equal(1, SlowJobProbe.ExecutionCount("sliding"));
+    }
+
+    [Fact]
+    public async Task FixedInvisibility_JobOutlivingTimeout_IsRefetched()
+    {
+        using var server = StartServer("hangfire_fixed", useSliding: false, out var storage);
+
+        try
+        {
+            new BackgroundJobClient(storage).Enqueue(() => SlowJobProbe.Run("fixed", 12_000));
+
+            Assert.True(
+                await WaitFor(() => SlowJobProbe.ExecutionCount("fixed") >= 2, TimeSpan.FromSeconds(20)),
+                "job outliving a fixed InvisibilityTimeout was expected to be re-fetched");
+        }
+        finally
+        {
+            SlowJobProbe.Stop("fixed");
+        }
+    }
+
+    private BackgroundJobServer StartServer(string schema, bool useSliding, out PostgreSqlStorage storage)
+    {
+        var options = new PostgreSqlStorageOptions
+        {
+            SchemaName = schema,
+            UseSlidingInvisibilityTimeout = useSliding,
+            InvisibilityTimeout = InvisibilityTimeout,
+            QueuePollInterval = TimeSpan.FromMilliseconds(250)
+        };
+        storage = new PostgreSqlStorage(new NpgsqlConnectionFactory(fixture.Container.GetConnectionString(), options), options);
+
+        return new BackgroundJobServer(
+            new BackgroundJobServerOptions
+            {
+                WorkerCount = 2,
+                ShutdownTimeout = TimeSpan.FromSeconds(5)
+            },
+            storage);
+    }
+
+    private static async Task<bool> WaitFor(Func<bool> condition, TimeSpan timeout)
+    {
+        var stopwatch = Stopwatch.StartNew();
+        while (stopwatch.Elapsed < timeout)
+        {
+            if (condition())
+                return true;
+
+            await Task.Delay(100);
+        }
+
+        return condition();
+    }
+}
+
+// Public so Hangfire's activator can resolve and invoke it from the persisted
+// job payload. Sleeps in slices so a test can release still-running
+// executions instead of stalling server shutdown.
+public static class SlowJobProbe
+{
+    private static readonly ConcurrentDictionary<string, int> _executions = new();
+    private static readonly ConcurrentDictionary<string, bool> _stopped = new();
+
+    public static int ExecutionCount(string key) => _executions.GetValueOrDefault(key);
+
+    public static void Stop(string key) => _stopped[key] = true;
+
+    public static void Run(string key, int milliseconds)
+    {
+        _executions.AddOrUpdate(key, 1, (_, count) => count + 1);
+
+        var stopwatch = Stopwatch.StartNew();
+        while (stopwatch.ElapsedMilliseconds < milliseconds && !_stopped.ContainsKey(key))
+            Thread.Sleep(100);
+    }
+}


### PR DESCRIPTION
## What

Replaces the fixed 6h Hangfire `InvisibilityTimeout` (merged in #225) with `UseSlidingInvisibilityTimeout = true` + a 15-minute timeout.

## Why

A fixed timeout conflates two concerns: how long a job may run, and how fast a dead worker's job gets re-picked. The 6h value protected long benchmark/indexing runs from the duplicate-execution loop observed live on the #219 benchmark (default ~30m presumed the 28-min run dead, re-queued it, and restarted a pay-per-run job) — but it also meant a job from a genuinely crashed worker stays stuck for up to 6 hours.

Sliding mode (available in our Hangfire.PostgreSql 1.20.13) heartbeats `fetchedat` every `InvisibilityTimeout/5` (3 min at 15m) via a storage background process while the worker is alive:

- arbitrarily long jobs (full-corpus meme indexing, #221) are never presumed dead mid-run
- a crashed/killed worker's job is re-picked in <= 15 minutes instead of 6 hours

Documented caveat: sliding requires the storage background processes, i.e. incompatible with `IsLightweightServer` — we run a full server, noted in the Program.cs comment.

## Tests

Testcontainers integration tests (real Postgres, no mocking) pin the contract with a 5s timeout and a 12s job:

- **sliding mode: the job executes exactly once** (heartbeat observed working)
- **fixed-mode control: the same job is re-fetched (>= 2 executions)** — reproduces the #219 incident, proving the test catches the regression

Both pass locally in ~22s.

🤖 Generated with [Claude Code](https://claude.com/claude-code)