### PR TITLE
feat: DB-driven meme indexing job with checkpoint resume + ops trigger (#221)

### DIFF
--- a/src/DiscordEventService/Configuration/MemeIndexOptions.cs
+++ b/src/DiscordEventService/Configuration/MemeIndexOptions.cs
@@ -11,5 +11,9 @@ public sealed class MemeIndexOptions
     // Hard ceiling on image size we download for analysis.
     public int MaxImageBytes { get; set; } = 25 * 1024 * 1024;
 
+    // Cost guardrail (#221): at most this many attachments are processed per
+    // indexing run. Re-trigger to continue — runs are incremental.
+    public int MaxImagesPerRun { get; set; } = 500;
+
     public bool IsConfigured => ChannelIds.Length > 0;
 }

--- a/src/DiscordEventService/Data/Entities/Core/BackfillCheckpointEntity.cs
+++ b/src/DiscordEventService/Data/Entities/Core/BackfillCheckpointEntity.cs
@@ -35,7 +35,11 @@ public enum BackfillType
     Channels = 3,
     Members = 4,
     Messages = 5,
-    Reactions = 6
+    Reactions = 6,
+
+    // Meme indexing (#221) — not part of the weekly full-backfill chain;
+    // triggered independently via /api/ops/meme-index.
+    MemeIndex = 7
 }
 
 public enum BackfillStatus

--- a/src/DiscordEventService/Endpoints/MemeIndexEndpoints.cs
+++ b/src/DiscordEventService/Endpoints/MemeIndexEndpoints.cs
@@ -1,0 +1,127 @@
+using DiscordEventService.Configuration;
+using DiscordEventService.Data;
+using DiscordEventService.Data.Entities.Core;
+using DiscordEventService.Jobs;
+using Hangfire;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Options;
+
+namespace DiscordEventService.Endpoints;
+
+public static class MemeIndexEndpoints
+{
+    public static void MapMemeIndexEndpoints(this WebApplication app)
+    {
+        var group = app.MapGroup("/api/ops/meme-index");
+
+        group.MapPost("/backfill/{guildId:long}", StartIndexing)
+            .WithName("StartMemeIndexing")
+            .Produces<MemeIndexStartResponse>(StatusCodes.Status202Accepted)
+            .Produces(StatusCodes.Status400BadRequest);
+
+        group.MapGet("/status", GetStatus)
+            .WithName("GetMemeIndexStatus")
+            .Produces<MemeIndexStatusResponse>();
+    }
+
+    private static async Task<IResult> StartIndexing(
+        ulong guildId,
+        IOptions<MemeIndexOptions> memeIndexOptions,
+        IOptions<OpenRouterOptions> openRouterOptions,
+        DiscordDbContext db,
+        IBackgroundJobClient backgroundJobClient)
+    {
+        if (!memeIndexOptions.Value.IsConfigured)
+            return Results.BadRequest(new { error = "MemeIndex:ChannelIds is empty — no meme channels configured" });
+        if (!openRouterOptions.Value.IsConfigured)
+            return Results.BadRequest(new { error = "OpenRouter:ApiKey is not configured" });
+        if (string.IsNullOrWhiteSpace(openRouterOptions.Value.Model))
+            return Results.BadRequest(new { error = "OpenRouter:Model is not set" });
+
+        var inProgress = await db.BackfillCheckpoints.AnyAsync(c =>
+            c.GuildDiscordId == guildId && c.Type == BackfillType.MemeIndex && c.Status == BackfillStatus.InProgress);
+        if (inProgress)
+            return Results.BadRequest(new { error = "Meme indexing already in progress for this guild" });
+
+        var jobId = backgroundJobClient.Enqueue<MemeIndexingJob>(j => j.ExecuteAsync(guildId, CancellationToken.None));
+
+        return Results.Accepted("/api/ops/meme-index/status", new MemeIndexStartResponse
+        {
+            HangfireJobId = jobId,
+            GuildId = guildId,
+            Model = openRouterOptions.Value.Model,
+            MaxImagesPerRun = memeIndexOptions.Value.MaxImagesPerRun
+        });
+    }
+
+    private static async Task<IResult> GetStatus(DiscordDbContext db)
+    {
+        var checkpoints = await db.BackfillCheckpoints
+            .Where(c => c.Type == BackfillType.MemeIndex)
+            .OrderBy(c => c.GuildDiscordId)
+            .Select(c => new MemeIndexCheckpointDto
+            {
+                GuildId = c.GuildDiscordId,
+                Status = c.Status.ToString(),
+                ProcessedCount = c.ProcessedCount,
+                TotalCount = c.TotalCount,
+                ErrorCount = c.ErrorCount,
+                LastError = c.LastError,
+                StartedAt = c.StartedAtUtc,
+                CompletedAt = c.CompletedAtUtc
+            })
+            .ToListAsync();
+
+        var countsByStatus = await db.MemeIndex
+            .GroupBy(m => m.Status)
+            .Select(g => new { g.Key, Count = g.Count() })
+            .ToDictionaryAsync(g => g.Key, g => g.Count);
+
+        return Results.Ok(new MemeIndexStatusResponse
+        {
+            Checkpoints = checkpoints,
+            Rows = new MemeIndexRowCounts
+            {
+                Pending = countsByStatus.GetValueOrDefault(MemeIndexStatus.Pending),
+                Indexed = countsByStatus.GetValueOrDefault(MemeIndexStatus.Indexed),
+                Failed = countsByStatus.GetValueOrDefault(MemeIndexStatus.Failed),
+                Skipped = countsByStatus.GetValueOrDefault(MemeIndexStatus.Skipped)
+            }
+        });
+    }
+}
+
+public sealed record MemeIndexStartResponse
+{
+    public required string HangfireJobId { get; init; }
+    public required ulong GuildId { get; init; }
+    public required string Model { get; init; }
+    public required int MaxImagesPerRun { get; init; }
+}
+
+public sealed record MemeIndexStatusResponse
+{
+    public required List<MemeIndexCheckpointDto> Checkpoints { get; init; }
+    public required MemeIndexRowCounts Rows { get; init; }
+}
+
+public sealed record MemeIndexRowCounts
+{
+    public int Pending { get; init; }
+    public int Indexed { get; init; }
+    public int Failed { get; init; }
+    public int Skipped { get; init; }
+    public int Total => Pending + Indexed + Failed + Skipped;
+}
+
+public sealed record MemeIndexCheckpointDto
+{
+    public required ulong GuildId { get; init; }
+    public required string Status { get; init; }
+    public int ProcessedCount { get; init; }
+    public int? TotalCount { get; init; }
+    public int ErrorCount { get; init; }
+    public string? LastError { get; init; }
+    public DateTime StartedAt { get; init; }
+    public DateTime? CompletedAt { get; init; }
+}

