### PR TITLE
feat: /meme slash command with ranked hybrid search (#224)

### DIFF
--- a/src/DiscordEventService/Commands/MemeCommand.cs
+++ b/src/DiscordEventService/Commands/MemeCommand.cs
@@ -1,0 +1,149 @@
+using System.ComponentModel;
+using DiscordEventService.Services.MemeIndexing;
+using DSharpPlus;
+using DSharpPlus.Commands;
+using DSharpPlus.Commands.Processors.SlashCommands;
+using DSharpPlus.Entities;
+using DSharpPlus.Exceptions;
+
+namespace DiscordEventService.Commands;
+
+// #224: the bot's first user-facing command. /meme searches the Indexed meme
+// metadata (MemeSearchService) and responds publicly: top hit as an embed with
+// the image re-fetched for a fresh signed CDN URL (stored URLs expire,
+// ADR-0004), runners-up as compact jump links. Every failure path answers the
+// interaction — a swallowed exception here would leave a dangling "thinking…"
+// state, but can never touch the gateway event pipeline.
+public sealed class MemeCommand(MemeSearchService searchService, ILogger<MemeCommand> logger)
+{
+    private const int RunnerUpCount = 4;
+
+    [Command("meme")]
+    [Description("Szuka mema po opisie, tekście z obrazka, tagach lub szablonie")]
+    public async ValueTask ExecuteAsync(
+        SlashCommandContext ctx,
+        [Description("Co znaleźć — np. \"kot lodówka\" albo tekst z mema")] string query)
+    {
+        // Defer immediately: the search plus the fresh-URL message fetch can
+        // exceed Discord's 3s interaction window.
+        await ctx.DeferResponseAsync();
+
+        try
+        {
+            await RespondWithSearchAsync(ctx, query);
+        }
+        catch (Exception ex)
+        {
+            logger.LogError(ex, "/meme failed for query {Query} in guild {GuildId}", query, ctx.Guild?.Id);
+            await ctx.EditResponseAsync("Coś poszło nie tak przy szukaniu — spróbuj jeszcze raz.");
+        }
+    }
+
+    private async Task RespondWithSearchAsync(SlashCommandContext ctx, string query)
+    {
+        if (ctx.Guild is null)
+        {
+            await ctx.EditResponseAsync("Ta komenda działa tylko na serwerze.");
+            return;
+        }
+
+        var hits = await searchService.SearchAsync(
+            ctx.Guild.Id, query, MemeSearchService.DefaultLimit, CancellationToken.None);
+
+        logger.LogInformation(
+            "/meme by {UserId} in guild {GuildId}: query {Query}, {HitCount} hits",
+            ctx.User.Id, ctx.Guild.Id, query, hits.Count);
+
+        // The raw query never goes into plain message content — pinging
+        // mentions could be smuggled in it (embeds are immune, content isn't).
+        if (hits.Count == 0)
+        {
+            await ctx.EditResponseAsync("Nic nie znalazłem dla tego zapytania.");
+            return;
+        }
+
+        // Top-1 needs a live message for the fresh image URL; an index row can
+        // outlive its message (just deleted, attachment edited away) — fall
+        // back to the next hit instead of rendering a dead embed.
+        MemeSearchHit? top = null;
+        string? freshUrl = null;
+        var runnersUp = new List<MemeSearchHit>();
+        foreach (var hit in hits)
+        {
+            if (top is not null)
+            {
+                runnersUp.Add(hit);
+                continue;
+            }
+
+            freshUrl = await TryGetFreshUrlAsync(ctx.Client, hit);
+            if (freshUrl is null)
+            {
+                logger.LogWarning(
+                    "/meme top hit {AttachmentId} in guild {GuildId} has no live message/attachment, falling back",
+                    hit.AttachmentDiscordId, ctx.Guild.Id);
+                continue;
+            }
+            top = hit;
+        }
+
+        if (top is null)
+        {
+            await ctx.EditResponseAsync("Znalazłem trafienia, ale ich wiadomości już nie istnieją.");
+            return;
+        }
+
+        var embed = new DiscordEmbedBuilder()
+            .WithDescription($"{Snippet(top, 300)}\n[Skocz do wiadomości]({JumpLink(ctx.Guild.Id, top)})")
+            .WithImageUrl(freshUrl!)
+            .WithFooter(top.FileName)
+            .WithTimestamp(top.MessageCreatedAtUtc)
+            .WithColor(new DiscordColor(0x5865F2));
+
+        if (runnersUp.Count > 0)
+        {
+            var lines = runnersUp
+                .Take(RunnerUpCount)
+                .Select(h => $"[{Snippet(h, 80)}]({JumpLink(ctx.Guild.Id, h)})");
+            embed.AddField("Inne trafienia", string.Join("\n", lines));
+        }
+
+        await ctx.EditResponseAsync(new DiscordMessageBuilder().AddEmbed(embed));
+    }
+
+    // Fresh signed CDN URL via a live message fetch; null when the message,
+    // channel, or the specific attachment is gone (or the bot lost access).
+    private static async Task<string?> TryGetFreshUrlAsync(DiscordClient client, MemeSearchHit hit)
+    {
+        try
+        {
+            var channel = await client.GetChannelAsync(hit.ChannelDiscordId);
+            var message = await channel.GetMessageAsync(hit.MessageDiscordId);
+            return message.Attachments.FirstOrDefault(a => a.Id == hit.AttachmentDiscordId)?.Url;
+        }
+        catch (NotFoundException)
+        {
+            return null;
+        }
+        catch (UnauthorizedException)
+        {
+            return null;
+        }
+    }
+
+    private static string JumpLink(ulong guildId, MemeSearchHit hit) =>
+        $"https://discord.com/channels/{guildId}/{hit.ChannelDiscordId}/{hit.MessageDiscordId}";
+
+    // The "why it matched" line: Polish description first (the corpus is a
+    // Polish guild), English fallback, file name as a last resort. Square
+    // brackets would break the surrounding markdown link labels.
+    private static string Snippet(MemeSearchHit hit, int maxLength)
+    {
+        var text = hit.DescriptionPl ?? hit.DescriptionEn ?? hit.FileName;
+        text = text.Replace('[', '(').Replace(']', ')');
+        return Truncate(text, maxLength);
+    }
+
+    private static string Truncate(string text, int maxLength) =>
+        text.Length <= maxLength ? text : text[..(maxLength - 1)] + "…";
+}

--- a/src/DiscordEventService/Configuration/DiscordOptions.cs
+++ b/src/DiscordEventService/Configuration/DiscordOptions.cs
@@ -9,4 +9,9 @@ public class DiscordOptions
     [Required]
     [MinLength(50, ErrorMessage = "Discord token appears invalid (too short)")]
     public string Token { get; set; } = string.Empty;
+
+    // #224: guild to register slash commands on (guild-scoped registration is
+    // instant; global takes up to an hour to propagate). Unset → the commands
+    // subsystem is not wired at all and the bot stays a pure passive logger.
+    public ulong? CommandGuildId { get; set; }
 }

