### PR TITLE
feat: live MessageCreated meme indexing + weekly healing sweep (#222)

### DIFF
--- a/src/DiscordEventService/Jobs/MemeIndexSweepJob.cs
+++ b/src/DiscordEventService/Jobs/MemeIndexSweepJob.cs
@@ -1,0 +1,68 @@
+using DiscordEventService.Configuration;
+using DiscordEventService.Data;
+using DiscordEventService.Data.Entities.Core;
+using Hangfire;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Options;
+
+namespace DiscordEventService.Jobs;
+
+/// <summary>
+/// Weekly meme-index healing sweep (#222). The live MessageCreated hook indexes
+/// new memes within seconds; this catches what it misses — attachments posted
+/// during downtime, live-path enqueue failures, and Failed rows still under the
+/// attempt cap. Mirrors <see cref="PeriodicFullBackfillJob"/>: a parameterless
+/// coordinator that enqueues one per-guild job, skipping guilds whose meme
+/// indexing is already running. A clean week is a cheap no-op (one candidate
+/// query, zero model calls).
+/// </summary>
+public sealed class MemeIndexSweepJob(
+    IServiceScopeFactory scopeFactory,
+    IBackgroundJobClient backgroundJobClient,
+    ILogger<MemeIndexSweepJob> logger)
+{
+    public async Task ExecuteAsync()
+    {
+        using var scope = scopeFactory.CreateScope();
+        var memeOptions = scope.ServiceProvider.GetRequiredService<IOptions<MemeIndexOptions>>().Value;
+        var openRouterOptions = scope.ServiceProvider.GetRequiredService<IOptions<OpenRouterOptions>>().Value;
+
+        // Checked here, not just in the per-guild job: an unconfigured deploy
+        // (prod until #223) must not write a Failed checkpoint every week.
+        if (!memeOptions.IsConfigured || !openRouterOptions.IsConfigured
+            || string.IsNullOrWhiteSpace(openRouterOptions.Model))
+        {
+            logger.LogInformation("Meme index sweep skipped: meme indexing is not fully configured");
+            return;
+        }
+
+        var db = scope.ServiceProvider.GetRequiredService<DiscordDbContext>();
+        var channelIds = memeOptions.ChannelIds;
+
+        var guildIds = await db.Channels.AsNoTracking()
+            .Where(c => channelIds.Contains(c.DiscordId))
+            .Join(db.Guilds.AsNoTracking().Where(g => g.LeftAtUtc == null),
+                c => c.GuildId, g => g.Id, (c, g) => g.DiscordId)
+            .Distinct()
+            .ToListAsync();
+
+        var inProgress = await db.BackfillCheckpoints.AsNoTracking()
+            .Where(c => c.Type == BackfillType.MemeIndex && c.Status == BackfillStatus.InProgress)
+            .Select(c => c.GuildDiscordId)
+            .ToListAsync();
+        var inProgressSet = inProgress.ToHashSet();
+
+        foreach (var guildId in guildIds)
+        {
+            if (inProgressSet.Contains(guildId))
+            {
+                logger.LogInformation(
+                    "Meme index sweep skipped for guild {GuildId}: indexing already in progress", guildId);
+                continue;
+            }
+
+            backgroundJobClient.Enqueue<MemeIndexingJob>(j => j.ExecuteSweepAsync(guildId, CancellationToken.None));
+            logger.LogInformation("Meme index sweep enqueued for guild {GuildId}", guildId);
+        }
+    }
+}

--- a/src/DiscordEventService/Jobs/MemeIndexingJob.cs
+++ b/src/DiscordEventService/Jobs/MemeIndexingJob.cs
@@ -1,4 +1,3 @@
-using System.Security.Cryptography;
 using DiscordEventService.Configuration;
 using DiscordEventService.Data;
 using DiscordEventService.Data.Entities.Core;
@@ -14,26 +13,97 @@ namespace DiscordEventService.Jobs;
 // re-signed via attachments/refresh-urls — no channel-history pagination, no
 // gateway. Idempotent: terminal rows (Indexed/Skipped) are skipped on re-run,
 // Failed rows are retried. Not part of the weekly full-backfill chain.
+//
+// Three entry points (#222): ExecuteAsync is the operator-triggered backfill
+// (Failed retries uncapped — deliberate, see PR #228), ExecuteSweepAsync is the
+// weekly healing sweep (Failed retries capped so an autonomous recurring job
+// can't re-bill permanently-broken rows forever), and IndexMessageAsync is the
+// live single-message path enqueued by MessageEventHandler.
 public sealed class MemeIndexingJob(
     BackfillJobExecutor executor,
-    IHttpClientFactory httpClientFactory,
+    IServiceScopeFactory scopeFactory,
     ILogger<MemeIndexingJob> logger) : BackfillJobBase
 {
+    public const int SweepMaxFailedAttempts = 3;
+
     protected override BackfillType BackfillType => BackfillType.MemeIndex;
 
-    private sealed class RunCounters
+    public Task ExecuteAsync(ulong guildId, CancellationToken cancellationToken)
+        => RunAsync(guildId, maxFailedAttempts: null, cancellationToken);
+
+    public Task ExecuteSweepAsync(ulong guildId, CancellationToken cancellationToken)
+        => RunAsync(guildId, SweepMaxFailedAttempts, cancellationToken);
+
+    // #222 live path: index every image attachment of one freshly-posted
+    // message. No checkpoint — checkpoints are unique per (guild, type) and
+    // belong to the backfill/sweep runs; live jobs are small, frequent, and
+    // idempotent (terminal rows are skipped), so a Hangfire retry after a
+    // mid-run crash is safe and a concurrent backfill at worst costs one
+    // duplicate model call resolved by the unique attachment index.
+    public async Task IndexMessageAsync(ulong guildId, ulong messageDiscordId, CancellationToken cancellationToken)
     {
-        public int Indexed { get; set; }
-        public int Deduped { get; set; }
-        public int Skipped { get; set; }
-        public int Failed { get; set; }
-        public int ModelCalls { get; set; }
-        public long PromptTokens { get; set; }
-        public long CompletionTokens { get; set; }
-        public decimal CostUsd { get; set; }
+        using var scope = scopeFactory.CreateScope();
+        var services = scope.ServiceProvider;
+        var memeOptions = services.GetRequiredService<IOptions<MemeIndexOptions>>().Value;
+        var openRouterOptions = services.GetRequiredService<IOptions<OpenRouterOptions>>().Value;
+
+        // Config can change between enqueue and execution (deploy restart);
+        // anything dropped here is healed by the weekly sweep.
+        if (!memeOptions.IsConfigured || !openRouterOptions.IsConfigured
+            || string.IsNullOrWhiteSpace(openRouterOptions.Model))
+        {
+            logger.LogWarning(
+                "Live meme indexing for message {MessageId} in guild {GuildId} skipped: meme indexing is not fully configured",
+                messageDiscordId, guildId);
+            return;
+        }
+
+        var db = services.GetRequiredService<DiscordDbContext>();
+        var sampleService = services.GetRequiredService<MemeSampleService>();
+        var urlRefreshService = services.GetRequiredService<AttachmentUrlRefreshService>();
+        var indexer = services.GetRequiredService<MemeAttachmentIndexer>();
+
+        var candidates = (await sampleService.GetCandidatesForMessageAsync(messageDiscordId, cancellationToken))
+            .OrderBy(c => c.AttachmentDiscordId)
+            .ToList();
+
+        // Terminal rows stay untouched — relevant when Hangfire retries this
+        // job after a crash that landed between attachments.
+        var attachmentIds = candidates.Select(c => c.AttachmentDiscordId).ToList();
+        var terminal = await db.MemeIndex
+            .Where(m => attachmentIds.Contains(m.AttachmentDiscordId)
+                        && (m.Status == MemeIndexStatus.Indexed || m.Status == MemeIndexStatus.Skipped))
+            .Select(m => m.AttachmentDiscordId)
+            .ToListAsync(cancellationToken);
+        var pending = candidates.Where(c => !terminal.Contains(c.AttachmentDiscordId)).ToList();
+
+        if (pending.Count == 0)
+        {
+            logger.LogDebug("Live meme indexing for message {MessageId}: nothing to do", messageDiscordId);
+            return;
+        }
+
+        var freshUrls = await urlRefreshService.RefreshAsync(
+            pending.Select(p => p.StoredUrl).ToList(), cancellationToken);
+
+        var counters = new MemeIndexRunCounters();
+        foreach (var item in pending)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+
+            var row = await indexer.GetOrCreateRowAsync(db, item, cancellationToken);
+            await indexer.ProcessOneAsync(db, row, item, freshUrls, counters, cancellationToken);
+            await db.SaveChangesAsync(cancellationToken);
+        }
+
+        logger.LogInformation(
+            "Live meme indexing for message {MessageId} in guild {GuildId}: {Indexed} indexed, {Deduped} deduped, " +
+            "{Skipped} skipped, {Failed} failed; {ModelCalls} model calls, cost {CostUsd:F4} USD",
+            messageDiscordId, guildId, counters.Indexed, counters.Deduped, counters.Skipped, counters.Failed,
+            counters.ModelCalls, counters.CostUsd);
     }
 
-    public Task ExecuteAsync(ulong guildId, CancellationToken cancellationToken)
+    private Task RunAsync(ulong guildId, int? maxFailedAttempts, CancellationToken cancellationToken)
         => executor.RunAsync(BackfillType, guildId, async ctx =>
         {
             var memeOptions = ctx.Services.GetRequiredService<IOptions<MemeIndexOptions>>().Value;
@@ -48,9 +118,10 @@ public sealed class MemeIndexingJob(
 
             var sampleService = ctx.Services.GetRequiredService<MemeSampleService>();
             var urlRefreshService = ctx.Services.GetRequiredService<AttachmentUrlRefreshService>();
-            var openRouterClient = ctx.Services.GetRequiredService<OpenRouterClient>();
+            var indexer = ctx.Services.GetRequiredService<MemeAttachmentIndexer>();
 
-            var pending = await CollectPendingAsync(ctx.Db, sampleService, guildId, ctx.Checkpoint, cancellationToken);
+            var pending = await CollectPendingAsync(
+                ctx.Db, sampleService, guildId, ctx.Checkpoint, maxFailedAttempts, cancellationToken);
 
             var cap = memeOptions.MaxImagesPerRun;
             var capped = pending.Count > cap;
@@ -79,7 +150,7 @@ public sealed class MemeIndexingJob(
                 "Meme indexing starting for guild {GuildId}: {Count} attachments, model {Model}",
                 guildId, pending.Count, openRouterOptions.Model);
 
-            var counters = new RunCounters();
+            var counters = new MemeIndexRunCounters();
 
             // Refresh-urls accepts ~50 per call; chunking also keeps signed URLs
             // fresh relative to when they're actually downloaded.
@@ -95,8 +166,8 @@ public sealed class MemeIndexingJob(
                 {
                     cancellationToken.ThrowIfCancellationRequested();
 
-                    var row = await GetOrCreateRowAsync(ctx.Db, item, cancellationToken);
-                    await ProcessOneAsync(ctx.Db, row, item, freshUrls, openRouterClient, memeOptions, openRouterOptions, counters, cancellationToken);
+                    var row = await indexer.GetOrCreateRowAsync(ctx.Db, item, cancellationToken);
+                    await indexer.ProcessOneAsync(ctx.Db, row, item, freshUrls, counters, cancellationToken);
 
                     position++;
                     ctx.Checkpoint.ProcessedCount++;
@@ -122,14 +193,16 @@ public sealed class MemeIndexingJob(
         }, cancellationToken);
 
     // All image attachments in this guild's meme channels that still need work:
-    // no row yet, or a Failed row (retried). Terminal rows (Indexed/Skipped) are
-    // skipped — this is what makes re-runs idempotent. Deterministic order is
-    // what makes the message-id resume cursor valid across runs.
+    // no row yet, or a Failed row (retried, optionally attempt-capped for the
+    // sweep). Terminal rows (Indexed/Skipped) are skipped — this is what makes
+    // re-runs idempotent. Deterministic order is what makes the message-id
+    // resume cursor valid across runs.
     private static async Task<List<MemeSampleItem>> CollectPendingAsync(
         DiscordDbContext db,
         MemeSampleService sampleService,
         ulong guildId,
         BackfillCheckpointEntity checkpoint,
+        int? maxFailedAttempts,
         CancellationToken cancellationToken)
     {
         var candidates = (await sampleService.GetCandidatesAsync(cancellationToken))
@@ -140,16 +213,26 @@ public sealed class MemeIndexingJob(
 
         var statusByAttachment = await db.MemeIndex
             .Where(m => m.GuildDiscordId == guildId)
-            .Select(m => new { m.AttachmentDiscordId, m.Status })
-            .ToDictionaryAsync(m => m.AttachmentDiscordId, m => m.Status, cancellationToken);
+            .Select(m => new { m.AttachmentDiscordId, m.Status, m.AttemptCount })
+            .ToDictionaryAsync(m => m.AttachmentDiscordId, m => (m.Status, m.AttemptCount), cancellationToken);
 
         // Only Indexed/Skipped are terminal. Failed retries by design; Pending
         // means a prior run was interrupted mid-attachment and the executor's
         // failure path flushed the freshly-added row — it must be picked up
         // again or the attachment is silently lost from the index.
         var pending = candidates
-            .Where(c => !statusByAttachment.TryGetValue(c.AttachmentDiscordId, out var status)
-                        || status is MemeIndexStatus.Failed or MemeIndexStatus.Pending)
+            .Where(c =>
+            {
+                if (!statusByAttachment.TryGetValue(c.AttachmentDiscordId, out var row))
+                    return true;
+                return row.Status switch
+                {
+                    MemeIndexStatus.Pending => true,
+                    MemeIndexStatus.Failed => maxFailedAttempts is not { } capAttempts
+                        || row.AttemptCount < capAttempts,
+                    _ => false
+                };
+            })
             .ToList();
 
         // Resume cursor survives only a mid-flight interruption (the executor
@@ -158,164 +241,5 @@ public sealed class MemeIndexingJob(
             pending = pending.Where(c => c.MessageDiscordId > cursor).ToList();
 
         return pending;
-    }
-
-    private static async Task<MemeIndexEntity> GetOrCreateRowAsync(
-        DiscordDbContext db, MemeSampleItem item, CancellationToken cancellationToken)
-    {
-        var row = await db.MemeIndex
-            .FirstOrDefaultAsync(m => m.AttachmentDiscordId == item.AttachmentDiscordId, cancellationToken);
-        if (row is not null)
-            return row;
-
-        row = new MemeIndexEntity
-        {
-            MessageId = item.MessageId,
-            GuildDiscordId = item.GuildDiscordId,
-            ChannelDiscordId = item.ChannelDiscordId,
-            MessageDiscordId = item.MessageDiscordId,
-            AttachmentDiscordId = item.AttachmentDiscordId,
-            FileName = item.FileName,
-            FileSizeBytes = item.FileSizeBytes,
-            Status = MemeIndexStatus.Pending
-        };
-        db.MemeIndex.Add(row);
-        return row;
-    }
-
-    private async Task ProcessOneAsync(
-        DiscordDbContext db,
-        MemeIndexEntity row,
-        MemeSampleItem item,
-        Dictionary<string, string> freshUrls,
-        OpenRouterClient openRouterClient,
-        MemeIndexOptions memeOptions,
-        OpenRouterOptions openRouterOptions,
-        RunCounters counters,
-        CancellationToken cancellationToken)
-    {
-        row.AttemptCount++;
-
-        if (!freshUrls.TryGetValue(AttachmentUrlRefreshService.StripQuery(item.StoredUrl), out var freshUrl))
-        {
-            Skip(row, counters, "dead attachment: refresh-urls declined to re-sign");
-            return;
-        }
-
-        byte[] imageBytes;
-        try
-        {
-            var client = httpClientFactory.CreateClient(MemeBenchmarkJob.DownloadHttpClientName);
-            imageBytes = await client.GetByteArrayAsync(freshUrl, cancellationToken);
-        }
-        catch (HttpRequestException ex) when (ex.StatusCode is System.Net.HttpStatusCode.NotFound
-            or System.Net.HttpStatusCode.Forbidden or System.Net.HttpStatusCode.Gone)
-        {
-            Skip(row, counters, $"dead attachment: download HTTP {(int)ex.StatusCode!}");
-            return;
-        }
-        catch (Exception ex) when (ex is HttpRequestException
-            || (ex is TaskCanceledException && !cancellationToken.IsCancellationRequested))
-        {
-            Fail(row, counters, $"download failed: {ex.Message}");
-            return;
-        }
-
-        row.FileSizeBytes = imageBytes.Length;
-
-        if (imageBytes.Length > memeOptions.MaxImageBytes)
-        {
-            Skip(row, counters, $"unsupported: image too large ({imageBytes.Length} bytes)");
-            return;
-        }
-
-        var mimeType = ImageMagic.SniffMimeType(imageBytes);
-        if (mimeType is null)
-        {
-            Skip(row, counters, "unsupported: bytes are not a recognized image format");
-            return;
-        }
-        row.ContentType = mimeType;
-
-        var contentHash = Convert.ToHexStringLower(SHA256.HashData(imageBytes));
-        row.ContentHash = contentHash;
-
-        // Repost dedupe: same bytes already Indexed → copy its metadata, no
-        // model call. RawResponseJson stays null — provenance lives on the
-        // original row, found via the shared content_hash.
-        var original = await db.MemeIndex.AsNoTracking()
-            .Where(m => m.ContentHash == contentHash && m.Status == MemeIndexStatus.Indexed && m.Id != row.Id)
-            .Select(m => new { m.DescriptionPl, m.DescriptionEn, m.OcrText, m.Tags, m.Source, m.Template, m.ModelId })
-            .FirstOrDefaultAsync(cancellationToken);
-
-        if (original is not null)
-        {
-            row.DescriptionPl = original.DescriptionPl;
-            row.DescriptionEn = original.DescriptionEn;
-            row.OcrText = original.OcrText;
-            row.Tags = original.Tags;
-            row.Source = original.Source;
-            row.Template = original.Template;
-            row.ModelId = original.ModelId;
-            row.RawResponseJson = null;
-            row.IndexedAtUtc = DateTime.UtcNow;
-            row.Status = MemeIndexStatus.Indexed;
-            row.Error = null;
-            counters.Deduped++;
-            logger.LogDebug("Meme attachment {AttachmentId} deduped via content hash {ContentHash}",
-                row.AttachmentDiscordId, contentHash);
-            return;
-        }
-
-        var result = await openRouterClient.AnalyzeImageAsync(imageBytes, mimeType, openRouterOptions.Model, cancellationToken);
-        counters.ModelCalls++;
-        counters.PromptTokens += result.Usage?.PromptTokens ?? 0;
-        counters.CompletionTokens += result.Usage?.CompletionTokens ?? 0;
-        counters.CostUsd += result.Usage?.CostUsd ?? 0;
-
-        switch (result.Outcome)
-        {
-            case MemeAnalysisOutcome.Success:
-                row.DescriptionPl = result.Metadata!.DescriptionPl;
-                row.DescriptionEn = result.Metadata.DescriptionEn;
-                row.OcrText = result.Metadata.OcrText;
-                row.Tags = result.Metadata.Tags;
-                row.Source = result.Metadata.Source;
-                row.Template = result.Metadata.Template;
-                row.ModelId = openRouterOptions.Model;
-                row.RawResponseJson = result.RawContent;
-                row.IndexedAtUtc = DateTime.UtcNow;
-                row.Status = MemeIndexStatus.Indexed;
-                row.Error = null;
-                counters.Indexed++;
-                break;
-
-            case MemeAnalysisOutcome.Refusal:
-                Skip(row, counters, $"model refusal: {result.Error}");
-                break;
-
-            default:
-                Fail(row, counters, result.Error ?? "unknown analysis error");
-                break;
-        }
-
-        await Task.Delay(TimeSpan.FromMilliseconds(openRouterOptions.RequestDelayMs), cancellationToken);
-    }
-
-    private void Skip(MemeIndexEntity row, RunCounters counters, string reason)
-    {
-        row.Status = MemeIndexStatus.Skipped;
-        row.Error = reason;
-        counters.Skipped++;
-        logger.LogInformation("Meme attachment {AttachmentId} skipped: {Reason}", row.AttachmentDiscordId, reason);
-    }
-
-    private void Fail(MemeIndexEntity row, RunCounters counters, string error)
-    {
-        row.Status = MemeIndexStatus.Failed;
-        row.Error = error;
-        counters.Failed++;
-        logger.LogWarning("Meme attachment {AttachmentId} failed (attempt {Attempt}): {Error}",
-            row.AttachmentDiscordId, row.AttemptCount, error);
     }
 }

--- a/src/DiscordEventService/Program.cs
+++ b/src/DiscordEventService/Program.cs
@@ -101,6 +101,10 @@ builder.Services.AddSingleton(rootSp =>
         services.AddSingleton<IHostEnvironment>(builder.Environment);
         services.AddSingleton<EventPipeline>();
         services.AddCoreServices();
+        // #222: MessageEventHandler's live meme-index hook reads the configured
+        // meme channels; root-container option bindings aren't visible here.
+        services.AddOptions<MemeIndexOptions>()
+            .Bind(builder.Configuration.GetSection(MemeIndexOptions.SectionName));
         // IBackgroundJobClient forwards to the root container's registration.
         // Hangfire registers IBackgroundJobClient as Transient with DI-based
         // JobStorage resolution; using `new BackgroundJobClient()` directly
@@ -221,8 +225,10 @@ builder.Services.AddHttpClient(AttachmentUrlRefreshService.HttpClientName)
 builder.Services.AddScoped<OpenRouterClient>();
 builder.Services.AddScoped<MemeSampleService>();
 builder.Services.AddScoped<AttachmentUrlRefreshService>();
+builder.Services.AddScoped<MemeAttachmentIndexer>();
 builder.Services.AddScoped<MemeBenchmarkJob>();
 builder.Services.AddScoped<MemeIndexingJob>();
+builder.Services.AddScoped<MemeIndexSweepJob>();
 
 // Hangfire. With a fixed InvisibilityTimeout a job outliving it gets presumed
 // dead, re-queued, and the original execution cancelled — observed live on the
@@ -318,6 +324,15 @@ RecurringJob.AddOrUpdate<HealthCheckJob>(
     "health-check",
     j => j.ExecuteAsync(),
     "*/5 * * * *"); // Every 5 minutes
+
+// Weekly meme-index healing sweep (#222) — indexes attachments the live
+// MessageCreated path missed (downtime, enqueue failures) and retries Failed
+// rows under the attempt cap. After the 03:00 full backfill so messages it
+// recovers are already in the DB. No-op while meme indexing is unconfigured.
+RecurringJob.AddOrUpdate<MemeIndexSweepJob>(
+    "meme-index-sweep",
+    j => j.ExecuteAsync(),
+    "0 5 * * 0"); // Sundays 05:00 UTC
 
 // Backfill API
 app.MapBackfillEndpoints();

--- a/src/DiscordEventService/Services/EventHandlers/MessageEventHandler.cs
+++ b/src/DiscordEventService/Services/EventHandlers/MessageEventHandler.cs
@@ -1,11 +1,16 @@
+using DiscordEventService.Configuration;
 using DiscordEventService.Data;
 using DiscordEventService.Data.Entities.Core;
 using DiscordEventService.Data.Entities.Events;
+using DiscordEventService.Jobs;
+using DiscordEventService.Services.MemeIndexing;
 using DiscordEventService.Services.Pipeline;
 using DSharpPlus;
 using DSharpPlus.Entities;
 using DSharpPlus.EventArgs;
+using Hangfire;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Options;
 using System.Text.Json;
 using System.Text.Json.Nodes;
 
@@ -101,6 +106,8 @@ public sealed class MessageEventHandler(EventPipeline pipeline) :
                     await ExtractAndSaveMentionsAsync(ctx.Db, messageId, e.Message);
                     await tx.CommitAsync();
                 });
+
+                EnqueueMemeIndexing(ctx, e);
             });
     }
 
@@ -281,6 +288,35 @@ public sealed class MessageEventHandler(EventPipeline pipeline) :
                 ctx.Db.MessageEvents.AddRange(events);
                 await ctx.Db.SaveChangesAsync();
             });