--- a/src/DiscordEventService/Jobs/MemeIndexingJob.cs
+++ b/src/DiscordEventService/Jobs/MemeIndexingJob.cs
@@ -1,0 +1,317 @@
+using System.Security.Cryptography;
+using DiscordEventService.Configuration;
+using DiscordEventService.Data;
+using DiscordEventService.Data.Entities.Core;
+using DiscordEventService.Services.MemeIndexing;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Options;
+
+namespace DiscordEventService.Jobs;
+
+// #221: walks every image attachment in the configured meme channels and
+// produces Indexed meme rows. Purely DB-driven (binding comment on #221):
+// candidates come from messages.attachments_json, expired CDN URLs are
+// re-signed via attachments/refresh-urls — no channel-history pagination, no
+// gateway. Idempotent: terminal rows (Indexed/Skipped) are skipped on re-run,
+// Failed rows are retried. Not part of the weekly full-backfill chain.
+public sealed class MemeIndexingJob(
+    BackfillJobExecutor executor,
+    IHttpClientFactory httpClientFactory,
+    ILogger<MemeIndexingJob> logger) : BackfillJobBase
+{
+    protected override BackfillType BackfillType => BackfillType.MemeIndex;
+
+    private sealed class RunCounters
+    {
+        public int Indexed { get; set; }
+        public int Deduped { get; set; }
+        public int Skipped { get; set; }
+        public int Failed { get; set; }
+        public int ModelCalls { get; set; }
+        public long PromptTokens { get; set; }
+        public long CompletionTokens { get; set; }
+        public decimal CostUsd { get; set; }
+    }
+
+    public Task ExecuteAsync(ulong guildId, CancellationToken cancellationToken)
+        => executor.RunAsync(BackfillType, guildId, async ctx =>
+        {
+            var memeOptions = ctx.Services.GetRequiredService<IOptions<MemeIndexOptions>>().Value;
+            var openRouterOptions = ctx.Services.GetRequiredService<IOptions<OpenRouterOptions>>().Value;
+
+            if (!memeOptions.IsConfigured)
+                return BackfillOutcome.ShortCircuit("MemeIndex:ChannelIds is empty — no meme channels configured");
+            if (!openRouterOptions.IsConfigured)
+                return BackfillOutcome.ShortCircuit("OpenRouter:ApiKey is not configured");
+            if (string.IsNullOrWhiteSpace(openRouterOptions.Model))
+                return BackfillOutcome.ShortCircuit("OpenRouter:Model is not set — the #219 model pick is required");
+
+            var sampleService = ctx.Services.GetRequiredService<MemeSampleService>();
+            var urlRefreshService = ctx.Services.GetRequiredService<AttachmentUrlRefreshService>();
+            var openRouterClient = ctx.Services.GetRequiredService<OpenRouterClient>();
+
+            var pending = await CollectPendingAsync(ctx.Db, sampleService, guildId, ctx.Checkpoint, cancellationToken);
+
+            var cap = memeOptions.MaxImagesPerRun;
+            var capped = pending.Count > cap;
+            if (capped)
+            {
+                logger.LogInformation(
+                    "Meme indexing for guild {GuildId}: {Pending} attachments pending, capping this run at {Cap}",
+                    guildId, pending.Count, cap);
+                pending = pending.Take(cap).ToList();
+            }
+
+            // A fresh run (no resume cursor) restarts the per-run progress pair;
+            // a mid-flight resume keeps accumulating into it.
+            if (ctx.Checkpoint.LastProcessedId is null)
+                ctx.Checkpoint.ProcessedCount = 0;
+            ctx.Checkpoint.TotalCount = pending.Count;
+            await ctx.Db.SaveChangesAsync(cancellationToken);
+
+            if (pending.Count == 0)
+            {
+                logger.LogInformation("Meme indexing for guild {GuildId}: nothing to do, all candidates terminal", guildId);
+                return BackfillOutcome.Completed;
+            }
+
+            logger.LogInformation(
+                "Meme indexing starting for guild {GuildId}: {Count} attachments, model {Model}",
+                guildId, pending.Count, openRouterOptions.Model);
+
+            var counters = new RunCounters();
+
+            // Refresh-urls accepts ~50 per call; chunking also keeps signed URLs
+            // fresh relative to when they're actually downloaded.
+            var position = 0;
+            foreach (var batch in pending.Chunk(50))
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+
+                var freshUrls = await urlRefreshService.RefreshAsync(
+                    batch.Select(b => b.StoredUrl).ToList(), cancellationToken);
+
+                foreach (var item in batch)
+                {
+                    cancellationToken.ThrowIfCancellationRequested();
+
+                    var row = await GetOrCreateRowAsync(ctx.Db, item, cancellationToken);
+                    await ProcessOneAsync(ctx.Db, row, item, freshUrls, openRouterClient, memeOptions, openRouterOptions, counters, cancellationToken);
+
+                    position++;
+                    ctx.Checkpoint.ProcessedCount++;
+                    // Advance the resume cursor only once a message's LAST pending
+                    // attachment is done — a mid-message cursor would skip siblings.
+                    var lastOfMessage = position == pending.Count
+                        || pending[position].MessageDiscordId != item.MessageDiscordId;
+                    if (lastOfMessage)
+                        ctx.Checkpoint.LastProcessedId = item.MessageDiscordId;
+
+                    await SaveProgressAsync(ctx.Db, ctx.Checkpoint);
+                }
+            }
+
+            logger.LogInformation(
+                "Meme indexing finished for guild {GuildId}: {Indexed} indexed, {Deduped} deduped, {Skipped} skipped, {Failed} failed; " +
+                "{ModelCalls} model calls, tokens {PromptTokens}/{CompletionTokens}, cost {CostUsd:F4} USD{CapNote}",
+                guildId, counters.Indexed, counters.Deduped, counters.Skipped, counters.Failed,
+                counters.ModelCalls, counters.PromptTokens, counters.CompletionTokens, counters.CostUsd,
+                capped ? " (cap reached — re-trigger to continue)" : "");
+
+            return BackfillOutcome.Completed;
+        }, cancellationToken);
+
+    // All image attachments in this guild's meme channels that still need work:
+    // no row yet, or a Failed row (retried). Terminal rows (Indexed/Skipped) are
+    // skipped — this is what makes re-runs idempotent. Deterministic order is
+    // what makes the message-id resume cursor valid across runs.
+    private static async Task<List<MemeSampleItem>> CollectPendingAsync(
+        DiscordDbContext db,
+        MemeSampleService sampleService,
+        ulong guildId,
+        BackfillCheckpointEntity checkpoint,
+        CancellationToken cancellationToken)
+    {
+        var candidates = (await sampleService.GetCandidatesAsync(cancellationToken))
+            .Where(c => c.GuildDiscordId == guildId)
+            .OrderBy(c => c.MessageDiscordId)
+            .ThenBy(c => c.AttachmentDiscordId)
+            .ToList();
+
+        var statusByAttachment = await db.MemeIndex
+            .Where(m => m.GuildDiscordId == guildId)
+            .Select(m => new { m.AttachmentDiscordId, m.Status })
+            .ToDictionaryAsync(m => m.AttachmentDiscordId, m => m.Status, cancellationToken);
+
+        var pending = candidates
+            .Where(c => !statusByAttachment.TryGetValue(c.AttachmentDiscordId, out var status)
+                        || status == MemeIndexStatus.Failed)
+            .ToList();
+
+        // Resume cursor survives only a mid-flight interruption (the executor
+        // clears it after terminal runs); skip messages already fully processed.
+        if (checkpoint.LastProcessedId is { } cursor)
+            pending = pending.Where(c => c.MessageDiscordId > cursor).ToList();
+
+        return pending;
+    }
+
+    private static async Task<MemeIndexEntity> GetOrCreateRowAsync(
+        DiscordDbContext db, MemeSampleItem item, CancellationToken cancellationToken)
+    {
+        var row = await db.MemeIndex
+            .FirstOrDefaultAsync(m => m.AttachmentDiscordId == item.AttachmentDiscordId, cancellationToken);
+        if (row is not null)
+            return row;
+
+        row = new MemeIndexEntity
+        {
+            MessageId = item.MessageId,
+            GuildDiscordId = item.GuildDiscordId,
+            ChannelDiscordId = item.ChannelDiscordId,
+            MessageDiscordId = item.MessageDiscordId,
+            AttachmentDiscordId = item.AttachmentDiscordId,
+            FileName = item.FileName,
+            FileSizeBytes = item.FileSizeBytes,
+            Status = MemeIndexStatus.Pending
+        };
+        db.MemeIndex.Add(row);
+        return row;
+    }
+
+    private async Task ProcessOneAsync(
+        DiscordDbContext db,
+        MemeIndexEntity row,
+        MemeSampleItem item,
+        Dictionary<string, string> freshUrls,
+        OpenRouterClient openRouterClient,
+        MemeIndexOptions memeOptions,
+        OpenRouterOptions openRouterOptions,
+        RunCounters counters,
+        CancellationToken cancellationToken)
+    {
+        row.AttemptCount++;
+
+        if (!freshUrls.TryGetValue(AttachmentUrlRefreshService.StripQuery(item.StoredUrl), out var freshUrl))
+        {
+            Skip(row, counters, "dead attachment: refresh-urls declined to re-sign");
+            return;
+        }
+
+        byte[] imageBytes;
+        try
+        {
+            var client = httpClientFactory.CreateClient(MemeBenchmarkJob.DownloadHttpClientName);
+            imageBytes = await client.GetByteArrayAsync(freshUrl, cancellationToken);
+        }
+        catch (HttpRequestException ex) when (ex.StatusCode is System.Net.HttpStatusCode.NotFound
+            or System.Net.HttpStatusCode.Forbidden or System.Net.HttpStatusCode.Gone)
+        {
+            Skip(row, counters, $"dead attachment: download HTTP {(int)ex.StatusCode!}");
+            return;
+        }
+        catch (Exception ex) when (ex is HttpRequestException
+            || (ex is TaskCanceledException && !cancellationToken.IsCancellationRequested))
+        {
+            Fail(row, counters, $"download failed: {ex.Message}");
+            return;
+        }
+
+        row.FileSizeBytes = imageBytes.Length;
+
+        if (imageBytes.Length > memeOptions.MaxImageBytes)
+        {
+            Skip(row, counters, $"unsupported: image too large ({imageBytes.Length} bytes)");
+            return;
+        }
+
+        var mimeType = ImageMagic.SniffMimeType(imageBytes);
+        if (mimeType is null)
+        {
+            Skip(row, counters, "unsupported: bytes are not a recognized image format");
+            return;
+        }
+        row.ContentType = mimeType;
+
+        var contentHash = Convert.ToHexStringLower(SHA256.HashData(imageBytes));
+        row.ContentHash = contentHash;
+
+        // Repost dedupe: same bytes already Indexed → copy its metadata, no
+        // model call. RawResponseJson stays null — provenance lives on the
+        // original row, found via the shared content_hash.
+        var original = await db.MemeIndex.AsNoTracking()
+            .Where(m => m.ContentHash == contentHash && m.Status == MemeIndexStatus.Indexed && m.Id != row.Id)
+            .Select(m => new { m.DescriptionPl, m.DescriptionEn, m.OcrText, m.Tags, m.Source, m.Template, m.ModelId })
+            .FirstOrDefaultAsync(cancellationToken);
+
+        if (original is not null)
+        {
+            row.DescriptionPl = original.DescriptionPl;
+            row.DescriptionEn = original.DescriptionEn;
+            row.OcrText = original.OcrText;
+            row.Tags = original.Tags;
+            row.Source = original.Source;
+            row.Template = original.Template;
+            row.ModelId = original.ModelId;
+            row.RawResponseJson = null;
+            row.IndexedAtUtc = DateTime.UtcNow;
+            row.Status = MemeIndexStatus.Indexed;
+            row.Error = null;
+            counters.Deduped++;
+            logger.LogDebug("Meme attachment {AttachmentId} deduped via content hash {ContentHash}",
+                row.AttachmentDiscordId, contentHash);
+            return;
+        }
+
+        var result = await openRouterClient.AnalyzeImageAsync(imageBytes, mimeType, openRouterOptions.Model, cancellationToken);
+        counters.ModelCalls++;
+        counters.PromptTokens += result.Usage?.PromptTokens ?? 0;
+        counters.CompletionTokens += result.Usage?.CompletionTokens ?? 0;
+        counters.CostUsd += result.Usage?.CostUsd ?? 0;
+
+        switch (result.Outcome)
+        {
+            case MemeAnalysisOutcome.Success:
+                row.DescriptionPl = result.Metadata!.DescriptionPl;
+                row.DescriptionEn = result.Metadata.DescriptionEn;
+                row.OcrText = result.Metadata.OcrText;
+                row.Tags = result.Metadata.Tags;
+                row.Source = result.Metadata.Source;
+                row.Template = result.Metadata.Template;
+                row.ModelId = openRouterOptions.Model;
+                row.RawResponseJson = result.RawContent;
+                row.IndexedAtUtc = DateTime.UtcNow;
+                row.Status = MemeIndexStatus.Indexed;
+                row.Error = null;
+                counters.Indexed++;
+                break;
+
+            case MemeAnalysisOutcome.Refusal:
+                Skip(row, counters, $"model refusal: {result.Error}");
+                break;
+
+            default:
+                Fail(row, counters, result.Error ?? "unknown analysis error");
+                break;
+        }
+
+        await Task.Delay(TimeSpan.FromMilliseconds(openRouterOptions.RequestDelayMs), cancellationToken);
+    }
+
+    private void Skip(MemeIndexEntity row, RunCounters counters, string reason)
+    {
+        row.Status = MemeIndexStatus.Skipped;
+        row.Error = reason;
+        counters.Skipped++;
+        logger.LogInformation("Meme attachment {AttachmentId} skipped: {Reason}", row.AttachmentDiscordId, reason);
+    }
+
+    private void Fail(MemeIndexEntity row, RunCounters counters, string error)
+    {
+        row.Status = MemeIndexStatus.Failed;
+        row.Error = error;
+        counters.Failed++;
+        logger.LogWarning("Meme attachment {AttachmentId} failed (attempt {Attempt}): {Error}",
+            row.AttachmentDiscordId, row.AttemptCount, error);
+    }
+}