--- a/src/DiscordEventService/DiscordEventService.csproj
+++ b/src/DiscordEventService/DiscordEventService.csproj
@@ -13,6 +13,7 @@
   <ItemGroup>
     <PackageReference Include="DotNetEnv" Version="3.1.1" />
     <PackageReference Include="DSharpPlus" Version="5.0.0-nightly-02485" />
+    <PackageReference Include="DSharpPlus.Commands" Version="5.0.0-nightly-02485" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="10.0.0" />
     <PackageReference Include="EFCore.NamingConventions" Version="10.0.1" />

--- a/src/DiscordEventService/Program.cs
+++ b/src/DiscordEventService/Program.cs
@@ -1,3 +1,4 @@
+using DiscordEventService.Commands;
 using DiscordEventService.Configuration;
 using DiscordEventService.Data;
 using DiscordEventService.Endpoints;
@@ -9,6 +10,8 @@ using DiscordEventService.Services.MemeIndexing;
 using DiscordEventService.Services.Pipeline;
 using DotNetEnv;
 using DSharpPlus;
+using DSharpPlus.Commands;
+using DSharpPlus.Commands.Processors.SlashCommands;
 using Hangfire;
 using Hangfire.PostgreSql;
 using Microsoft.EntityFrameworkCore;
@@ -78,6 +81,7 @@ builder.Services.AddDbContext<DiscordDbContext>(options =>
 // Discord Client with services configured for DI
 var discordToken = builder.Configuration.GetSection(DiscordOptions.SectionName).Get<DiscordOptions>()?.Token
     ?? throw new InvalidOperationException("Discord:Token is required");
+var commandGuildId = builder.Configuration.GetSection(DiscordOptions.SectionName).Get<DiscordOptions>()?.CommandGuildId;
 
 builder.Services.AddSingleton(rootSp =>
 {
@@ -157,6 +161,19 @@ builder.Services.AddSingleton(rootSp =>
         // Socket lifecycle (downtime tracking)
         .AddEventHandlers<SocketLifecycleHandler>(ServiceLifetime.Scoped)
     );
+
+    // #224: the bot's first user-facing command. Slash-only (no text-prefix
+    // processor — the bot must keep ignoring message content), guild-scoped
+    // registration so it shows up instantly. Without Discord:CommandGuildId
+    // the commands subsystem isn't wired at all (pure passive logger).
+    if (commandGuildId is { } commandGuild)
+    {
+        clientBuilder.UseCommands((_, extension) =>
+        {
+            extension.AddProcessor(new SlashCommandProcessor());
+            extension.AddCommands([typeof(MemeCommand)], commandGuild);
+        }, new CommandsConfiguration { RegisterDefaultCommandProcessors = false });
+    }
 
     return clientBuilder.Build();
 });

--- a/src/DiscordEventService/Services/CoreServiceRegistration.cs
+++ b/src/DiscordEventService/Services/CoreServiceRegistration.cs
@@ -1,4 +1,5 @@
 using DiscordEventService.Jobs;
+using DiscordEventService.Services.MemeIndexing;
 using DiscordEventService.Services.Pipeline;
 
 namespace DiscordEventService.Services;
@@ -22,6 +23,7 @@ public static class CoreServiceRegistration
         typeof(DowntimeTrackerService),
         typeof(GuildBackfillOrchestrator),
         typeof(BootQuickSyncService),
+        typeof(MemeSearchService),
     ];
 
     public static IServiceCollection AddCoreServices(this IServiceCollection services)