+    }
+
+    // #222 live path: a message with image attachments in a configured meme
+    // channel gets a single-message index job enqueued once its row has
+    // committed. Failures are swallowed (warning only) — indexing must never
+    // break message persistence, and the weekly sweep heals anything missed.
+    private static void EnqueueMemeIndexing(EventContext ctx, MessageCreatedEventArgs e)
+    {
+        try
+        {
+            if (e.Message.Attachments.Count == 0)
+                return;
+
+            var memeOptions = ctx.Services.GetRequiredService<IOptions<MemeIndexOptions>>().Value;
+            if (!memeOptions.ChannelIds.Contains(e.Channel.Id))
+                return;
+            if (!e.Message.Attachments.Any(a => a.FileName is not null && ImageMagic.IsIndexableFileName(a.FileName)))
+                return;
+
+            ctx.Services.GetRequiredService<IBackgroundJobClient>()
+                .Enqueue<MemeIndexingJob>(j => j.IndexMessageAsync(e.Guild.Id, e.Message.Id, CancellationToken.None));
+            ctx.Logger.LogDebug("Live meme indexing enqueued for message {MessageId}", e.Message.Id);
+        }
+        catch (Exception ex)
+        {
+            ctx.Logger.LogWarning(ex,
+                "Failed to enqueue live meme indexing for message {MessageId} — the weekly sweep will heal it",
+                e.Message.Id);
+        }
     }
 
     private static async Task ExtractAndSaveMentionsAsync(DiscordDbContext db, Guid messageId, DiscordMessage message)