--- a/src/DiscordEventService/Jobs/MemeIndexingJob.cs
+++ b/src/DiscordEventService/Jobs/MemeIndexingJob.cs
@@ -143,9 +143,13 @@ public sealed class MemeIndexingJob(
             .Select(m => new { m.AttachmentDiscordId, m.Status })
             .ToDictionaryAsync(m => m.AttachmentDiscordId, m => m.Status, cancellationToken);
 
+        // Only Indexed/Skipped are terminal. Failed retries by design; Pending
+        // means a prior run was interrupted mid-attachment and the executor's
+        // failure path flushed the freshly-added row — it must be picked up
+        // again or the attachment is silently lost from the index.
         var pending = candidates
             .Where(c => !statusByAttachment.TryGetValue(c.AttachmentDiscordId, out var status)
-                        || status == MemeIndexStatus.Failed)
+                        || status is MemeIndexStatus.Failed or MemeIndexStatus.Pending)
             .ToList();
 
         // Resume cursor survives only a mid-flight interruption (the executor

--- a/src/DiscordEventService/Program.cs
+++ b/src/DiscordEventService/Program.cs
@@ -222,6 +222,7 @@ builder.Services.AddScoped<OpenRouterClient>();
 builder.Services.AddScoped<MemeSampleService>();
 builder.Services.AddScoped<AttachmentUrlRefreshService>();
 builder.Services.AddScoped<MemeBenchmarkJob>();