--- a/src/DiscordEventService/Services/MemeIndexing/MemeSearchService.cs
+++ b/src/DiscordEventService/Services/MemeIndexing/MemeSearchService.cs
@@ -1,0 +1,113 @@
+using DiscordEventService.Data;
+using DiscordEventService.Data.Entities.Core;
+using Microsoft.EntityFrameworkCore;
+
+namespace DiscordEventService.Services.MemeIndexing;
+
+// One ranked /meme hit. Snowflakes for the jump link + fresh-URL re-fetch,
+// descriptions for the "why it matched" snippet.
+public sealed record MemeSearchHit(
+    ulong ChannelDiscordId,
+    ulong MessageDiscordId,
+    ulong AttachmentDiscordId,
+    string FileName,
+    string? DescriptionPl,
+    string? DescriptionEn,
+    DateTime MessageCreatedAtUtc,
+    double Score);
+
+// #224 ranked hybrid search over Indexed memes (binding design on #224, column
+// semantics pinned by MemeIndexSchemaTests): an OR'd to_tsquery gate — NOT
+// websearch AND-semantics, the 'simple' config keeps stopwords so AND would
+// zero out natural-language queries — plus a word_similarity trigram rescue
+// for Polish inflections and typos (no Polish stemmer exists). Relevance comes
+// from the rank blend, not the gate; recency breaks ties.
+public sealed class MemeSearchService(DiscordDbContext db)
+{
+    public const int DefaultLimit = 5;
+
+    // k in the binding rank blend: ts_rank with the A/B/C setweight scheme
+    // lands roughly in 0.1–0.9, word_similarity in 0–1; 0.5 lets a strong
+    // trigram match compete with an OCR hit without drowning out tag hits.
+    // Tuned against the seeded rows in MemeSearchServiceTests.
+    private const double TrigramWeight = 0.5;
+
+    // Pinned by MemeIndexSchemaTests: the threshold at which Polish
+    // inflections (postgres ~ postgresie) still match without false positives.
+    private const double TrigramThreshold = 0.4;
+
+    public async Task<List<MemeSearchHit>> SearchAsync(
+        ulong guildId, string query, int limit, CancellationToken cancellationToken)
+    {
+        var tokens = Tokenize(query);
+        if (tokens.Count == 0)
+            return [];
+
+        // Tokens are alphanumeric-only, so joining with the OR operator cannot
+        // inject other tsquery syntax (&, !, parentheses, prefix stars).
+        var orQuery = string.Join(" | ", tokens);
+        var guild = (long)guildId;
+        var indexed = (int)MemeIndexStatus.Indexed;
+
+        // Column names are snake_case: the EFCore.NamingConventions plugin
+        // applies to SqlQuery DTOs too, so MemeSearchRow.Score binds to
+        // "score", MessageCreatedAtUtc to "message_created_at_utc", etc.
+        var rows = await db.Database.SqlQuery<MemeSearchRow>($"""
+            SELECT m.channel_discord_id,
+                   m.message_discord_id,
+                   m.attachment_discord_id,
+                   m.file_name,
+                   m.description_pl,
+                   m.description_en,
+                   msg.created_at_utc AS message_created_at_utc,
+                   (ts_rank(m.search_vector, to_tsquery('simple', public.f_unaccent({orQuery})))
+                    + {TrigramWeight} * word_similarity(public.f_unaccent({query}), m.search_text))::float8 AS score
+            FROM meme_index AS m
+            JOIN messages AS msg ON msg.id = m.message_id
+            WHERE m.guild_discord_id = {guild}
+              AND m.status = {indexed}
+              AND NOT msg.is_deleted
+              AND (m.search_vector @@ to_tsquery('simple', public.f_unaccent({orQuery}))
+                   OR word_similarity(public.f_unaccent({query}), m.search_text) >= {TrigramThreshold})
+            ORDER BY score DESC, msg.created_at_utc DESC
+            LIMIT {limit}
+            """).ToListAsync(cancellationToken);
+
+        return rows
+            .Select(r => new MemeSearchHit(
+                (ulong)r.ChannelDiscordId,
+                (ulong)r.MessageDiscordId,
+                (ulong)r.AttachmentDiscordId,
+                r.FileName,
+                r.DescriptionPl,
+                r.DescriptionEn,
+                r.MessageCreatedAtUtc,
+                r.Score))
+            .ToList();
+    }
+
+    // Word characters only (letters incl. Polish, digits); everything else is
+    // a separator. Lowercasing is cosmetic — tsquery and pg_trgm both fold
+    // case — but keeps logs and tests deterministic.
+    private static List<string> Tokenize(string query) =>
+        query
+            .ToLowerInvariant()
+            .Split([' ', '\t', '\n', '\r'], StringSplitOptions.RemoveEmptyEntries)
+            .Select(w => new string(w.Where(char.IsLetterOrDigit).ToArray()))
+            .Where(w => w.Length > 0)
+            .Distinct()
+            .ToList();
+
+    // SqlQuery maps result-set columns to properties by name; snowflakes come
+    // back as bigint (the EF ulong columns are stored as int8), hence long here
+    // with the unsigned cast applied in SearchAsync.
+    private sealed record MemeSearchRow(
+        long ChannelDiscordId,
+        long MessageDiscordId,
+        long AttachmentDiscordId,
+        string FileName,
+        string? DescriptionPl,
+        string? DescriptionEn,
+        DateTime MessageCreatedAtUtc,
+        double Score);
+}