--- a/src/DiscordEventService/Services/MemeIndexing/MemeAttachmentIndexer.cs
+++ b/src/DiscordEventService/Services/MemeIndexing/MemeAttachmentIndexer.cs
@@ -1,0 +1,193 @@
+using System.Security.Cryptography;
+using DiscordEventService.Configuration;
+using DiscordEventService.Data;
+using DiscordEventService.Data.Entities.Core;
+using DiscordEventService.Jobs;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Options;
+
+namespace DiscordEventService.Services.MemeIndexing;
+
+public sealed class MemeIndexRunCounters
+{
+    public int Indexed { get; set; }
+    public int Deduped { get; set; }
+    public int Skipped { get; set; }
+    public int Failed { get; set; }
+    public int ModelCalls { get; set; }
+    public long PromptTokens { get; set; }
+    public long CompletionTokens { get; set; }
+    public decimal CostUsd { get; set; }
+}
+
+// The per-attachment indexing pipeline (#221): download → MIME sniff → sha256
+// repost dedupe → vision model → status lifecycle. Extracted from
+// MemeIndexingJob so the live single-message path (#222) and the backfill/sweep
+// runs share one implementation. The DbContext stays a parameter — callers own
+// the unit of work and decide when to flush.
+public sealed class MemeAttachmentIndexer(
+    OpenRouterClient openRouterClient,
+    IHttpClientFactory httpClientFactory,
+    IOptions<MemeIndexOptions> memeIndexOptions,
+    IOptions<OpenRouterOptions> openRouterOptions,
+    ILogger<MemeAttachmentIndexer> logger)
+{
+    public async Task<MemeIndexEntity> GetOrCreateRowAsync(
+        DiscordDbContext db, MemeSampleItem item, CancellationToken cancellationToken)
+    {
+        var row = await db.MemeIndex
+            .FirstOrDefaultAsync(m => m.AttachmentDiscordId == item.AttachmentDiscordId, cancellationToken);
+        if (row is not null)
+            return row;
+
+        row = new MemeIndexEntity
+        {
+            MessageId = item.MessageId,
+            GuildDiscordId = item.GuildDiscordId,
+            ChannelDiscordId = item.ChannelDiscordId,
+            MessageDiscordId = item.MessageDiscordId,
+            AttachmentDiscordId = item.AttachmentDiscordId,
+            FileName = item.FileName,
+            FileSizeBytes = item.FileSizeBytes,
+            Status = MemeIndexStatus.Pending
+        };
+        db.MemeIndex.Add(row);
+        return row;
+    }
+
+    public async Task ProcessOneAsync(
+        DiscordDbContext db,
+        MemeIndexEntity row,
+        MemeSampleItem item,
+        Dictionary<string, string> freshUrls,
+        MemeIndexRunCounters counters,
+        CancellationToken cancellationToken)
+    {
+        var memeOptions = memeIndexOptions.Value;
+        var openRouter = openRouterOptions.Value;
+
+        row.AttemptCount++;
+
+        if (!freshUrls.TryGetValue(AttachmentUrlRefreshService.StripQuery(item.StoredUrl), out var freshUrl))
+        {
+            Skip(row, counters, "dead attachment: refresh-urls declined to re-sign");
+            return;
+        }
+
+        byte[] imageBytes;
+        try
+        {
+            var client = httpClientFactory.CreateClient(MemeBenchmarkJob.DownloadHttpClientName);
+            imageBytes = await client.GetByteArrayAsync(freshUrl, cancellationToken);
+        }
+        catch (HttpRequestException ex) when (ex.StatusCode is System.Net.HttpStatusCode.NotFound
+            or System.Net.HttpStatusCode.Forbidden or System.Net.HttpStatusCode.Gone)
+        {
+            Skip(row, counters, $"dead attachment: download HTTP {(int)ex.StatusCode!}");
+            return;
+        }
+        catch (Exception ex) when (ex is HttpRequestException
+            || (ex is TaskCanceledException && !cancellationToken.IsCancellationRequested))
+        {
+            Fail(row, counters, $"download failed: {ex.Message}");
+            return;
+        }
+
+        row.FileSizeBytes = imageBytes.Length;
+
+        if (imageBytes.Length > memeOptions.MaxImageBytes)
+        {
+            Skip(row, counters, $"unsupported: image too large ({imageBytes.Length} bytes)");
+            return;
+        }
+
+        var mimeType = ImageMagic.SniffMimeType(imageBytes);
+        if (mimeType is null)
+        {
+            Skip(row, counters, "unsupported: bytes are not a recognized image format");
+            return;
+        }
+        row.ContentType = mimeType;
+
+        var contentHash = Convert.ToHexStringLower(SHA256.HashData(imageBytes));
+        row.ContentHash = contentHash;
+
+        // Repost dedupe: same bytes already Indexed → copy its metadata, no
+        // model call. RawResponseJson stays null — provenance lives on the
+        // original row, found via the shared content_hash.
+        var original = await db.MemeIndex.AsNoTracking()
+            .Where(m => m.ContentHash == contentHash && m.Status == MemeIndexStatus.Indexed && m.Id != row.Id)
+            .Select(m => new { m.DescriptionPl, m.DescriptionEn, m.OcrText, m.Tags, m.Source, m.Template, m.ModelId })
+            .FirstOrDefaultAsync(cancellationToken);
+
+        if (original is not null)
+        {
+            row.DescriptionPl = original.DescriptionPl;
+            row.DescriptionEn = original.DescriptionEn;
+            row.OcrText = original.OcrText;
+            row.Tags = original.Tags;
+            row.Source = original.Source;
+            row.Template = original.Template;
+            row.ModelId = original.ModelId;
+            row.RawResponseJson = null;
+            row.IndexedAtUtc = DateTime.UtcNow;
+            row.Status = MemeIndexStatus.Indexed;
+            row.Error = null;
+            counters.Deduped++;
+            logger.LogDebug("Meme attachment {AttachmentId} deduped via content hash {ContentHash}",
+                row.AttachmentDiscordId, contentHash);
+            return;
+        }
+
+        var result = await openRouterClient.AnalyzeImageAsync(imageBytes, mimeType, openRouter.Model, cancellationToken);
+        counters.ModelCalls++;
+        counters.PromptTokens += result.Usage?.PromptTokens ?? 0;
+        counters.CompletionTokens += result.Usage?.CompletionTokens ?? 0;
+        counters.CostUsd += result.Usage?.CostUsd ?? 0;
+
+        switch (result.Outcome)
+        {
+            case MemeAnalysisOutcome.Success:
+                row.DescriptionPl = result.Metadata!.DescriptionPl;
+                row.DescriptionEn = result.Metadata.DescriptionEn;
+                row.OcrText = result.Metadata.OcrText;
+                row.Tags = result.Metadata.Tags;
+                row.Source = result.Metadata.Source;
+                row.Template = result.Metadata.Template;
+                row.ModelId = openRouter.Model;
+                row.RawResponseJson = result.RawContent;
+                row.IndexedAtUtc = DateTime.UtcNow;
+                row.Status = MemeIndexStatus.Indexed;
+                row.Error = null;
+                counters.Indexed++;
+                break;
+
+            case MemeAnalysisOutcome.Refusal:
+                Skip(row, counters, $"model refusal: {result.Error}");
+                break;
+
+            default:
+                Fail(row, counters, result.Error ?? "unknown analysis error");
+                break;
+        }
+
+        await Task.Delay(TimeSpan.FromMilliseconds(openRouter.RequestDelayMs), cancellationToken);
+    }
+
+    private void Skip(MemeIndexEntity row, MemeIndexRunCounters counters, string reason)
+    {
+        row.Status = MemeIndexStatus.Skipped;
+        row.Error = reason;
+        counters.Skipped++;
+        logger.LogInformation("Meme attachment {AttachmentId} skipped: {Reason}", row.AttachmentDiscordId, reason);
+    }
+
+    private void Fail(MemeIndexEntity row, MemeIndexRunCounters counters, string error)
+    {
+        row.Status = MemeIndexStatus.Failed;
+        row.Error = error;
+        counters.Failed++;
+        logger.LogWarning("Meme attachment {AttachmentId} failed (attempt {Attempt}): {Error}",
+            row.AttachmentDiscordId, row.AttemptCount, error);
+    }
+}