+builder.Services.AddScoped<MemeIndexingJob>();
 
 // Hangfire. With a fixed InvisibilityTimeout a job outliving it gets presumed
 // dead, re-queued, and the original execution cancelled — observed live on the
@@ -326,6 +327,7 @@ app.MapOpsEndpoints();
 
 // Meme benchmark API (#219)
 app.MapMemeBenchmarkEndpoints();
+app.MapMemeIndexEndpoints();
 
 // SPA fallback — LAST so it only catches client-side routes (any non-/api,
 // non-/health, non-/hangfire GET) and serves index.html for deep links.

--- a/src/DiscordEventService/Services/MemeIndexing/MemeMetadata.cs
+++ b/src/DiscordEventService/Services/MemeIndexing/MemeMetadata.cs
@@ -50,8 +50,12 @@ public sealed record MemeAnalysisResult
     public string? Error { get; init; }
     public bool IsTransient { get; init; }
 
-    public static MemeAnalysisResult Success(MemeMetadata metadata, MemeAnalysisUsage usage) =>
-        new MemeAnalysisResult { Outcome = MemeAnalysisOutcome.Success, Metadata = metadata, Usage = usage };
+    // The model's verbatim structured-output JSON — provenance for
+    // meme_index.raw_response_json (#221).
+    public string? RawContent { get; init; }
+
+    public static MemeAnalysisResult Success(MemeMetadata metadata, MemeAnalysisUsage usage, string? rawContent = null) =>
+        new MemeAnalysisResult { Outcome = MemeAnalysisOutcome.Success, Metadata = metadata, Usage = usage, RawContent = rawContent };
 
     public static MemeAnalysisResult Refusal(string reason) =>
         new MemeAnalysisResult { Outcome = MemeAnalysisOutcome.Refusal, Error = reason };

--- a/src/DiscordEventService/Services/MemeIndexing/MemeSampleService.cs
+++ b/src/DiscordEventService/Services/MemeIndexing/MemeSampleService.cs
@@ -8,6 +8,8 @@ namespace DiscordEventService.Services.MemeIndexing;
 
 // One image attachment in a meme channel: snowflakes for the jump link plus
 // the stored (expired) CDN URL, which AttachmentUrlRefreshService re-signs.