--- a/src/DiscordEventService/appsettings.json
+++ b/src/DiscordEventService/appsettings.json
@@ -17,7 +17,8 @@
     "AutoMigrate": true
   },
   "Discord": {
-    "Token": ""
+    "Token": "",
+    "CommandGuildId": null
   },
   "EventSettings": {
     "EnablePresenceEvents": true,

--- a/tests/DiscordEventService.Tests/MemeSearchServiceTests.cs
+++ b/tests/DiscordEventService.Tests/MemeSearchServiceTests.cs
@@ -1,0 +1,272 @@
+using DiscordEventService.Data;
+using DiscordEventService.Data.Entities.Core;
+using DiscordEventService.Services.MemeIndexing;
+using Microsoft.EntityFrameworkCore;
+using Xunit;
+
+namespace DiscordEventService.Tests;
+
+// #224 acceptance contracts for the /meme search query (binding design on
+// #224, column semantics pinned by MemeIndexSchemaTests): hybrid FTS + trigram
+// gate, weighted rank blend, soft-delete exclusion, recency tiebreak. The
+// slash-command surface itself can't be integration-tested (bots can't invoke
+// other bots' commands) — that part is user-verified live on the dev guild.
+public sealed class MemeSearchServiceTests(PostgresFixture fixture) : IClassFixture<PostgresFixture>, IAsyncLifetime
+{
+    private const ulong GuildDiscordId = 1UL;
+    private const ulong ChannelDiscordId = 2UL;
+
+    private DiscordDbContext _db = null!;
+    private GuildEntity _guild = null!;
+    private ChannelEntity _channel = null!;
+    private UserEntity _author = null!;
+
+    public async Task InitializeAsync()
+    {
+        _db = NewContext();
+        await _db.Database.MigrateAsync();
+
+        await _db.MemeIndex.ExecuteDeleteAsync();
+        await _db.Messages.ExecuteDeleteAsync();
+        await _db.Channels.ExecuteDeleteAsync();
+        await _db.Users.ExecuteDeleteAsync();
+        await _db.Guilds.ExecuteDeleteAsync();
+
+        _guild = new GuildEntity { DiscordId = GuildDiscordId, Name = "g" };
+        _db.Guilds.Add(_guild);
+        await _db.SaveChangesAsync();
+
+        _channel = new ChannelEntity { DiscordId = ChannelDiscordId, GuildId = _guild.Id, Name = "memes", Type = ChannelType.Text };
+        _author = new UserEntity { DiscordId = 3UL, Username = "u" };
+        _db.Channels.Add(_channel);
+        _db.Users.Add(_author);
+        await _db.SaveChangesAsync();
+    }
+
+    public Task DisposeAsync() => _db.DisposeAsync().AsTask();
+
+    [Fact]
+    public async Task Search_MultiWordAccentlessQuery_RanksMatchingRowOnly()
+    {
+        await SeedIndexedMeme(11UL, 1001UL,
+            descriptionPl: "Pies siedzi przy komputerze",
+            ocrText: "kiedy kod działa za pierwszym razem",
+            tags: ["pies", "programowanie"]);
+        await SeedIndexedMeme(12UL, 1002UL,
+            descriptionPl: "Kot patrzy na lodówkę",
+            ocrText: "",
+            tags: ["kot"]);
+
+        var hits = await Search("kod dziala");
+
+        var hit = Assert.Single(hits);
+        Assert.Equal(11UL, hit.AttachmentDiscordId);
+    }
+
+    [Fact]
+    public async Task Search_TagHit_OutranksDescriptionOnlyHit()
+    {
+        await SeedIndexedMeme(21UL, 1101UL,
+            descriptionPl: "Mem o czymś zupełnie innym",
+            ocrText: "",
+            tags: ["rakieta"]);
+        await SeedIndexedMeme(22UL, 1102UL,
+            descriptionPl: "Start rakieta kończy się klapą",
+            ocrText: "",
+            tags: ["porażka"]);
+
+        var hits = await Search("rakieta");
+
+        Assert.Equal(2, hits.Count);
+        // setweight A (tags) ≫ C (descriptions) under ts_rank.
+        Assert.Equal(21UL, hits[0].AttachmentDiscordId);
+        Assert.Equal(22UL, hits[1].AttachmentDiscordId);
+    }
+
+    [Fact]
+    public async Task Search_PolishInflectedQuery_MatchesViaTrigram()
+    {
+        await SeedIndexedMeme(31UL, 1201UL,
+            descriptionPl: "Mem o bazie danych",
+            ocrText: "",
+            tags: ["postgres"]);
+
+        // FTS can't stem Polish ("postgresie" ≠ "postgres" in the simple
+        // config) — word_similarity is what rescues the inflected query.
+        var hits = await Search("postgresie");
+
+        var hit = Assert.Single(hits);
+        Assert.Equal(31UL, hit.AttachmentDiscordId);
+    }
+
+    [Fact]
+    public async Task Search_RowOnSoftDeletedMessage_IsExcluded()
+    {
+        await SeedIndexedMeme(41UL, 1301UL,
+            descriptionPl: "Unikatowy żółw na deskorolce",
+            ocrText: "",
+            tags: ["żółw"]);
+        await SeedIndexedMeme(42UL, 1302UL,
+            descriptionPl: "Unikatowy żółw na hulajnodze",
+            ocrText: "",
+            tags: ["żółw"],
+            messageDeleted: true);
+
+        var hits = await Search("zolw");
+
+        var hit = Assert.Single(hits);
+        Assert.Equal(41UL, hit.AttachmentDiscordId);
+    }
+
+    [Fact]
+    public async Task Search_NonIndexedStatuses_AreExcluded()
+    {
+        // A Failed row may carry metadata from an earlier attempt; the status
+        // CHECK allows it. Search must still ignore anything not Indexed.
+        var failed = await SeedIndexedMeme(51UL, 1401UL,
+            descriptionPl: "Niepowtarzalny borsuk gra na perkusji",
+            ocrText: "",
+            tags: ["borsuk"]);
+        failed.Status = MemeIndexStatus.Failed;
+        failed.Error = "model exploded";
+        failed.IndexedAtUtc = null;
+        failed.ModelId = null;
+        await _db.SaveChangesAsync();
+
+        var hits = await Search("borsuk");
+
+        Assert.Empty(hits);
+    }
+
+    [Fact]
+    public async Task Search_OtherGuildRows_AreExcluded()
+    {
+        await SeedIndexedMeme(61UL, 1501UL,
+            descriptionPl: "Jednorożec w innym lochu",
+            ocrText: "",
+            tags: ["jednorożec"],
+            guildDiscordId: 999UL);
+
+        var hits = await Search("jednorozec");
+
+        Assert.Empty(hits);
+    }
+
+    [Fact]
+    public async Task Search_EqualScores_BreakTiesByMessageRecency()
+    {
+        // Repost dedupe copies metadata verbatim → identical scores.
+        await SeedIndexedMeme(71UL, 1601UL,
+            descriptionPl: "Słoń maluje płot",
+            ocrText: "",
+            tags: ["słoń"],
+            messageCreatedAtUtc: DateTime.UtcNow.AddDays(-30));
+        await SeedIndexedMeme(72UL, 1602UL,
+            descriptionPl: "Słoń maluje płot",
+            ocrText: "",
+            tags: ["słoń"],
+            messageCreatedAtUtc: DateTime.UtcNow.AddDays(-1));
+
+        var hits = await Search("slon");
+
+        Assert.Equal(2, hits.Count);
+        Assert.Equal(72UL, hits[0].AttachmentDiscordId);
+    }
+
+    [Fact]
+    public async Task Search_RespectsLimit()
+    {
+        await SeedIndexedMeme(81UL, 1701UL, "Trzy wielbłądy na pustyni", "", ["wielbłąd"]);
+        await SeedIndexedMeme(82UL, 1702UL, "Dwa wielbłądy w oazie", "", ["wielbłąd"]);
+        await SeedIndexedMeme(83UL, 1703UL, "Jeden wielbłąd w biurze", "", ["wielbłąd"]);
+
+        var hits = await Search("wielblad", limit: 2);
+
+        Assert.Equal(2, hits.Count);
+    }
+
+    [Fact]
+    public async Task Search_NoMatch_ReturnsEmpty()
+    {
+        await SeedIndexedMeme(91UL, 1801UL, "Pies siedzi przy komputerze", "", ["pies"]);
+
+        var hits = await Search("kwantowa termodynamika frytek");
+
+        Assert.Empty(hits);
+    }
+
+    [Fact]
+    public async Task Search_QueryWithoutWordCharacters_ReturnsEmptyWithoutQuerying()
+    {
+        await SeedIndexedMeme(101UL, 1901UL, "Cokolwiek", "", ["cokolwiek"]);
+
+        var hits = await Search("!!! ??? ((( |||");
+
+        Assert.Empty(hits);
+    }
+
+    private async Task<List<MemeSearchHit>> Search(string query, int limit = MemeSearchService.DefaultLimit)
+    {
+        await using var db = NewContext();
+        return await new MemeSearchService(db)
+            .SearchAsync(GuildDiscordId, query, limit, CancellationToken.None);
+    }
+
+    private async Task<MemeIndexEntity> SeedIndexedMeme(
+        ulong attachmentDiscordId,
+        ulong messageDiscordId,
+        string descriptionPl,
+        string ocrText,
+        string[] tags,
+        bool messageDeleted = false,
+        ulong guildDiscordId = GuildDiscordId,
+        DateTime? messageCreatedAtUtc = null)
+    {
+        var message = new MessageEntity
+        {
+            DiscordId = messageDiscordId,
+            ChannelId = _channel.Id,
+            GuildId = _guild.Id,
+            AuthorId = _author.Id,
+            HasAttachments = true,
+            CreatedAtUtc = messageCreatedAtUtc ?? DateTime.UtcNow,
+            IsDeleted = messageDeleted,
+            DeletedAtUtc = messageDeleted ? DateTime.UtcNow : null
+        };
+        _db.Messages.Add(message);
+        await _db.SaveChangesAsync();
+
+        var meme = new MemeIndexEntity
+        {
+            MessageId = message.Id,
+            GuildDiscordId = guildDiscordId,
+            ChannelDiscordId = ChannelDiscordId,
+            MessageDiscordId = messageDiscordId,
+            AttachmentDiscordId = attachmentDiscordId,
+            FileName = $"meme-{attachmentDiscordId}.png",
+            FileSizeBytes = 1234,
+            ContentType = "image/png",
+            ContentHash = $"hash-{attachmentDiscordId}",
+            Status = MemeIndexStatus.Indexed,
+            DescriptionPl = descriptionPl,
+            DescriptionEn = "english description",
+            OcrText = ocrText,
+            Tags = tags,
+            ModelId = "google/gemini-3-flash-preview",
+            RawResponseJson = "{}",
+            IndexedAtUtc = DateTime.UtcNow
+        };
+        _db.MemeIndex.Add(meme);
+        await _db.SaveChangesAsync();
+        return meme;
+    }
+
+    private DiscordDbContext NewContext()
+    {
+        var options = new DbContextOptionsBuilder<DiscordDbContext>()
+            .UseNpgsql(fixture.Container.GetConnectionString())
+            .UseSnakeCaseNamingConvention()
+            .Options;
+        return new DiscordDbContext(options);
+    }
+}


### PR DESCRIPTION
Closes #224. Last code slice of epic #218.

## What

The bot's first user-facing command. `/meme query:<text>` searches Indexed memes and responds publicly.

- **Commands subsystem**: `DSharpPlus.Commands` (same nightly as DSharpPlus), slash-only — `RegisterDefaultCommandProcessors = false` so no text-prefix processor ever reads message content. Guild-scoped registration driven by `Discord:CommandGuildId`; when unset (prod today) the subsystem isn't wired at all and the bot stays a pure passive logger.
- **`MemeSearchService`** (binding design comment on #224): OR'd `to_tsquery('simple', f_unaccent(...))` gate — deliberately not `websearch_to_tsquery` AND-semantics, since the `simple` config keeps stopwords and AND would zero out natural-language queries — blended with `word_similarity` trigram rescue (threshold 0.4, pinned by `MemeIndexSchemaTests`) for Polish inflections (`postgresie` ~ `postgres`) and typos. Rank = `ts_rank + 0.5 × word_similarity`, recency tiebreak, `Indexed`-only, soft-deleted messages excluded, guild-filtered, LIMIT 5.
- **`MemeCommand`**: defer + edit (search plus message re-fetch can exceed Discord's 3s window). Top hit → live message re-fetch for a fresh signed CDN URL (stored URLs expire, ADR-0004) → embed with image, Polish description snippet, jump link, file-name footer, message timestamp; up to 4 runner-up jump links in a field. Falls back to the next hit when the top message/attachment is gone. The raw query is never echoed into plain content (mention-injection safe; embeds can't ping). Every failure path answers the interaction and can never touch the gateway pipeline.

## Tests

10 Testcontainers tests on the search contract (`MemeSearchServiceTests`): multi-word accentless query ranks the right row, tag hit outranks description-only hit (setweight A≫C), Polish inflected query matched via trigram, soft-deleted/non-Indexed/other-guild rows excluded, equal-score recency tiebreak, limit respected, zero-hit and garbage-query no-ops. Full suite 151/151.

## Live-verified on dev guild

- `/meme` registered guild-scoped (verified via Discord API: 1 guild command, 0 global; 2 stale POC globals cleaned up by the framework)
- User ran `/meme query: reddit` → 5 hits; embed verified via raw API: Polish description, fresh image URL, file-name footer, timestamp, 4 runner-up jump links; zero errors in the bot log
- Search SQL sanity-checked against the 26 real indexed rows in the local dev DB

## Prod activation (deferred, #223)

Dormant on prod until `Discord__CommandGuildId` (+ meme index env vars) land in the homelab compose — recorded on #223.

🤖 Generated with [Claude Code](https://claude.com/claude-code)