--- a/src/DiscordEventService/Services/MemeIndexing/MemeSampleService.cs
+++ b/src/DiscordEventService/Services/MemeIndexing/MemeSampleService.cs
@@ -72,28 +72,43 @@ public sealed class MemeSampleService(
 
     // Also the candidate source for the indexing job (#221) — every image
     // attachment in the configured meme channels, no sampling.
-    public async Task<List<MemeSampleItem>> GetCandidatesAsync(CancellationToken cancellationToken)
+    public Task<List<MemeSampleItem>> GetCandidatesAsync(CancellationToken cancellationToken)
+        => GetCandidatesCoreAsync(messageDiscordId: null, cancellationToken);
+
+    // #222 live path: the candidates of ONE message (empty when the message is
+    // not in a configured meme channel — the job-level guard behind the
+    // handler's channel filter).
+    public Task<List<MemeSampleItem>> GetCandidatesForMessageAsync(
+        ulong messageDiscordId, CancellationToken cancellationToken)
+        => GetCandidatesCoreAsync(messageDiscordId, cancellationToken);
+
+    private async Task<List<MemeSampleItem>> GetCandidatesCoreAsync(
+        ulong? messageDiscordId, CancellationToken cancellationToken)
     {
         var channelIds = options.Value.ChannelIds;
 
-        var rows = await (
-                from m in db.Messages.AsNoTracking()
-                join c in db.Channels.AsNoTracking() on m.ChannelId equals c.Id
-                join g in db.Guilds.AsNoTracking() on m.GuildId equals g.Id
-                where channelIds.Contains(c.DiscordId)
-                      && m.HasAttachments
-                      && !m.IsDeleted
-                      && m.AttachmentsJson != null
-                select new
-                {
-                    m.Id,
-                    m.DiscordId,
-                    m.AttachmentsJson,
-                    m.CreatedAtUtc,
-                    ChannelDiscordId = c.DiscordId,
-                    GuildDiscordId = g.DiscordId
-                })
-            .ToListAsync(cancellationToken);
+        var query =
+            from m in db.Messages.AsNoTracking()
+            join c in db.Channels.AsNoTracking() on m.ChannelId equals c.Id
+            join g in db.Guilds.AsNoTracking() on m.GuildId equals g.Id
+            where channelIds.Contains(c.DiscordId)
+                  && m.HasAttachments
+                  && !m.IsDeleted
+                  && m.AttachmentsJson != null
+            select new
+            {
+                m.Id,
+                m.DiscordId,
+                m.AttachmentsJson,
+                m.CreatedAtUtc,
+                ChannelDiscordId = c.DiscordId,
+                GuildDiscordId = g.DiscordId
+            };
+
+        if (messageDiscordId is { } id)
+            query = query.Where(r => r.DiscordId == id);
+
+        var rows = await query.ToListAsync(cancellationToken);
 
         var candidates = new List<MemeSampleItem>();
         foreach (var row in rows)

--- a/tests/DiscordEventService.Tests/MemeIndexLiveAndSweepTests.cs
+++ b/tests/DiscordEventService.Tests/MemeIndexLiveAndSweepTests.cs
@@ -1,0 +1,332 @@
+using DiscordEventService.Configuration;
+using DiscordEventService.Data;
+using DiscordEventService.Data.Entities.Core;
+using DiscordEventService.Jobs;
+using DiscordEventService.Services.MemeIndexing;
+using Hangfire;
+using Hangfire.Common;
+using Hangfire.States;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace DiscordEventService.Tests;
+
+// #222 acceptance contracts: the live single-message path (IndexMessageAsync),
+// the weekly healing sweep (ExecuteSweepAsync + MemeIndexSweepJob coordinator),
+// end-to-end against real Postgres with the same handler-level HTTP fakes as
+// MemeIndexingJobTests.
+public sealed class MemeIndexLiveAndSweepTests(PostgresFixture fixture) : IClassFixture<PostgresFixture>, IAsyncLifetime
+{
+    private const ulong GuildDiscordId = 1UL;
+    private const ulong ChannelDiscordId = 2UL;
+    private const ulong OtherChannelDiscordId = 99UL;
+
+    private DiscordDbContext _db = null!;
+    private GuildEntity _guild = null!;
+    private ChannelEntity _channel = null!;
+    private ChannelEntity _otherChannel = null!;
+    private UserEntity _author = null!;
+    private FakeMemeHttpHandler _http = null!;
+
+    public async Task InitializeAsync()
+    {
+        _db = NewContext();
+        await _db.Database.MigrateAsync();
+
+        await _db.MemeIndex.ExecuteDeleteAsync();
+        await _db.BackfillCheckpoints.ExecuteDeleteAsync();
+        await _db.Messages.ExecuteDeleteAsync();
+        await _db.Channels.ExecuteDeleteAsync();
+        await _db.Users.ExecuteDeleteAsync();
+        await _db.Guilds.ExecuteDeleteAsync();
+
+        _guild = new GuildEntity { DiscordId = GuildDiscordId, Name = "g" };
+        _db.Guilds.Add(_guild);
+        await _db.SaveChangesAsync();
+
+        _channel = new ChannelEntity { DiscordId = ChannelDiscordId, GuildId = _guild.Id, Name = "memes", Type = ChannelType.Text };
+        _otherChannel = new ChannelEntity { DiscordId = OtherChannelDiscordId, GuildId = _guild.Id, Name = "general", Type = ChannelType.Text };
+        _author = new UserEntity { DiscordId = 3UL, Username = "u" };
+        _db.Channels.AddRange(_channel, _otherChannel);
+        _db.Users.Add(_author);
+        await _db.SaveChangesAsync();
+
+        _http = new FakeMemeHttpHandler();
+    }
+
+    public Task DisposeAsync() => _db.DisposeAsync().AsTask();
+
+    [Fact]
+    public async Task IndexMessageAsync_IndexesOnlyThatMessage_AndCreatesNoCheckpoint()
+    {
+        AddMessage(1001UL, _channel, Attachment(11UL, "fresh.png"), Attachment(12UL, "also-fresh.png"));
+        AddMessage(1002UL, _channel, Attachment(13UL, "someone-elses.png"));
+        await _db.SaveChangesAsync();
+        _http.SetImage(11UL, Png(1));
+        _http.SetImage(12UL, Png(2));
+        _http.SetImage(13UL, Png(3));
+
+        await RunLiveAsync(1001UL);
+
+        await using var verify = NewContext();
+        var rows = await verify.MemeIndex.OrderBy(m => m.AttachmentDiscordId).ToListAsync();
+        Assert.Equal([11UL, 12UL], rows.Select(r => r.AttachmentDiscordId));
+        Assert.All(rows, r => Assert.Equal(MemeIndexStatus.Indexed, r.Status));
+        Assert.Equal(2, _http.ModelCalls);
+
+        // Live runs never touch the backfill/sweep checkpoint machinery.
+        Assert.Equal(0, await verify.BackfillCheckpoints.CountAsync());
+    }
+
+    [Fact]
+    public async Task IndexMessageAsync_Rerun_MakesNoExtraModelCalls()
+    {
+        AddMessage(1001UL, _channel, Attachment(11UL, "a.png"));
+        await _db.SaveChangesAsync();
+        _http.SetImage(11UL, Png(1));
+
+        await RunLiveAsync(1001UL);
+        Assert.Equal(1, _http.ModelCalls);
+
+        // A Hangfire retry of the same job must be a no-op on terminal rows.
+        await RunLiveAsync(1001UL);
+
+        Assert.Equal(1, _http.ModelCalls);
+        await using var verify = NewContext();
+        Assert.Equal(1, await verify.MemeIndex.CountAsync());
+    }
+
+    [Fact]
+    public async Task IndexMessageAsync_MessageOutsideMemeChannels_IsIgnored()
+    {
+        AddMessage(1001UL, _otherChannel, Attachment(11UL, "not-a-meme.png"));
+        await _db.SaveChangesAsync();
+        _http.SetImage(11UL, Png(1));
+
+        await RunLiveAsync(1001UL);
+
+        Assert.Equal(0, _http.ModelCalls);
+        await using var verify = NewContext();
+        Assert.Equal(0, await verify.MemeIndex.CountAsync());
+    }
+
+    [Fact]
+    public async Task ExecuteSweepAsync_IndexesAttachmentsMissedDuringDowntime()
+    {
+        // Messages landed in the DB (e.g. via backfill after downtime) but the
+        // live path never fired — no meme_index rows exist.
+        AddMessage(1001UL, _channel, Attachment(11UL, "missed-1.png"));
+        AddMessage(1002UL, _channel, Attachment(12UL, "missed-2.png"));
+        await _db.SaveChangesAsync();
+        _http.SetImage(11UL, Png(1));
+        _http.SetImage(12UL, Png(2));
+
+        await RunSweepAsync();
+
+        await using var verify = NewContext();
+        var rows = await verify.MemeIndex.OrderBy(m => m.AttachmentDiscordId).ToListAsync();
+        Assert.Equal([11UL, 12UL], rows.Select(r => r.AttachmentDiscordId));
+        Assert.All(rows, r => Assert.Equal(MemeIndexStatus.Indexed, r.Status));
+
+        var checkpoint = await verify.BackfillCheckpoints.SingleAsync(c => c.Type == BackfillType.MemeIndex);
+        Assert.Equal(BackfillStatus.Completed, checkpoint.Status);
+    }
+
+    [Fact]
+    public async Task ExecuteSweepAsync_RetriesFailedUnderCap_LeavesCappedFailedAndSkippedUntouched()
+    {
+        AddMessage(1001UL, _channel, Attachment(11UL, "retry-me.png"));
+        AddMessage(1002UL, _channel, Attachment(12UL, "given-up.png"));
+        AddMessage(1003UL, _channel, Attachment(13UL, "refused-before.png"));
+        await _db.SaveChangesAsync();
+        SeedRow(1001UL, 11UL, "retry-me.png", MemeIndexStatus.Failed, attemptCount: 1);
+        SeedRow(1002UL, 12UL, "given-up.png", MemeIndexStatus.Failed, attemptCount: MemeIndexingJob.SweepMaxFailedAttempts);
+        SeedRow(1003UL, 13UL, "refused-before.png", MemeIndexStatus.Skipped, attemptCount: 1);
+        await _db.SaveChangesAsync();
+        _http.SetImage(11UL, Png(1));
+
+        await RunSweepAsync();
+
+        Assert.Equal(1, _http.ModelCalls);
+        await using var verify = NewContext();
+        var byId = await verify.MemeIndex.ToDictionaryAsync(m => m.AttachmentDiscordId);
+        Assert.Equal(MemeIndexStatus.Indexed, byId[11UL].Status);
+        Assert.Equal(2, byId[11UL].AttemptCount);
+        Assert.Equal(MemeIndexStatus.Failed, byId[12UL].Status);
+        Assert.Equal(MemeIndexingJob.SweepMaxFailedAttempts, byId[12UL].AttemptCount);
+        Assert.Equal(MemeIndexStatus.Skipped, byId[13UL].Status);
+        Assert.Equal(1, byId[13UL].AttemptCount);
+    }
+
+    [Fact]
+    public async Task ExecuteSweepAsync_CleanRun_MakesNoModelOrCdnCalls()
+    {
+        AddMessage(1001UL, _channel, Attachment(11UL, "a.png"));
+        await _db.SaveChangesAsync();
+        _http.SetImage(11UL, Png(1));
+
+        await RunSweepAsync();
+        Assert.Equal(1, _http.ModelCalls);
+
+        await RunSweepAsync();
+
+        Assert.Equal(1, _http.ModelCalls);
+        await using var verify = NewContext();
+        var row = await verify.MemeIndex.SingleAsync();
+        Assert.Equal(1, row.AttemptCount);
+    }
+
+    [Fact]
+    public async Task SweepCoordinator_EnqueuesOnePerGuildJob()
+    {
+        var jobClient = new RecordingJobClient();
+
+        await RunCoordinatorAsync(jobClient, configured: true);
+
+        var job = Assert.Single(jobClient.Created);
+        Assert.Equal(nameof(MemeIndexingJob.ExecuteSweepAsync), job.Method.Name);
+        Assert.Equal(GuildDiscordId, job.Args[0]);
+    }
+
+    [Fact]
+    public async Task SweepCoordinator_SkipsGuildWithIndexingInProgress()
+    {
+        _db.BackfillCheckpoints.Add(new BackfillCheckpointEntity
+        {
+            GuildDiscordId = GuildDiscordId,
+            Type = BackfillType.MemeIndex,
+            Status = BackfillStatus.InProgress,
+            StartedAtUtc = DateTime.UtcNow
+        });
+        await _db.SaveChangesAsync();
+        var jobClient = new RecordingJobClient();
+
+        await RunCoordinatorAsync(jobClient, configured: true);
+
+        Assert.Empty(jobClient.Created);
+    }
+
+    [Fact]
+    public async Task SweepCoordinator_Unconfigured_IsANoOp()
+    {
+        var jobClient = new RecordingJobClient();
+
+        await RunCoordinatorAsync(jobClient, configured: false);
+
+        Assert.Empty(jobClient.Created);
+    }
+
+    private async Task RunLiveAsync(ulong messageDiscordId)
+    {
+        await using var provider = BuildProvider();
+        using var scope = provider.CreateScope();
+        await scope.ServiceProvider.GetRequiredService<MemeIndexingJob>()
+            .IndexMessageAsync(GuildDiscordId, messageDiscordId, CancellationToken.None);
+    }
+
+    private async Task RunSweepAsync()
+    {
+        await using var provider = BuildProvider();
+        using var scope = provider.CreateScope();
+        await scope.ServiceProvider.GetRequiredService<MemeIndexingJob>()
+            .ExecuteSweepAsync(GuildDiscordId, CancellationToken.None);
+    }
+
+    private async Task RunCoordinatorAsync(RecordingJobClient jobClient, bool configured)
+    {
+        await using var provider = BuildProvider(configured ? [ChannelDiscordId] : [], jobClient);
+        using var scope = provider.CreateScope();
+        await scope.ServiceProvider.GetRequiredService<MemeIndexSweepJob>().ExecuteAsync();
+    }
+
+    private ServiceProvider BuildProvider(ulong[]? channelIds = null, IBackgroundJobClient? jobClient = null)
+    {
+        var services = new ServiceCollection();
+        services.AddLogging();
+        services.AddDbContext<DiscordDbContext>(o => o
+            .UseNpgsql(fixture.Container.GetConnectionString())
+            .UseSnakeCaseNamingConvention());
+        services.Configure<MemeIndexOptions>(o => o.ChannelIds = channelIds ?? [ChannelDiscordId]);
+        services.Configure<OpenRouterOptions>(o =>
+        {
+            o.ApiKey = "test-key";
+            o.Model = "test/model";
+            o.RequestDelayMs = 0;
+        });
+        services.Configure<DiscordOptions>(o => o.Token = new string('x', 60));
+        services.AddSingleton<IHttpClientFactory>(new FakeHttpClientFactory(_http));
+        services.AddSingleton(jobClient ?? new RecordingJobClient());
+        services.AddScoped<MemeSampleService>();
+        services.AddScoped<AttachmentUrlRefreshService>();
+        services.AddScoped<OpenRouterClient>();
+        services.AddScoped<MemeAttachmentIndexer>();
+        services.AddScoped<BackfillJobExecutor>();
+        services.AddScoped<MemeIndexingJob>();
+        services.AddScoped<MemeIndexSweepJob>();
+        return services.BuildServiceProvider();
+    }
+
+    private void AddMessage(ulong discordId, ChannelEntity channel, params string[] attachments)
+    {
+        _db.Messages.Add(new MessageEntity
+        {
+            DiscordId = discordId,
+            ChannelId = channel.Id,
+            GuildId = _guild.Id,
+            AuthorId = _author.Id,
+            HasAttachments = true,
+            AttachmentsJson = $"[{string.Join(",", attachments)}]",
+            CreatedAtUtc = DateTime.UtcNow
+        });
+    }
+
+    private void SeedRow(ulong messageDiscordId, ulong attachmentId, string fileName, MemeIndexStatus status, int attemptCount)
+    {
+        _db.MemeIndex.Add(new MemeIndexEntity
+        {
+            MessageId = _db.Messages.Local.Single(m => m.DiscordId == messageDiscordId).Id,
+            GuildDiscordId = GuildDiscordId,
+            ChannelDiscordId = ChannelDiscordId,
+            MessageDiscordId = messageDiscordId,
+            AttachmentDiscordId = attachmentId,
+            FileName = fileName,
+            FileSizeBytes = 123,
+            Status = status,
+            Error = "seeded by test",
+            AttemptCount = attemptCount
+        });
+    }
+
+    // The 4-field PascalCase shape MessageEventHandler/MessagesBackfillJob serialize.
+    private static string Attachment(ulong id, string fileName) =>
+        $"{{\"Id\":{id},\"Url\":\"https://cdn.test/attachments/{ChannelDiscordId}/{id}/{fileName}?ex=expired\",\"FileName\":\"{fileName}\",\"FileSize\":123}}";
+
+    // Distinct valid-PNG-magic payloads (≥12 bytes for the sniffer).
+    private static byte[] Png(byte seed) =>
+        [0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A, 0, 0, 0, 13, seed, seed, seed];
+
+    private DiscordDbContext NewContext()
+    {
+        var options = new DbContextOptionsBuilder<DiscordDbContext>()
+            .UseNpgsql(fixture.Container.GetConnectionString())
+            .UseSnakeCaseNamingConvention()
+            .Options;
+        return new DiscordDbContext(options);
+    }
+}
+
+// Captures Hangfire enqueues without a storage backend; the coordinator's
+// contract is "which jobs got created", not their execution.
+internal sealed class RecordingJobClient : IBackgroundJobClient
+{
+    public List<Job> Created { get; } = [];
+
+    public string Create(Job job, IState state)
+    {
+        Created.Add(job);
+        return Created.Count.ToString();
+    }
+
+    public bool ChangeState(string jobId, IState state, string expectedState) => true;
+}

--- a/tests/DiscordEventService.Tests/MemeIndexingJobTests.cs
+++ b/tests/DiscordEventService.Tests/MemeIndexingJobTests.cs
@@ -270,6 +270,7 @@ public sealed class MemeIndexingJobTests(PostgresFixture fixture) : IClassFixtur
         services.AddScoped<MemeSampleService>();
         services.AddScoped<AttachmentUrlRefreshService>();
         services.AddScoped<OpenRouterClient>();
+        services.AddScoped<MemeAttachmentIndexer>();
         services.AddScoped<BackfillJobExecutor>();
         services.AddScoped<MemeIndexingJob>();
 


### PR DESCRIPTION
Closes #222.

## What

Keeps the meme index current without manual triggers — the third slice of epic #218:

- **Live path**: `MessageEventHandler` enqueues a single-message index job (`MemeIndexingJob.IndexMessageAsync`) after the MessageCreated transaction commits, filtered to configured meme channels + indexable image filenames. Enqueue failures are swallowed with a warning — message persistence is never affected, and the sweep heals anything missed. No checkpoint involvement: checkpoints are unique per (guild, type) and stay owned by backfill/sweep runs; live jobs are idempotent (terminal rows skipped), so Hangfire retries are safe.
- **Healing sweep**: `MemeIndexSweepJob` (weekly recurring, Sundays 05:00 UTC — after the 03:00 full backfill so recovered messages are already in the DB) enqueues `ExecuteSweepAsync` per guild owning a configured meme channel, skipping guilds with indexing already in progress and short-circuiting cleanly on unconfigured deploys (no weekly Failed checkpoints on prod before #223). The sweep retries Failed rows only under `SweepMaxFailedAttempts = 3`; Skipped rows are never retried; operator-triggered backfill (`ExecuteAsync`) deliberately stays uncapped (PR #228 decision).
- **Refactor**: the per-attachment pipeline (download → MIME sniff → sha256 dedupe → model call → status lifecycle) moved verbatim from `MemeIndexingJob` into `MemeAttachmentIndexer`, shared by all three entry points. `MemeSampleService.GetCandidatesForMessageAsync` is the single-message candidate query. `MemeIndexOptions` is now also bound in the DSharpPlus child container (the handler hook reads it; root bindings aren't visible there).

## Tests

9 new Testcontainers tests in `MemeIndexLiveAndSweepTests` (same handler-level HTTP-fake harness as `MemeIndexingJobTests`): live path indexes only its message + creates no checkpoint, rerun makes no extra model calls, non-meme channel ignored, sweep heals downtime gaps, attempt-cap semantics (Failed<3 retried, Failed=3 and Skipped untouched), clean run is a no-op, coordinator enqueues per guild / skips in-progress / no-ops unconfigured. Full suite 141/141.

## Live-verified on dev bot

- Image posted via webhook in configured `#devtuś` → Indexed in seconds (1 model call, $0.0031), correct metadata in `meme_index`
- Image in non-configured channel → message persisted, no index row, live path silent
- Bot killed → image posted during downtime → reboot → gap-backfill ingested the message → `meme-index-sweep` triggered via Hangfire dashboard → row healed (1 attachment, $0.0026)
- Second sweep trigger → "nothing to do, all candidates terminal" (cheap no-op)

🤖 Generated with [Claude Code](https://claude.com/claude-code)