+// The trailing defaults keep pre-#221 benchmark links files deserializable —
+// old exports simply lack MessageId/FileSizeBytes.
 public sealed record MemeSampleItem(
     ulong GuildDiscordId,
     ulong ChannelDiscordId,
@@ -15,7 +17,9 @@ public sealed record MemeSampleItem(
     ulong AttachmentDiscordId,
     string FileName,
     DateTime CreatedAtUtc,
-    string StoredUrl);
+    string StoredUrl,
+    Guid MessageId = default,
+    long FileSizeBytes = 0);
 
 public sealed class MemeSampleService(
     DiscordDbContext db,
@@ -66,7 +70,9 @@ public sealed class MemeSampleService(
         return picked;
     }
 
-    private async Task<List<MemeSampleItem>> GetCandidatesAsync(CancellationToken cancellationToken)
+    // Also the candidate source for the indexing job (#221) — every image
+    // attachment in the configured meme channels, no sampling.
+    public async Task<List<MemeSampleItem>> GetCandidatesAsync(CancellationToken cancellationToken)
     {
         var channelIds = options.Value.ChannelIds;
 
@@ -80,6 +86,7 @@ public sealed class MemeSampleService(
                       && m.AttachmentsJson != null
                 select new
                 {
+                    m.Id,
                     m.DiscordId,
                     m.AttachmentsJson,
                     m.CreatedAtUtc,
@@ -114,7 +121,9 @@ public sealed class MemeSampleService(
                     a.Id,
                     a.FileName!,
                     row.CreatedAtUtc,
-                    a.Url!)));
+                    a.Url!,
+                    row.Id,
+                    a.FileSize)));
         }
 
         return candidates;

--- a/src/DiscordEventService/Services/MemeIndexing/OpenRouterClient.cs
+++ b/src/DiscordEventService/Services/MemeIndexing/OpenRouterClient.cs
@@ -191,7 +191,7 @@ public sealed class OpenRouterClient(
             completion.Usage?.CompletionTokens ?? 0,
             completion.Usage?.Cost);
 
-        return MemeAnalysisResult.Success(metadata, usage);
+        return MemeAnalysisResult.Success(metadata, usage, choice.Message.Content);
     }
 
     private static string Truncate(string value, int max) =>

--- a/tests/DiscordEventService.Tests/MemeIndexingJobTests.cs
+++ b/tests/DiscordEventService.Tests/MemeIndexingJobTests.cs
@@ -165,6 +165,35 @@ public sealed class MemeIndexingJobTests(PostgresFixture fixture) : IClassFixtur
     }
 
     [Fact]
