### PR TITLE
feat: meme_index schema with FTS + trigram search columns (#220)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -410,5 +410,8 @@ src/DiscordEventService/wwwroot/
 # Stray local screenshots saved to a working dir during visual testing
 /*.png
 src/Dashboard/*.png
-# Meme benchmark local artifacts (links-file inputs + generated reports)
-src/DiscordEventService/data/
+# Meme benchmark local artifacts (links-file inputs + generated reports).
+# Scope precisely: on macOS git matches .gitignore case-insensitively, so a
+# bare "data/" rule would silently ignore NEW source files under Data/.
+src/DiscordEventService/Data/meme-benchmark/
+src/DiscordEventService/Data/meme-benchmark-inputs/

--- a/src/DiscordEventService/Data/Configurations/MemeIndexEntityConfiguration.cs
+++ b/src/DiscordEventService/Data/Configurations/MemeIndexEntityConfiguration.cs
@@ -1,0 +1,57 @@
+using DiscordEventService.Data.Entities.Core;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
+namespace DiscordEventService.Data.Configurations;
+
+internal sealed class MemeIndexEntityConfiguration : IEntityTypeConfiguration<MemeIndexEntity>
+{
+    // Weighted search vector (#220 binding design): tag/source/template hit ≫
+    // OCR hit ≫ description hit under ts_rank's default weights. f_unaccent and
+    // f_text_array_join are IMMUTABLE wrappers created in the MemeIndexSchema
+    // migration — bare unaccent() and array_to_string() are STABLE and rejected
+    // inside generated columns.
+    private const string SearchVectorSql =
+        "setweight(to_tsvector('simple', public.f_unaccent(coalesce(public.f_text_array_join(tags), '') || ' ' || coalesce(source, '') || ' ' || coalesce(template, ''))), 'A') || " +
+        "setweight(to_tsvector('simple', public.f_unaccent(coalesce(ocr_text, ''))), 'B') || " +
+        "setweight(to_tsvector('simple', public.f_unaccent(coalesce(description_pl, '') || ' ' || coalesce(description_en, ''))), 'C')";
+
+    private const string SearchTextSql =
+        "public.f_unaccent(coalesce(public.f_text_array_join(tags), '') || ' ' || coalesce(source, '') || ' ' || coalesce(template, '') || ' ' || " +
+        "coalesce(ocr_text, '') || ' ' || coalesce(description_pl, '') || ' ' || coalesce(description_en, ''))";
+
+    // Status is the per-row lifecycle (#221 job): Pending rows carry no result
+    // yet, Indexed rows must carry the full metadata block + provenance, and
+    // Failed/Skipped rows must say why.
+    private const string StatusConstraintSql =
+        "(status = 0 AND indexed_at_utc IS NULL) OR " +
+        "(status = 1 AND indexed_at_utc IS NOT NULL AND model_id IS NOT NULL AND description_pl IS NOT NULL AND description_en IS NOT NULL AND ocr_text IS NOT NULL) OR " +
+        "(status = 2 AND error IS NOT NULL) OR " +
+        "(status = 3 AND error IS NOT NULL)";
+
+    public void Configure(EntityTypeBuilder<MemeIndexEntity> builder)
+    {
+        builder.ToTable("meme_index", t => t.HasCheckConstraint("ck_meme_index_status", StatusConstraintSql));
+
+        builder.HasIndex(m => m.AttachmentDiscordId).IsUnique();
+        builder.HasIndex(m => m.ContentHash);
+        builder.HasIndex(m => m.MessageId);
+
+        builder.Property(m => m.RawResponseJson).HasColumnType("jsonb");
+
+        builder.Property(m => m.SearchVector)
+            .HasComputedColumnSql(SearchVectorSql, stored: true);
+        builder.Property(m => m.SearchText)
+            .HasComputedColumnSql(SearchTextSql, stored: true);
+
+        builder.HasIndex(m => m.SearchVector).HasMethod("GIN");
+        builder.HasIndex(m => m.SearchText).HasMethod("GIN").HasOperators("gin_trgm_ops");
+
+        // Same rationale as messages (§P2.6): meme rows must not vanish if a
+        // message hard-delete ever happens — surface it as a violation instead.
+        builder.HasOne(m => m.Message)
+            .WithMany()
+            .HasForeignKey(m => m.MessageId)
+            .OnDelete(DeleteBehavior.Restrict);
+    }
+}

--- a/src/DiscordEventService/Data/DiscordDbContext.cs
+++ b/src/DiscordEventService/Data/DiscordDbContext.cs
@@ -86,9 +86,17 @@ public class DiscordDbContext(DbContextOptions<DiscordDbContext> options) : DbCo
     // Bot heartbeats (single-row liveness signal for power-loss detection)
     public DbSet<BotHeartbeatEntity> BotHeartbeats => Set<BotHeartbeatEntity>();
 
+    // Indexed memes (#218): vision metadata per meme-channel image attachment
+    public DbSet<MemeIndexEntity> MemeIndex => Set<MemeIndexEntity>();
+
     protected override void OnModelCreating(ModelBuilder modelBuilder)
     {
         base.OnModelCreating(modelBuilder);
+
+        // Meme search (#220, ADR-0005): unaccent feeds f_unaccent inside the
+        // meme_index generated columns; pg_trgm backs the trigram GIN index.
+        modelBuilder.HasPostgresExtension("unaccent");
+        modelBuilder.HasPostgresExtension("pg_trgm");
 
         // Apply snowflake converter to all ulong properties
         var snowflakeConverter = new ValueConverter<ulong, long>(

--- a/src/DiscordEventService/Data/Entities/Core/MemeIndexEntity.cs
+++ b/src/DiscordEventService/Data/Entities/Core/MemeIndexEntity.cs
@@ -1,0 +1,62 @@
+using NpgsqlTypes;
+
+namespace DiscordEventService.Data.Entities.Core;
+
+public enum MemeIndexStatus
+{
+    Pending = 0,
+    Indexed = 1,
+    Failed = 2,
+    Skipped = 3
+}
+
+// One row per image attachment in a meme channel (an "Indexed meme",
+// CONTEXT.md / ADR-0004 / ADR-0005) — a 3-image message yields 3 rows.
+public class MemeIndexEntity : ITimestamped
+{
+    public Guid Id { get; set; }
+
+    public Guid MessageId { get; set; }
+
+    // Denormalized snowflakes: jump links + joins without touching messages.
+    public ulong GuildDiscordId { get; set; }
+    public ulong ChannelDiscordId { get; set; }
+    public ulong MessageDiscordId { get; set; }
+
+    // Natural idempotency key — an attachment is indexed at most once.
+    public ulong AttachmentDiscordId { get; set; }
+
+    public string FileName { get; set; } = "";
+    public long FileSizeBytes { get; set; }
+    public string? ContentType { get; set; }
+
+    // SHA-256 hex of the downloaded bytes; null until indexed. Dedupe handle.
+    public string? ContentHash { get; set; }
+
+    // Vision metadata (MemeMetadata shape); null/empty until status = Indexed.
+    public string? DescriptionPl { get; set; }
+    public string? DescriptionEn { get; set; }
+    public string? OcrText { get; set; }
+    public string[] Tags { get; set; } = [];
+    public string? Source { get; set; }
+    public string? Template { get; set; }
+
+    // Provenance: which model produced the metadata, and its raw response.
+    public string? ModelId { get; set; }
+    public string? RawResponseJson { get; set; }
+    public DateTime? IndexedAtUtc { get; set; }
+
+    public MemeIndexStatus Status { get; set; }
+    public string? Error { get; set; }
+    public int AttemptCount { get; set; }
+
+    public DateTime FirstSeenUtc { get; set; }
+    public DateTime LastUpdatedUtc { get; set; }
+
+    // Stored generated columns (#220 binding design comment) — never set from
+    // code; the database derives them from the metadata columns.
+    public NpgsqlTsVector SearchVector { get; set; } = null!;
+    public string SearchText { get; set; } = null!;
+
+    public MessageEntity Message { get; set; } = null!;
+}

--- a/src/DiscordEventService/Data/Migrations/20260610195741_MemeIndexSchema.Designer.cs
+++ b/src/DiscordEventService/Data/Migrations/20260610195741_MemeIndexSchema.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using DiscordEventService.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using NpgsqlTypes;
@@ -12,9 +13,11 @@ using NpgsqlTypes;
 namespace DiscordEventService.Data.Migrations
 {
     [DbContext(typeof(DiscordDbContext))]
-    partial class DiscordDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260610195741_MemeIndexSchema")]
+    partial class MemeIndexSchema
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/DiscordEventService/Data/Migrations/20260610195741_MemeIndexSchema.cs
+++ b/src/DiscordEventService/Data/Migrations/20260610195741_MemeIndexSchema.cs
@@ -1,0 +1,127 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+using NpgsqlTypes;
+
+#nullable disable
+
+namespace DiscordEventService.Data.Migrations
+{
+    /// <inheritdoc />
+    public partial class MemeIndexSchema : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AlterDatabase()
+                .Annotation("Npgsql:PostgresExtension:pg_trgm", ",,")
+                .Annotation("Npgsql:PostgresExtension:unaccent", ",,");
+
+            // Bare unaccent() and array_to_string() are STABLE (unaccent's
+            // dictionary resolves via search_path; array_to_string invokes
+            // element output functions) and PostgreSQL rejects non-IMMUTABLE
+            // functions in generated columns. With a pinned dictionary and pure
+            // text[] input both are deterministic, hence safely IMMUTABLE.
+            // Must exist before CreateTable - meme_index's generated columns call them.
+            migrationBuilder.Sql("""
+                CREATE OR REPLACE FUNCTION public.f_unaccent(text)
+                  RETURNS text
+                  LANGUAGE sql IMMUTABLE PARALLEL SAFE STRICT
+                AS $func$
+                SELECT public.unaccent('public.unaccent'::regdictionary, $1)
+                $func$;
+
+                CREATE OR REPLACE FUNCTION public.f_text_array_join(text[])
+                  RETURNS text
+                  LANGUAGE sql IMMUTABLE PARALLEL SAFE STRICT
+                AS $func$
+                SELECT array_to_string($1, ' ')
+                $func$;
+                """);
+
+            migrationBuilder.CreateTable(
+                name: "meme_index",
+                columns: table => new
+                {
+                    id = table.Column<Guid>(type: "uuid", nullable: false, defaultValueSql: "uuidv7()"),
+                    message_id = table.Column<Guid>(type: "uuid", nullable: false),
+                    guild_discord_id = table.Column<long>(type: "bigint", nullable: false),
+                    channel_discord_id = table.Column<long>(type: "bigint", nullable: false),
+                    message_discord_id = table.Column<long>(type: "bigint", nullable: false),
+                    attachment_discord_id = table.Column<long>(type: "bigint", nullable: false),
+                    file_name = table.Column<string>(type: "text", nullable: false),
+                    file_size_bytes = table.Column<long>(type: "bigint", nullable: false),
+                    content_type = table.Column<string>(type: "text", nullable: true),
+                    content_hash = table.Column<string>(type: "text", nullable: true),
+                    description_pl = table.Column<string>(type: "text", nullable: true),
+                    description_en = table.Column<string>(type: "text", nullable: true),
+                    ocr_text = table.Column<string>(type: "text", nullable: true),
+                    tags = table.Column<string[]>(type: "text[]", nullable: false),
+                    source = table.Column<string>(type: "text", nullable: true),
+                    template = table.Column<string>(type: "text", nullable: true),
+                    model_id = table.Column<string>(type: "text", nullable: true),
+                    raw_response_json = table.Column<string>(type: "jsonb", nullable: true),
+                    indexed_at_utc = table.Column<DateTime>(type: "timestamp with time zone", nullable: true),
+                    status = table.Column<int>(type: "integer", nullable: false),
+                    error = table.Column<string>(type: "text", nullable: true),
+                    attempt_count = table.Column<int>(type: "integer", nullable: false),
+                    first_seen_utc = table.Column<DateTime>(type: "timestamp with time zone", nullable: false),
+                    last_updated_utc = table.Column<DateTime>(type: "timestamp with time zone", nullable: false),
+                    search_vector = table.Column<NpgsqlTsVector>(type: "tsvector", nullable: false, computedColumnSql: "setweight(to_tsvector('simple', public.f_unaccent(coalesce(public.f_text_array_join(tags), '') || ' ' || coalesce(source, '') || ' ' || coalesce(template, ''))), 'A') || setweight(to_tsvector('simple', public.f_unaccent(coalesce(ocr_text, ''))), 'B') || setweight(to_tsvector('simple', public.f_unaccent(coalesce(description_pl, '') || ' ' || coalesce(description_en, ''))), 'C')", stored: true),
+                    search_text = table.Column<string>(type: "text", nullable: false, computedColumnSql: "public.f_unaccent(coalesce(public.f_text_array_join(tags), '') || ' ' || coalesce(source, '') || ' ' || coalesce(template, '') || ' ' || coalesce(ocr_text, '') || ' ' || coalesce(description_pl, '') || ' ' || coalesce(description_en, ''))", stored: true)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("pk_meme_index", x => x.id);
+                    table.CheckConstraint("ck_meme_index_status", "(status = 0 AND indexed_at_utc IS NULL) OR (status = 1 AND indexed_at_utc IS NOT NULL AND model_id IS NOT NULL AND description_pl IS NOT NULL AND description_en IS NOT NULL AND ocr_text IS NOT NULL) OR (status = 2 AND error IS NOT NULL) OR (status = 3 AND error IS NOT NULL)");
+                    table.ForeignKey(
+                        name: "fk_meme_index_messages_message_id",
+                        column: x => x.message_id,
+                        principalTable: "messages",
+                        principalColumn: "id",
+                        onDelete: ReferentialAction.Restrict);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "ix_meme_index_attachment_discord_id",
+                table: "meme_index",
+                column: "attachment_discord_id",
+                unique: true);
+
+            migrationBuilder.CreateIndex(
+                name: "ix_meme_index_content_hash",
+                table: "meme_index",
+                column: "content_hash");
+
+            migrationBuilder.CreateIndex(
+                name: "ix_meme_index_message_id",
+                table: "meme_index",
+                column: "message_id");
+
+            migrationBuilder.CreateIndex(
+                name: "ix_meme_index_search_text",
+                table: "meme_index",
+                column: "search_text")
+                .Annotation("Npgsql:IndexMethod", "GIN")
+                .Annotation("Npgsql:IndexOperators", new[] { "gin_trgm_ops" });
+
+            migrationBuilder.CreateIndex(
+                name: "ix_meme_index_search_vector",
+                table: "meme_index",
+                column: "search_vector")
+                .Annotation("Npgsql:IndexMethod", "GIN");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "meme_index");
+
+            migrationBuilder.Sql("DROP FUNCTION IF EXISTS public.f_unaccent(text); DROP FUNCTION IF EXISTS public.f_text_array_join(text[]);");
+
+            migrationBuilder.AlterDatabase()
+                .OldAnnotation("Npgsql:PostgresExtension:pg_trgm", ",,")
+                .OldAnnotation("Npgsql:PostgresExtension:unaccent", ",,");
+        }
+    }
+}

--- a/tests/DiscordEventService.Tests/MemeIndexSchemaTests.cs
+++ b/tests/DiscordEventService.Tests/MemeIndexSchemaTests.cs
@@ -1,0 +1,242 @@
+using DiscordEventService.Data;
+using DiscordEventService.Data.Entities.Core;
+using Microsoft.EntityFrameworkCore;
+using Npgsql;
+using Xunit;
+
+namespace DiscordEventService.Tests;
+
+// #220 acceptance contracts for the meme_index schema: idempotency key,
+// status lifecycle CHECK, FTS + trigram search semantics on the stored
+// generated columns, and the soft-delete join shape /meme (§6) will use.
+public sealed class MemeIndexSchemaTests(PostgresFixture fixture) : IClassFixture<PostgresFixture>, IAsyncLifetime
+{
+    private DiscordDbContext _db = null!;
+    private MessageEntity _liveMessage = null!;
+    private MessageEntity _deletedMessage = null!;
+
+    public async Task InitializeAsync()
+    {
+        _db = NewContext();
+        await _db.Database.MigrateAsync();
+
+        await _db.MemeIndex.ExecuteDeleteAsync();
+        await _db.Messages.ExecuteDeleteAsync();
+        await _db.Channels.ExecuteDeleteAsync();
+        await _db.Users.ExecuteDeleteAsync();
+        await _db.Guilds.ExecuteDeleteAsync();
+
+        var guild = new GuildEntity { DiscordId = 1UL, Name = "g" };
+        _db.Guilds.Add(guild);
+        await _db.SaveChangesAsync();
+
+        var channel = new ChannelEntity { DiscordId = 2UL, GuildId = guild.Id, Name = "memes", Type = ChannelType.Text };
+        var author = new UserEntity { DiscordId = 3UL, Username = "u" };
+        _db.Channels.Add(channel);
+        _db.Users.Add(author);
+        await _db.SaveChangesAsync();
+
+        _liveMessage = Message(channel, author, guild, 1001UL, isDeleted: false);
+        _deletedMessage = Message(channel, author, guild, 1002UL, isDeleted: true);
+        _db.Messages.AddRange(_liveMessage, _deletedMessage);
+        await _db.SaveChangesAsync();
+        _db.ChangeTracker.Clear();
+    }
+
+    public Task DisposeAsync() => _db.DisposeAsync().AsTask();
+
+    [Fact]
+    public async Task Insert_WhenDuplicateAttachmentDiscordId_IsRejected()
+    {
+        _db.MemeIndex.Add(PendingMeme(42UL));
+        await _db.SaveChangesAsync();
+
+        await using var second = NewContext();
+        second.MemeIndex.Add(PendingMeme(42UL));
+
+        await Assert.ThrowsAsync<DbUpdateException>(() => second.SaveChangesAsync());
+    }
+
+    [Fact]
+    public async Task Insert_WhenIndexedWithoutMetadata_ViolatesStatusConstraint()
+    {
+        var meme = PendingMeme(43UL);
+        meme.Status = MemeIndexStatus.Indexed;
+        meme.IndexedAtUtc = DateTime.UtcNow;
+        _db.MemeIndex.Add(meme);
+
+        await Assert.ThrowsAsync<DbUpdateException>(() => _db.SaveChangesAsync());
+    }
+
+    [Fact]
+    public async Task Insert_WhenFailedWithoutError_ViolatesStatusConstraint()
+    {
+        var meme = PendingMeme(44UL);
+        meme.Status = MemeIndexStatus.Failed;
+        _db.MemeIndex.Add(meme);
+
+        await Assert.ThrowsAsync<DbUpdateException>(() => _db.SaveChangesAsync());
+    }
+
+    [Fact]
+    public async Task Insert_WhenPending_GeneratesIdAndSearchColumns()
+    {
+        _db.MemeIndex.Add(PendingMeme(45UL));
+        await _db.SaveChangesAsync();
+
+        await using var verify = NewContext();
+        var row = await verify.MemeIndex.SingleAsync(m => m.AttachmentDiscordId == 45UL);
+        Assert.NotEqual(Guid.Empty, row.Id);
+        Assert.NotNull(row.SearchText);
+    }
+
+    [Fact]
+    public async Task SearchVector_MultiWordAccentInsensitiveQuery_FindsOnlyMatchingRow()
+    {
+        _db.MemeIndex.Add(IndexedMeme(50UL,
+            descriptionPl: "Pies siedzi przy komputerze",
+            descriptionEn: "A dog sits at a computer",
+            ocrText: "kiedy kod działa za pierwszym razem",
+            tags: ["pies", "programowanie"]));
+        _db.MemeIndex.Add(IndexedMeme(51UL,
+            descriptionPl: "Kot patrzy na lodówkę",
+            descriptionEn: "A cat stares at the fridge",
+            ocrText: "",
+            tags: ["kot"]));
+        await _db.SaveChangesAsync();
+
+        // Accentless multi-word query must hit the accented OCR text ("działa").
+        var hits = await SearchByVector("dziala kod");
+
+        Assert.Equal([50L], hits);
+    }
+
+    [Fact]
+    public async Task SearchText_TrigramSimilarity_MatchesPolishInflectionBothWays()
+    {
+        _db.MemeIndex.Add(IndexedMeme(60UL,
+            descriptionPl: "Mem o bazie danych",
+            descriptionEn: "Database meme",
+            ocrText: "",
+            tags: ["postgresie"]));
+        _db.MemeIndex.Add(IndexedMeme(61UL,
+            descriptionPl: "Inny mem o bazie danych",
+            descriptionEn: "Another database meme",
+            ocrText: "",
+            tags: ["postgres"]));
+        await _db.SaveChangesAsync();
+
+        var forBaseForm = await SearchByTrigram("postgres");
+        var forInflected = await SearchByTrigram("postgresie");
+
+        Assert.Contains(60L, forBaseForm);
+        Assert.Contains(61L, forInflected);
+    }
+
+    [Fact]
+    public async Task MessagesJoin_WhenMessageSoftDeleted_RowIsExcludable()
+    {
+        _db.MemeIndex.Add(PendingMeme(70UL));
+        var onDeleted = PendingMeme(71UL);
+        onDeleted.MessageId = _deletedMessage.Id;
+        onDeleted.MessageDiscordId = _deletedMessage.DiscordId;
+        _db.MemeIndex.Add(onDeleted);
+        await _db.SaveChangesAsync();
+
+        // The §6 query shape: search hits joined to messages, soft-deleted out.
+        var visible = await _db.MemeIndex
+            .Where(m => !m.Message.IsDeleted)
+            .Select(m => m.AttachmentDiscordId)
+            .ToListAsync();
+
+        Assert.Equal([70UL], visible);
+    }
+
+    private async Task<List<long>> SearchByVector(string query)
+    {
+        await using var connection = new NpgsqlConnection(fixture.Container.GetConnectionString());
+        await connection.OpenAsync();
+        await using var command = connection.CreateCommand();
+        command.CommandText = """
+            SELECT attachment_discord_id FROM meme_index
+            WHERE search_vector @@ websearch_to_tsquery('simple', public.f_unaccent($1))
+            ORDER BY attachment_discord_id
+            """;
+        command.Parameters.AddWithValue(query);
+        return await ReadIds(command);
+    }
+
+    private async Task<List<long>> SearchByTrigram(string query)
+    {
+        await using var connection = new NpgsqlConnection(fixture.Container.GetConnectionString());
+        await connection.OpenAsync();
+        await using var command = connection.CreateCommand();
+        command.CommandText = """
+            SELECT attachment_discord_id FROM meme_index
+            WHERE word_similarity(public.f_unaccent($1), search_text) >= 0.4
+            ORDER BY attachment_discord_id
+            """;
+        command.Parameters.AddWithValue(query);
+        return await ReadIds(command);
+    }
+
+    private static async Task<List<long>> ReadIds(NpgsqlCommand command)
+    {
+        var ids = new List<long>();
+        await using var reader = await command.ExecuteReaderAsync();
+        while (await reader.ReadAsync())
+            ids.Add(reader.GetInt64(0));
+        return ids;
+    }
+
+    private MemeIndexEntity PendingMeme(ulong attachmentDiscordId) => new MemeIndexEntity
+    {
+        MessageId = _liveMessage.Id,
+        GuildDiscordId = 1UL,
+        ChannelDiscordId = 2UL,
+        MessageDiscordId = _liveMessage.DiscordId,
+        AttachmentDiscordId = attachmentDiscordId,
+        FileName = "meme.png",
+        FileSizeBytes = 1234,
+        ContentType = "image/png",
+        Status = MemeIndexStatus.Pending
+    };
+
+    private MemeIndexEntity IndexedMeme(ulong attachmentDiscordId, string descriptionPl, string descriptionEn,
+        string ocrText, string[] tags)
+    {
+        var meme = PendingMeme(attachmentDiscordId);
+        meme.Status = MemeIndexStatus.Indexed;
+        meme.DescriptionPl = descriptionPl;
+        meme.DescriptionEn = descriptionEn;
+        meme.OcrText = ocrText;
+        meme.Tags = tags;
+        meme.ContentHash = $"hash-{attachmentDiscordId}";
+        meme.ModelId = "google/gemini-3-flash-preview";
+        meme.RawResponseJson = "{}";
+        meme.IndexedAtUtc = DateTime.UtcNow;
+        return meme;
+    }
+
+    private DiscordDbContext NewContext()
+    {
+        var options = new DbContextOptionsBuilder<DiscordDbContext>()
+            .UseNpgsql(fixture.Container.GetConnectionString())
+            .UseSnakeCaseNamingConvention()
+            .Options;
+        return new DiscordDbContext(options);
+    }
+
+    private MessageEntity Message(ChannelEntity channel, UserEntity author, GuildEntity guild, ulong discordId, bool isDeleted) =>
+        new MessageEntity
+        {
+            DiscordId = discordId,
+            ChannelId = channel.Id,
+            GuildId = guild.Id,
+            AuthorId = author.Id,
+            HasAttachments = true,
+            CreatedAtUtc = DateTime.UtcNow,
+            IsDeleted = isDeleted,
+            DeletedAtUtc = isDeleted ? DateTime.UtcNow : null
+        };
+}


### PR DESCRIPTION
## What

Closes #220 (epic #218 §2): the persistent home of an **Indexed meme** — one row per image attachment in a meme channel.

- `meme_index` table: Guid PK (uuidv7), FK to `messages` (Restrict) + denormalized guild/channel/message snowflakes, **unique `attachment_discord_id`** (natural idempotency key), file facts + sha256 `content_hash` (indexed), bilingual metadata (`description_pl/en`, `ocr_text`, `tags text[]`, `source`, `template`), provenance (`model_id`, `raw_response_json` jsonb, `indexed_at_utc`), status lifecycle with CHECK (`Indexed` requires the metadata block + provenance; `Failed`/`Skipped` require an error).
- Extensions `unaccent` + `pg_trgm` via `HasPostgresExtension` (stock postgres:18 contrib, no image change, no pgvector — ADR-0005).
- Search columns per the binding design comment: stored generated weighted tsvector (A = tags/source/template, B = ocr, C = descriptions, `simple` config) with GIN, and unaccented `search_text` with trigram GIN (`gin_trgm_ops`).

## Design amendment (vs the binding comment on #220)

The binding design called `array_to_string(tags, ' ')` directly inside the generated columns — Postgres rejects that (`42P17`): `array_to_string` is declared **STABLE**, the same volatility problem the design already anticipated for `unaccent()`. The migration therefore creates **two** IMMUTABLE wrappers: `f_unaccent` (pinned dictionary) and `f_text_array_join` (deterministic for pure `text[]`). Raw SQL in a migration is the documented EF Core mechanism for functions ([Managing Migrations → arbitrary changes via raw SQL](https://learn.microsoft.com/en-us/ef/core/managing-schemas/migrations/managing)).

## Also: .gitignore fix

#225's `src/DiscordEventService/data/` ignore rule (for local benchmark artifacts) silently ignored **new source files** under `Data/` — macOS git matches .gitignore case-insensitively (`core.ignorecase=true`). Scoped it to the two artifact dirs. (Caught because this PR's new entity/migration files vanished from the first commit attempt.)

## Tests (acceptance criteria)

7 Testcontainers contracts (real postgres:18, no mocking), all green; full suite 125/125:

- migration applies cleanly (every test runs the full chain from zero)
- duplicate `attachment_discord_id` rejected; both CHECK branches (`Indexed` w/o metadata, `Failed` w/o error) rejected
- `websearch_to_tsquery` multi-word **accent-insensitive** query ("dziala kod" → row with OCR "kiedy kod **działa**…") finds only the matching row
- trgm `word_similarity`: "postgres" finds row tagged "postgresie" **and vice versa**
- soft-deleted message excluded via the messages join (the §6 query shape)

Also live-verified: booted the dev bot against a local DB sitting at the current prod migration level — `MemeIndexSchema` applied **incrementally**, table/indexes/constraint match design exactly, zero errors in the boot log.

🤖 Generated with [Claude Code](https://claude.com/claude-code)