+    public async Task ExecuteAsync_StrandedPendingRow_IsReprocessed()
+    {
+        // A mid-attachment interruption leaves a committed Pending row behind
+        // (the executor's failure path flushes it). It must not be terminal.
+        AddMessage(1001UL, Attachment(11UL, "stranded.png"));
+        await _db.SaveChangesAsync();
+        _db.MemeIndex.Add(new MemeIndexEntity
+        {
+            MessageId = _db.Messages.Single(m => m.DiscordId == 1001UL).Id,
+            GuildDiscordId = GuildDiscordId,
+            ChannelDiscordId = ChannelDiscordId,
+            MessageDiscordId = 1001UL,
+            AttachmentDiscordId = 11UL,
+            FileName = "stranded.png",
+            FileSizeBytes = 123,
+            Status = MemeIndexStatus.Pending
+        });
+        await _db.SaveChangesAsync();
+        _http.SetImage(11UL, Png(1));
+
+        await RunJobAsync();
+
+        await using var verify = NewContext();
+        var row = await verify.MemeIndex.SingleAsync(m => m.AttachmentDiscordId == 11UL);
+        Assert.Equal(MemeIndexStatus.Indexed, row.Status);
+        Assert.Equal(1, _http.ModelCalls);
+    }
+
+    [Fact]
     public async Task ExecuteAsync_InterruptedRun_ResumesFromMessageCursor()
     {
         AddMessage(1001UL, Attachment(11UL, "done-before-crash.png"));

--- a/tests/DiscordEventService.Tests/MemeIndexingJobTests.cs
+++ b/tests/DiscordEventService.Tests/MemeIndexingJobTests.cs
@@ -1,0 +1,399 @@
+using System.Net;
+using System.Text;
+using System.Text.Json;
+using DiscordEventService.Configuration;
+using DiscordEventService.Data;
+using DiscordEventService.Data.Entities.Core;
+using DiscordEventService.Jobs;
+using DiscordEventService.Services.MemeIndexing;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace DiscordEventService.Tests;
+
+// #221 acceptance contracts, end-to-end against real Postgres with the three
+// HTTP surfaces (refresh-urls, CDN, OpenRouter) faked at the handler level —
+// the job, executor, sampler, refresh service, and client all run for real.
+public sealed class MemeIndexingJobTests(PostgresFixture fixture) : IClassFixture<PostgresFixture>, IAsyncLifetime
+{
+    private const ulong GuildDiscordId = 1UL;
+    private const ulong ChannelDiscordId = 2UL;
+
+    private DiscordDbContext _db = null!;
+    private GuildEntity _guild = null!;
+    private ChannelEntity _channel = null!;
+    private UserEntity _author = null!;
+    private FakeMemeHttpHandler _http = null!;
+
+    public async Task InitializeAsync()
+    {
+        _db = NewContext();
+        await _db.Database.MigrateAsync();
+
+        await _db.MemeIndex.ExecuteDeleteAsync();
+        await _db.BackfillCheckpoints.ExecuteDeleteAsync();
+        await _db.Messages.ExecuteDeleteAsync();
+        await _db.Channels.ExecuteDeleteAsync();
+        await _db.Users.ExecuteDeleteAsync();
+        await _db.Guilds.ExecuteDeleteAsync();
+
+        _guild = new GuildEntity { DiscordId = GuildDiscordId, Name = "g" };
+        _db.Guilds.Add(_guild);
+        await _db.SaveChangesAsync();
+
+        _channel = new ChannelEntity { DiscordId = ChannelDiscordId, GuildId = _guild.Id, Name = "memes", Type = ChannelType.Text };
+        _author = new UserEntity { DiscordId = 3UL, Username = "u" };
+        _db.Channels.Add(_channel);
+        _db.Users.Add(_author);
+        await _db.SaveChangesAsync();
+
+        _http = new FakeMemeHttpHandler();
+    }
+
+    public Task DisposeAsync() => _db.DisposeAsync().AsTask();
+
+    [Fact]
+    public async Task ExecuteAsync_FullRun_IndexesEveryImageAttachment()
+    {
+        AddMessage(1001UL, Attachment(11UL, "a.png"), Attachment(12UL, "b.png"));
+        AddMessage(1002UL, Attachment(13UL, "c.png"), Attachment(14UL, "clip.mp4"));
+        await _db.SaveChangesAsync();
+        _http.SetImage(11UL, Png(1));
+        _http.SetImage(12UL, Png(2));
+        _http.SetImage(13UL, Png(3));
+
+        await RunJobAsync();
+
+        await using var verify = NewContext();
+        var rows = await verify.MemeIndex.OrderBy(m => m.AttachmentDiscordId).ToListAsync();
+        Assert.Equal([11UL, 12UL, 13UL], rows.Select(r => r.AttachmentDiscordId));
+        Assert.All(rows, r =>
+        {
+            Assert.Equal(MemeIndexStatus.Indexed, r.Status);
+            Assert.Equal(GuildDiscordId, r.GuildDiscordId);
+            Assert.Equal(ChannelDiscordId, r.ChannelDiscordId);
+            Assert.Equal("test/model", r.ModelId);
+            Assert.NotNull(r.ContentHash);
+            Assert.NotNull(r.IndexedAtUtc);
+            Assert.NotEqual(Guid.Empty, r.MessageId);
+        });
+        Assert.Equal(3, _http.ModelCalls);
+
+        var checkpoint = await verify.BackfillCheckpoints.SingleAsync(c => c.Type == BackfillType.MemeIndex);
+        Assert.Equal(BackfillStatus.Completed, checkpoint.Status);
+        Assert.Equal(3, checkpoint.ProcessedCount);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_RerunOverTerminalRows_MakesNoModelCalls()
+    {
+        AddMessage(1001UL, Attachment(11UL, "a.png"));
+        await _db.SaveChangesAsync();
+        _http.SetImage(11UL, Png(1));
+
+        await RunJobAsync();
+        Assert.Equal(1, _http.ModelCalls);
+
+        await RunJobAsync();
+
+        Assert.Equal(1, _http.ModelCalls);
+        await using var verify = NewContext();
+        Assert.Equal(1, await verify.MemeIndex.CountAsync());
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_SameBytesTwice_DedupesWithoutSecondModelCall()
+    {
+        AddMessage(1001UL, Attachment(11UL, "original.png"));
+        AddMessage(1002UL, Attachment(12UL, "repost.png"));
+        await _db.SaveChangesAsync();
+        _http.SetImage(11UL, Png(7));
+        _http.SetImage(12UL, Png(7));
+
+        await RunJobAsync();
+
+        Assert.Equal(1, _http.ModelCalls);
+        await using var verify = NewContext();
+        var rows = await verify.MemeIndex.OrderBy(m => m.AttachmentDiscordId).ToListAsync();
+        Assert.All(rows, r => Assert.Equal(MemeIndexStatus.Indexed, r.Status));
+        Assert.Equal(rows[0].ContentHash, rows[1].ContentHash);
+        Assert.Equal(rows[0].DescriptionPl, rows[1].DescriptionPl);
+        Assert.NotNull(rows[0].RawResponseJson);
+        Assert.Null(rows[1].RawResponseJson);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_OutcomeMapping_SkippedVsFailed()
+    {
+        AddMessage(1001UL, Attachment(11UL, "refused.png"));
+        AddMessage(1002UL, Attachment(12UL, "flaky.png"));
+        AddMessage(1003UL, Attachment(13UL, "not-an-image.png"));
+        AddMessage(1004UL, Attachment(14UL, "dead.png"));
+        await _db.SaveChangesAsync();
+        _http.SetImage(11UL, Png(1));
+        _http.SetImage(12UL, Png(2));
+        _http.SetImage(13UL, Encoding.ASCII.GetBytes("definitely not image bytes"));
+        _http.DeadAttachments.Add(14UL);
+        _http.RefusalFor.Add(Png(1));
+        _http.TransientErrorFor.Add(Png(2));
+
+        await RunJobAsync();
+
+        await using var verify = NewContext();
+        var byId = await verify.MemeIndex.ToDictionaryAsync(m => m.AttachmentDiscordId);
+        Assert.Equal(MemeIndexStatus.Skipped, byId[11UL].Status);
+        Assert.StartsWith("model refusal", byId[11UL].Error);
+        Assert.Equal(MemeIndexStatus.Failed, byId[12UL].Status);
+        Assert.Equal(1, byId[12UL].AttemptCount);
+        Assert.Equal(MemeIndexStatus.Skipped, byId[13UL].Status);
+        Assert.StartsWith("unsupported", byId[13UL].Error);
+        Assert.Equal(MemeIndexStatus.Skipped, byId[14UL].Status);
+        Assert.StartsWith("dead attachment", byId[14UL].Error);
+
+        // Re-run retries ONLY the Failed row — and this time it succeeds.
+        _http.TransientErrorFor.Clear();
+        var callsBefore = _http.ModelCalls;
+        await RunJobAsync();
+
+        Assert.Equal(callsBefore + 1, _http.ModelCalls);
+        await using var verify2 = NewContext();
+        var retried = await verify2.MemeIndex.SingleAsync(m => m.AttachmentDiscordId == 12UL);
+        Assert.Equal(MemeIndexStatus.Indexed, retried.Status);
+        Assert.Equal(2, retried.AttemptCount);
+        Assert.Null(retried.Error);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_InterruptedRun_ResumesFromMessageCursor()
+    {
+        AddMessage(1001UL, Attachment(11UL, "done-before-crash.png"));
+        AddMessage(1002UL, Attachment(12UL, "after-cursor.png"));
+        await _db.SaveChangesAsync();
+        _http.SetImage(11UL, Png(1));
+        _http.SetImage(12UL, Png(2));
+
+        // Simulate a SIGKILLed run: checkpoint left InProgress with the cursor
+        // past message 1001 — the executor only honors the cursor in this state.
+        _db.BackfillCheckpoints.Add(new BackfillCheckpointEntity
+        {
+            GuildDiscordId = GuildDiscordId,
+            Type = BackfillType.MemeIndex,
+            Status = BackfillStatus.InProgress,
+            LastProcessedId = 1001UL,
+            StartedAtUtc = DateTime.UtcNow
+        });
+        await _db.SaveChangesAsync();
+
+        await RunJobAsync();
+
+        await using var verify = NewContext();
+        var rows = await verify.MemeIndex.ToListAsync();
+        var row = Assert.Single(rows);
+        Assert.Equal(12UL, row.AttachmentDiscordId);
+        Assert.Equal(1, _http.ModelCalls);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_MaxImagesPerRun_CapsTheRunAndNextRunContinues()
+    {
+        AddMessage(1001UL, Attachment(11UL, "a.png"));
+        AddMessage(1002UL, Attachment(12UL, "b.png"));
+        AddMessage(1003UL, Attachment(13UL, "c.png"));
+        await _db.SaveChangesAsync();
+        _http.SetImage(11UL, Png(1));
+        _http.SetImage(12UL, Png(2));
+        _http.SetImage(13UL, Png(3));
+
+        await RunJobAsync(maxImagesPerRun: 2);
+
+        await using var verify = NewContext();
+        Assert.Equal(2, await verify.MemeIndex.CountAsync());
+        Assert.Equal(2, _http.ModelCalls);
+
+        await RunJobAsync(maxImagesPerRun: 2);
+
+        await using var verify2 = NewContext();
+        Assert.Equal(3, await verify2.MemeIndex.CountAsync());
+        Assert.Equal(3, _http.ModelCalls);
+    }
+
+    private async Task RunJobAsync(int maxImagesPerRun = 500)
+    {
+        var services = new ServiceCollection();
+        services.AddLogging();
+        services.AddDbContext<DiscordDbContext>(o => o
+            .UseNpgsql(fixture.Container.GetConnectionString())
+            .UseSnakeCaseNamingConvention());
+        services.Configure<MemeIndexOptions>(o =>
+        {
+            o.ChannelIds = [ChannelDiscordId];
+            o.MaxImagesPerRun = maxImagesPerRun;
+        });
+        services.Configure<OpenRouterOptions>(o =>
+        {
+            o.ApiKey = "test-key";
+            o.Model = "test/model";
+            o.RequestDelayMs = 0;
+        });
+        services.Configure<DiscordOptions>(o => o.Token = new string('x', 60));
+        services.AddSingleton<IHttpClientFactory>(new FakeHttpClientFactory(_http));
+        services.AddScoped<MemeSampleService>();
+        services.AddScoped<AttachmentUrlRefreshService>();
+        services.AddScoped<OpenRouterClient>();
+        services.AddScoped<BackfillJobExecutor>();
+        services.AddScoped<MemeIndexingJob>();
+
+        await using var provider = services.BuildServiceProvider();
+        using var scope = provider.CreateScope();
+        await scope.ServiceProvider.GetRequiredService<MemeIndexingJob>()
+            .ExecuteAsync(GuildDiscordId, CancellationToken.None);
+    }
+
+    private void AddMessage(ulong discordId, params string[] attachments)
+    {
+        _db.Messages.Add(new MessageEntity
+        {
+            DiscordId = discordId,
+            ChannelId = _channel.Id,
+            GuildId = _guild.Id,
+            AuthorId = _author.Id,
+            HasAttachments = true,
+            AttachmentsJson = $"[{string.Join(",", attachments)}]",
+            CreatedAtUtc = DateTime.UtcNow
+        });
+    }
+
+    // The 4-field PascalCase shape MessageEventHandler/MessagesBackfillJob serialize.
+    private static string Attachment(ulong id, string fileName) =>
+        $"{{\"Id\":{id},\"Url\":\"https://cdn.test/attachments/{ChannelDiscordId}/{id}/{fileName}?ex=expired\",\"FileName\":\"{fileName}\",\"FileSize\":123}}";
+
+    // Distinct valid-PNG-magic payloads (≥12 bytes for the sniffer).
+    private static byte[] Png(byte seed) =>
+        [0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A, 0, 0, 0, 13, seed, seed, seed];
+
+    private DiscordDbContext NewContext()
+    {
+        var options = new DbContextOptionsBuilder<DiscordDbContext>()
+            .UseNpgsql(fixture.Container.GetConnectionString())
+            .UseSnakeCaseNamingConvention()
+            .Options;
+        return new DiscordDbContext(options);
+    }
+}
+
+// Routes the three HTTP surfaces the job touches. CDN bytes are keyed by
+// attachment id parsed from the URL path; refresh succeeds for everything
+// except DeadAttachments (absent from the refresh response, like Discord).
+internal sealed class FakeMemeHttpHandler : HttpMessageHandler
+{
+    private readonly Dictionary<ulong, byte[]> _imagesByAttachment = new Dictionary<ulong, byte[]>();
+
+    public HashSet<ulong> DeadAttachments { get; } = [];
+    public List<byte[]> RefusalFor { get; } = [];
+    public List<byte[]> TransientErrorFor { get; } = [];
+    public int ModelCalls { get; private set; }
+
+    public void SetImage(ulong attachmentId, byte[] bytes) => _imagesByAttachment[attachmentId] = bytes;
+
+    protected override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+    {
+        var path = request.RequestUri!.AbsolutePath;
+
+        if (path.EndsWith("attachments/refresh-urls", StringComparison.Ordinal))
+            return await HandleRefreshAsync(request, cancellationToken);
+
+        if (path.EndsWith("chat/completions", StringComparison.Ordinal))
+            return await HandleModelAsync(request, cancellationToken);
+
+        return HandleCdn(request);
+    }
+
+    private async Task<HttpResponseMessage> HandleRefreshAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+    {
+        var body = await request.Content!.ReadAsStringAsync(cancellationToken);
+        var urls = JsonDocument.Parse(body).RootElement.GetProperty("attachment_urls");
+
+        var refreshed = urls.EnumerateArray()
+            .Select(u => u.GetString()!)
+            .Where(u => !DeadAttachments.Contains(AttachmentIdOf(u)))
+            .Select(u => new { original = u, refreshed = u + "?sig=fresh" })
+            .ToList();
+
+        return Json(HttpStatusCode.OK, JsonSerializer.Serialize(new { refreshed_urls = refreshed }));
+    }
+
+    private HttpResponseMessage HandleCdn(HttpRequestMessage request)
+    {
+        var id = AttachmentIdOf(request.RequestUri!.AbsoluteUri);
+        if (!_imagesByAttachment.TryGetValue(id, out var bytes))
+            return new HttpResponseMessage(HttpStatusCode.NotFound);
+
+        return new HttpResponseMessage(HttpStatusCode.OK) { Content = new ByteArrayContent(bytes) };
+    }
+
+    private async Task<HttpResponseMessage> HandleModelAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+    {
+        var body = await request.Content!.ReadAsStringAsync(cancellationToken);
+        var imageBytes = ExtractImageBytes(body);
+        ModelCalls++;
+
+        if (TransientErrorFor.Any(b => b.AsSpan().SequenceEqual(imageBytes)))
+            return Json(HttpStatusCode.InternalServerError, """{"error":"upstream exploded"}""");
+
+        if (RefusalFor.Any(b => b.AsSpan().SequenceEqual(imageBytes)))
+            return Json(HttpStatusCode.OK,
+                """{"choices":[{"message":{"content":null,"refusal":"safety"},"finish_reason":"stop"}]}""");
+
+        var metadata = JsonSerializer.Serialize(new
+        {
+            description_pl = $"Opis obrazka {imageBytes[^1]}",
+            description_en = $"Description of image {imageBytes[^1]}",
+            ocr_text = "",
+            tags = new[] { "test", "mem" },
+            source = (string?)null,
+            template = (string?)null
+        });
+        var response = JsonSerializer.Serialize(new
+        {
+            choices = new[] { new { message = new { content = metadata, refusal = (string?)null }, finish_reason = "stop" } },
+            usage = new { prompt_tokens = 100, completion_tokens = 50, cost = 0.0016m }
+        });
+        return Json(HttpStatusCode.OK, response);
+    }
+
+    private static byte[] ExtractImageBytes(string requestBody)
+    {
+        using var doc = JsonDocument.Parse(requestBody);
+        var dataUrl = doc.RootElement.GetProperty("messages")[1].GetProperty("content")[0]
+            .GetProperty("image_url").GetProperty("url").GetString()!;
+        return Convert.FromBase64String(dataUrl[(dataUrl.IndexOf("base64,", StringComparison.Ordinal) + 7)..]);
+    }
+
+    // .../attachments/{channelId}/{attachmentId}/{fileName}
+    private static ulong AttachmentIdOf(string url)
+    {
+        var segments = new Uri(url).AbsolutePath.Split('/', StringSplitOptions.RemoveEmptyEntries);
+        return ulong.Parse(segments[^2]);
+    }
+
+    private static HttpResponseMessage Json(HttpStatusCode status, string json) =>
+        new HttpResponseMessage(status)
+        {
+            Content = new StringContent(json, Encoding.UTF8, "application/json")
+        };
+}
+
+internal sealed class FakeHttpClientFactory(HttpMessageHandler handler) : IHttpClientFactory
+{
+    public HttpClient CreateClient(string name) =>
+        new HttpClient(handler, disposeHandler: false)
+        {
+            BaseAddress = name switch
+            {
+                AttachmentUrlRefreshService.HttpClientName => new Uri("https://discord.test/api/v10/"),
+                OpenRouterClient.HttpClientName => new Uri("https://openrouter.test/api/v1/"),
+                _ => null
+            }
+        };
+}


### PR DESCRIPTION
## What

Closes #221 (epic #218 §3): the job that turns the empty `meme_index` table (#220) into an actual index.

- **`MemeIndexingJob`** on the existing `BackfillJobExecutor`/checkpoint infrastructure (`BackfillType.MemeIndex = 7`, deliberately NOT in the weekly full-backfill chain).
- **Purely DB-driven** per the binding design comment: candidates from `messages.attachments_json` via `MemeSampleService.GetCandidatesAsync` (now public, + message Guid and file size on `MemeSampleItem` — trailing defaults keep old benchmark links-files deserializable), expired CDN URLs re-signed in batches of 50 via `attachments/refresh-urls`. No channel pagination, no gateway, no Discord rate-limit coupling.
- **Per attachment**: refresh → download → magic-byte sniff → sha256. Identical bytes already Indexed → metadata copied, **no model call** (repost dedupe; `raw_response_json` stays null, provenance lives on the original via shared hash). Otherwise → `OpenRouterClient` with the #219-picked model.
- **Outcome → #220 lifecycle**: refusal / dead attachment (refresh declined, download 404/403/410) / oversize / unsupported bytes → **Skipped** with reason; transport/API/schema errors → **Failed** with attempt count, retried on the next run; success → **Indexed** with model id + verbatim structured output (`MemeAnalysisResult.RawContent`) as provenance.
- **Idempotent + resumable**: terminal rows skipped on re-run; message-id resume cursor advances only after a message's *last* attachment (no sibling-skipping), honored only for mid-flight interruptions (executor semantics).
- **Cost guardrails**: `MemeIndex:MaxImagesPerRun` (default 500) caps each run — runs are incremental, re-trigger to continue; model-call throttle via existing `OpenRouter:RequestDelayMs`; token/cost totals logged per run.
- **Ops**: `POST /api/ops/meme-index/backfill/{guildId}` (config guards, rejects concurrent runs) + `GET /api/ops/meme-index/status` (checkpoint + per-status row counts).

## Tests

6 Testcontainers contracts — real Postgres + real job/executor/sampler/refresh/client, only the three HTTP surfaces (refresh-urls, CDN, OpenRouter) faked at `HttpMessageHandler` level. Full suite 131/131.

- full run indexes every image attachment with correct jump-link snowflakes + provenance
- re-run over terminal rows makes **zero** model calls
- identical bytes deduped without a second model call
- refusal→Skipped, transient→Failed(+attempt, retried-and-succeeds on next run), non-image bytes→Skipped, dead attachment→Skipped
- SIGKILL-style interrupted run resumes from the message cursor
- `MaxImagesPerRun` caps the run; next run continues where it left off

## Live demo (dev guild, real OpenRouter + real Discord refresh-urls)

Two capped runs of 12 images each over dev channels (Grafana alert PNGs + a 2023 message with a long-expired URL): **24 Indexed, 0 failed, 0 errors**, ~$0.02/run (matches benchmark rate), the 2023 URL refreshed + downloaded fine, second run picked up exactly the next 12 — verified via the ops endpoints and the run-summary log line.

🤖 Generated with [Claude Code](https://claude.com/claude-code)