### PR TITLE
chore: apply mechanical dotnet-guidelines fixes (Tier A)

### DIFF
--- a/src/DiscordEventService/Commands/MemeCommand.cs
+++ b/src/DiscordEventService/Commands/MemeCommand.cs
@@ -6,14 +6,6 @@ using DSharpPlus.Entities;
 
 namespace DiscordEventService.Commands;
 
-// #224: the bot's first user-facing command. /meme searches the Indexed meme
-// metadata (MemeSearchService) and responds publicly with one line per hit: a
-// bare jump link — Discord renders it as the native "#channel › 💬" pill —
-// followed by the description snippet. No embeds (user call, follow-up to
-// #230): the pill jumps straight to the original message with the image.
-// Every failure path answers the interaction — a swallowed exception here
-// would leave a dangling "thinking…" state, but can never touch the gateway
-// event pipeline.
 public sealed class MemeCommand(MemeSearchService searchService, ILogger<MemeCommand> logger)
 {
     [Command("meme")]

--- a/src/DiscordEventService/Configuration/OpenRouterOptions.cs
+++ b/src/DiscordEventService/Configuration/OpenRouterOptions.cs
@@ -17,7 +17,7 @@ public sealed class OpenRouterOptions
     [
         "google/gemini-2.5-flash",
         "google/gemini-3-flash-preview",
-        "google/gemini-3.5-flash"
+        "google/gemini-3.5-flash",
     ];
 
     public int RequestDelayMs { get; set; } = 250;

--- a/src/DiscordEventService/Controllers/EntitiesController.cs
+++ b/src/DiscordEventService/Controllers/EntitiesController.cs
@@ -5,11 +5,6 @@ using Microsoft.EntityFrameworkCore;
 
 namespace DiscordEventService.Controllers;
 
-/// <summary>
-/// Rich, hand-crafted views over the core current-state entities (users, channels,
-/// members, messages) with name-resolved joins and detail drill-downs. All reads
-/// are AsNoTracking; joins are core-to-core by Guid FK.
-/// </summary>
 [ApiController]
 [Route("api/entities")]
 public sealed class EntitiesController(DiscordDbContext db) : ControllerBase
@@ -60,9 +55,7 @@ public sealed class EntitiesController(DiscordDbContext db) : ControllerBase
             .FirstOrDefaultAsync(ct);
 
         if (user is null)
-        {
             return NotFound();
-        }
 
         var history = await db.UserNameHistory.AsNoTracking()
             .Where(h => h.UserId == id)
@@ -109,9 +102,7 @@ public sealed class EntitiesController(DiscordDbContext db) : ControllerBase
             .FirstOrDefaultAsync(ct);
 
         if (channel is null)
-        {
             return NotFound();
-        }
 
         return Ok(new ChannelDetailDto(
             channel.Id, channel.DiscordId, channel.Name, channel.Type.ToString(), channel.Topic,
@@ -136,9 +127,7 @@ public sealed class EntitiesController(DiscordDbContext db) : ControllerBase
     {
         var query = db.Messages.AsNoTracking();
         if (channelId is not null)
-        {
             query = query.Where(m => m.ChannelId == channelId.Value);
-        }
 
         return PageAsync(
             query.OrderByDescending(m => m.CreatedAtUtc).ThenByDescending(m => m.Id)
@@ -177,9 +166,7 @@ public sealed class EntitiesController(DiscordDbContext db) : ControllerBase
             .FirstOrDefaultAsync(ct);
 
         if (message is null)
-        {
             return NotFound();
-        }
 
         var edits = await db.MessageEditHistory.AsNoTracking()
             .Where(h => h.MessageId == id)

--- a/src/DiscordEventService/Controllers/GuildController.cs
+++ b/src/DiscordEventService/Controllers/GuildController.cs
@@ -6,12 +6,9 @@ using Microsoft.EntityFrameworkCore;
 
 namespace DiscordEventService.Controllers;
 
-/// <summary>
-/// Server header: identity, headline counts, and a small "who's online now" list
-/// derived from the latest presence row per user. Counts are global (single-guild
-/// deployment); the guild identity row is chosen deterministically (still-joined row
-/// first, then earliest first-seen) so it is stable across requests.
-/// </summary>
+// Counts are global (single-guild deployment); the guild identity row is chosen
+// deterministically (still-joined row first, then earliest first-seen) so it is stable
+// across requests.
 [ApiController]
 [Route("api/guild")]
 public sealed class GuildController(DiscordDbContext db) : ControllerBase
@@ -26,9 +23,7 @@ public sealed class GuildController(DiscordDbContext db) : ControllerBase
             .FirstOrDefaultAsync(ct);
 
         if (guild is null)
-        {
             return NotFound();
-        }
 
         var memberCount = await db.Members.LongCountAsync(ct);
         var channelCount = await db.Channels.LongCountAsync(c => !c.IsDeleted, ct);

--- a/src/DiscordEventService/Controllers/PeopleController.cs
+++ b/src/DiscordEventService/Controllers/PeopleController.cs
@@ -7,11 +7,6 @@ using Microsoft.EntityFrameworkCore;
 
 namespace DiscordEventService.Controllers;
 
-/// <summary>
-/// Per-person profile: all-time activity totals, a favourite emote, busiest channel,
-/// a 14-day message sparkline, current presence status and the name-change history.
-/// Keyed by Discord snowflake (route param), 404 when the snowflake is unknown.
-/// </summary>
 [ApiController]
 [Route("api/people")]
 public sealed class PeopleController(DiscordDbContext db) : ControllerBase
@@ -39,9 +34,7 @@ public sealed class PeopleController(DiscordDbContext db) : ControllerBase
             .FirstOrDefaultAsync(ct);
 
         if (user is null)
-        {
             return NotFound();
-        }
 
         var userId = user.Id;
 
@@ -137,9 +130,7 @@ public sealed class PeopleController(DiscordDbContext db) : ControllerBase
         for (var i = 0; i < events.Count - 1; i++)
         {
             if (events[i].ChannelDiscordIdAfter is null)
-            {
                 continue;
-            }
 
             var start = events[i].ReceivedAtUtc;
             var end = events[i + 1].ReceivedAtUtc;
@@ -158,25 +149,16 @@ public sealed class PeopleController(DiscordDbContext db) : ControllerBase
 
             var seconds = (end - start).TotalSeconds - downSeconds;
             if (seconds > 0)
-            {
                 totalMinutes += seconds / 60.0;
-            }
         }
 
         return (long)Math.Round(totalMinutes, MidpointRounding.AwayFromZero);
     }
 
-    /// <summary>
-    /// Online minutes (best-effort approximation). Discord does not expose presence
-    /// durations, so we sessionize presence_events: each event's contribution is the gap
-    /// until the next event, counted only when (a) the event's overall device status is
-    /// non-offline (max device after-status &gt; 0), (b) the gap is at most 30 minutes — a
-    /// cap that keeps stale/offline tails and bot-downtime windows from inflating the
-    /// figure (longer-gap segments are dropped entirely, not clamped), and (c) the
-    /// [start, next) segment does not overlap a recorded bot-downtime interval (open
-    /// intervals coalesced to now()). Treat the result as an approximation, not a precise
-    /// online-time ledger.
-    /// </summary>
+    // Best-effort approximation: Discord exposes no presence durations, so we sessionize
+    // presence_events — each event contributes the gap to the next, counted only when the device
+    // status is non-offline, the gap is at most 30 min (longer gaps are dropped, not clamped, to
+    // keep stale/offline tails out), and the segment does not overlap a recorded bot-downtime.
     private async Task<long> OnlineMinutesAsync(ulong discordSf, CancellationToken ct)
     {
         var events = await db.PresenceEvents.AsNoTracking()
@@ -200,22 +182,16 @@ public sealed class PeopleController(DiscordDbContext db) : ControllerBase
             var current = events[i];
             var next = events[i + 1];
             if (current.Overall <= 0)
-            {
                 continue;
-            }
 
             var gap = next.ReceivedAtUtc - current.ReceivedAtUtc;
             if (gap > TimeSpan.FromMinutes(30))
-            {
                 continue;
-            }
 
             var overlapsDowntime = downtimes.Any(d =>
                 current.ReceivedAtUtc < (d.EndedAtUtc ?? now) && next.ReceivedAtUtc > d.StartedAtUtc);
             if (overlapsDowntime)
-            {
                 continue;
-            }
 
             totalMinutes += gap.TotalMinutes;
         }

--- a/src/DiscordEventService/Controllers/PingController.cs
+++ b/src/DiscordEventService/Controllers/PingController.cs
@@ -2,10 +2,6 @@ using Microsoft.AspNetCore.Mvc;
 
 namespace DiscordEventService.Controllers;
 
-/// <summary>
-/// Liveness probe for the dashboard API surface. Confirms MVC controllers are
-/// wired and the SPA's <c>/api</c> calls reach the backend end-to-end.
-/// </summary>
 [ApiController]
 [Route("api/ping")]
 public sealed class PingController : ControllerBase

--- a/src/DiscordEventService/Controllers/RawEventsController.cs
+++ b/src/DiscordEventService/Controllers/RawEventsController.cs
@@ -6,10 +6,6 @@ using Microsoft.EntityFrameworkCore;
 
 namespace DiscordEventService.Controllers;
 
-/// <summary>
-/// Technical explorer over raw_event_logs: filter by event type / time / failed-flag,
-/// inspect the full raw JSON payload of any event. The replay/debug surface.
-/// </summary>
 [ApiController]
 [Route("api/raw-events")]
 public sealed class RawEventsController(DiscordDbContext db) : ControllerBase
@@ -17,7 +13,6 @@ public sealed class RawEventsController(DiscordDbContext db) : ControllerBase
     private const int DefaultPageSize = 50;
     private const int MaxPageSize = 200;
 
-    /// <summary>Distinct event types with counts, for the filter dropdown.</summary>
     [HttpGet("types")]
     public async Task<ActionResult<IReadOnlyList<RawEventTypeDto>>> GetTypes(CancellationToken ct)
     {
@@ -31,7 +26,6 @@ public sealed class RawEventsController(DiscordDbContext db) : ControllerBase
         return Ok(types);
     }
 
-    /// <summary>Paginated raw-event summaries (no payload), newest first.</summary>
     [HttpGet]
     public async Task<ActionResult<PagedResult<RawEventSummaryDto>>> GetEvents(
         [FromQuery] int page = 1,
@@ -46,18 +40,14 @@ public sealed class RawEventsController(DiscordDbContext db) : ControllerBase
 
         var query = db.RawEventLogs.AsNoTracking();
         if (!string.IsNullOrWhiteSpace(eventType))
-        {
             query = query.Where(r => r.EventType == eventType);
-        }
         if (since is not null)
         {
             var sinceUtc = since.Value.ToUtcInstant();
             query = query.Where(r => r.ReceivedAtUtc >= sinceUtc);
         }
         if (failedOnly)
-        {
             query = query.Where(r => r.SerializationFailed);
-        }
 
         var total = await query.LongCountAsync(ct);
         var items = await query
@@ -73,7 +63,6 @@ public sealed class RawEventsController(DiscordDbContext db) : ControllerBase
         return Ok(new PagedResult<RawEventSummaryDto>(items, total, page, pageSize));
     }
 
-    /// <summary>A single raw event with its full parsed JSON payload.</summary>
     [HttpGet("{id:guid}")]
     public async Task<ActionResult<RawEventDetailDto>> GetEvent(Guid id, CancellationToken ct)
     {
@@ -95,9 +84,7 @@ public sealed class RawEventsController(DiscordDbContext db) : ControllerBase
             .FirstOrDefaultAsync(ct);
 
         if (row is null)
-        {
             return NotFound();
-        }
 
         return Ok(new RawEventDetailDto(
             row.Id, row.EventType, row.GuildDiscordId, row.ChannelDiscordId, row.UserDiscordId,

--- a/src/DiscordEventService/Controllers/StatsController.cs
+++ b/src/DiscordEventService/Controllers/StatsController.cs
@@ -10,15 +10,6 @@ using Npgsql;
 
 namespace DiscordEventService.Controllers;
 
-/// <summary>
-/// Pre-aggregated statistics across four buckets: Volume &amp; trends, People, Places,
-/// Behavior. Time buckets use guild-local time (Europe/Warsaw) computed server-side.
-/// Aggregations are EF LINQ where the provider can translate them; raw SQL is reserved for
-/// what LINQ/Npgsql cannot express — CET-local <c>AT TIME ZONE</c> bucketing, dense
-/// <c>generate_series</c> zero-fill, and <c>LEAD()</c> window sessionization (each noted at
-/// its call site). All queries are fixed (no client identifiers) over base tables — no
-/// dependency on the prod-only SQL views, so the same queries run under Testcontainers.
-/// </summary>
 [ApiController]
 [Route("api/stats")]
 public sealed class StatsController(DiscordDbContext db) : ControllerBase
@@ -84,8 +75,6 @@ public sealed class StatsController(DiscordDbContext db) : ControllerBase
             .Select(x => new EmojiStatDto(x.EmoteName, x.EmoteDiscordId, x.EmoteDiscordId is > 0, x.Count))
             .ToList();
     }
-
-    // ---- Overview (home dashboard) ----
 
     [HttpGet("overview")]
     public async Task<OverviewDto> Overview(CancellationToken ct)
@@ -168,7 +157,6 @@ public sealed class StatsController(DiscordDbContext db) : ControllerBase
             topChatter, topChannel, messagesDaily, topEmojis);
     }
 
-    // ---- Volume & trends ----
     // volume/daily + volume/hourly stay raw: they bucket by CET calendar day / hour via
     // `... AT TIME ZONE 'Europe/Warsaw'`, which Npgsql's EF Core provider does not translate
     // from LINQ. volume/by-type (no time bucketing) is plain EF below.
@@ -202,8 +190,6 @@ public sealed class StatsController(DiscordDbContext db) : ControllerBase
         GROUP BY hour ORDER BY hour
         """,
         r => new VolumeHourlyDto(r.GetInt32(0), r.GetInt64(1)), ct);
-
-    // ---- People ----
 
     [HttpGet("people/top-messages")]
     public Task<List<UserStatDto>> TopMessages(CancellationToken ct) =>
@@ -241,11 +227,7 @@ public sealed class StatsController(DiscordDbContext db) : ControllerBase
             .Select(x => new UserStatDto(x.Username, x.DiscordId, x.Count, x.AvatarHash))
             .ToListAsync(ct);
 
-    /// <summary>
-    /// Voice minutes per user. Each event where the user is in a channel
-    /// (channel_discord_id_after not null) contributes the gap until their next
-    /// event. Open sessions (no following event) are excluded — surfaced in the UI.
-    /// </summary>
+    // Open sessions (no following event) are excluded — surfaced in the UI.
     [HttpGet("people/voice-leaderboard")]
     public Task<List<VoiceStatDto>> VoiceLeaderboard(CancellationToken ct) => QueryAsync(
         $"""
@@ -263,22 +245,16 @@ public sealed class StatsController(DiscordDbContext db) : ControllerBase
         """,
         r => new VoiceStatDto(NullableString(r, 0), Snowflake(r, 1), r.GetInt64(2), NullableString(r, 3)), ct);
 
-    // ---- Places ----
-
     [HttpGet("places/channel-activity")]
     public Task<List<ChannelActivityDto>> ChannelActivity(CancellationToken ct) => QueryAsync(
         $"{ChannelActivitySql} 50",
         r => new ChannelActivityDto(r.GetString(0), Snowflake(r, 1), r.GetInt64(2), r.GetInt64(3)), ct);
 
-    // ---- Behavior ----
-
     [HttpGet("behavior/top-emojis")]
     public Task<List<EmojiStatDto>> TopEmojis(CancellationToken ct) => TopEmojisAsync(25, ct);
 
-    /// <summary>
-    /// Top presence activities ("playing X"). NOTE: includes presence artifacts such
-    /// as "Custom Status" and "Playing N/10" — surfaced (not hidden) with a UI note.
-    /// </summary>
+    // Includes presence artifacts such as "Custom Status" and "Playing N/10" —
+    // surfaced (not hidden) with a UI note.
     [HttpGet("behavior/top-activities")]
     public Task<List<ActivityStatDto>> TopActivities(CancellationToken ct) =>
         db.Activities.AsNoTracking()
@@ -303,22 +279,13 @@ public sealed class StatsController(DiscordDbContext db) : ControllerBase
         """,
         r => new HeatmapCellDto(r.GetInt32(0), r.GetInt32(1), r.GetInt64(2)), ct);
 
-    // ---- Community (windowed headline metrics + leaderboards) ----
-
-    /// <summary>
-    /// Headline community metrics over a rolling window (week=7d, month=30d, all=since
-    /// launch) with a same-length preceding-window comparison (null for <c>all</c>) and
-    /// a dense daily sparkline. Leaderboards are the top 6 per metric in the window.
-    /// </summary>
     [HttpGet("community")]
     public async Task<ActionResult<CommunityDto>> Community(
         [FromQuery] string range = "week", CancellationToken ct = default)
     {
         range = (range ?? "week").Trim().ToLowerInvariant();
         if (range is not ("week" or "month" or "all"))
-        {
             return BadRequest(new { error = "range must be one of: week, month, all." });
-        }
 
         var (curStart, curEnd, prevStart, prevEnd, sparkDays, label, prevLabel) =
             await ResolveWindowAsync(range, ct);
@@ -420,19 +387,11 @@ public sealed class StatsController(DiscordDbContext db) : ControllerBase
         return new CommunityDto(range, label, prevLabel, metrics, leaderboards);
     }
 
-    // ---- Spotify ----
-
-    /// <summary>
-    /// Spotify listening: who is listening right now (active Listening activities) and
-    /// the most-played tracks all-time. Artist is the first entry of the JSON artist
-    /// array stored on the activity.
-    /// NOTE (data reality): the bot currently records only the activity name ("Spotify")
-    /// for Listening presence — the rich track fields (song title, artist, album, art) are
-    /// not captured and are NULL/placeholder in stored data. So <c>track</c> is null when
-    /// the stored "song title" is just the generic activity name, and top-tracks excludes
-    /// that placeholder (yielding an empty list until richer presence is ingested). The
-    /// now-playing tile still honestly shows who is currently listening.
-    /// </summary>
+    // Data reality: the bot currently records only the activity name ("Spotify") for
+    // Listening presence — the rich track fields (title, artist, album, art) are
+    // NULL/placeholder. So track is null when the stored "song title" is just the generic
+    // activity name, and top-tracks excludes that placeholder until richer presence is
+    // ingested.
     [HttpGet("spotify")]
     public async Task<SpotifyDto> Spotify(CancellationToken ct)
     {
@@ -489,15 +448,11 @@ public sealed class StatsController(DiscordDbContext db) : ControllerBase
         return new SpotifyDto(nowPlaying, topTracks);
     }
 
-    // ---- helpers ----
-
     private async Task<List<T>> QueryAsync<T>(string sql, Func<NpgsqlDataReader, T> map, CancellationToken ct)
     {
         var connection = (NpgsqlConnection)db.Database.GetDbConnection();
         if (connection.State != ConnectionState.Open)
-        {
             await connection.OpenAsync(ct);
-        }
 
         await using var cmd = connection.CreateCommand();
         cmd.CommandText = sql;
@@ -505,9 +460,7 @@ public sealed class StatsController(DiscordDbContext db) : ControllerBase
 
         var results = new List<T>();
         while (await reader.ReadAsync(ct))
-        {
             results.Add(map(reader));
-        }
         return results;
     }
 
@@ -515,9 +468,7 @@ public sealed class StatsController(DiscordDbContext db) : ControllerBase
     {
         var connection = (NpgsqlConnection)db.Database.GetDbConnection();
         if (connection.State != ConnectionState.Open)
-        {
             await connection.OpenAsync(ct);
-        }
 
         await using var cmd = connection.CreateCommand();
         cmd.CommandText = sql;
@@ -533,8 +484,6 @@ public sealed class StatsController(DiscordDbContext db) : ControllerBase
     // regardless of how Npgsql materializes the column kind.
     private static DateTime? AsUtc(DateTime? dt) =>
         dt is null ? null : DateTime.SpecifyKind(dt.Value, DateTimeKind.Utc);
-
-    // ---- Community window helpers ----
 
     // Window resolution: anchor everything to a single DB now() so the current and
     // preceding windows line up exactly (the spark series, prev comparison and counts
@@ -752,9 +701,7 @@ public sealed class StatsController(DiscordDbContext db) : ControllerBase
     {
         var connection = (NpgsqlConnection)db.Database.GetDbConnection();
         if (connection.State != ConnectionState.Open)
-        {
             await connection.OpenAsync(ct);
-        }
 
         await using var cmd = connection.CreateCommand();
         cmd.CommandText = sql;
@@ -772,9 +719,7 @@ public sealed class StatsController(DiscordDbContext db) : ControllerBase
     private static string? FirstArtist(string? json)
     {
         if (string.IsNullOrWhiteSpace(json))
-        {
             return null;
-        }
 
         try
         {

--- a/src/DiscordEventService/Controllers/TablesController.cs
+++ b/src/DiscordEventService/Controllers/TablesController.cs
@@ -8,16 +8,10 @@ using Npgsql;
 
 namespace DiscordEventService.Controllers;
 
-/// <summary>
-/// Generic, schema-driven explorer over every EF-mapped table. Lists tables with
-/// row counts, exposes per-table column metadata, and returns paginated rows.
-/// <para>
-/// SECURITY: table, sort, and filter-column identifiers are validated against the
-/// <see cref="SchemaCatalog"/> whitelist and only the catalog's trusted literal is
-/// ever emitted into SQL. Filter VALUES and paging are bound as parameters. Client
-/// text is never interpolated as an identifier.
-/// </para>
-/// </summary>
+// SECURITY: table, sort, and filter-column identifiers are validated against the
+// SchemaCatalog whitelist and only the catalog's trusted literal is ever emitted into
+// SQL. Filter VALUES and paging are bound as parameters. Client text is never
+// interpolated as an identifier.
 [ApiController]
 [Route("api/tables")]
 public sealed class TablesController(DiscordDbContext db, SchemaCatalog catalog) : ControllerBase
@@ -25,7 +19,6 @@ public sealed class TablesController(DiscordDbContext db, SchemaCatalog catalog)
     private const int DefaultPageSize = 50;
     private const int MaxPageSize = 200;
 
-    /// <summary>Lists explorable tables with approximate row counts (from pg_stat).</summary>
     [HttpGet]
     public async Task<ActionResult<IReadOnlyList<TableInfoDto>>> GetTables(CancellationToken ct)
     {
@@ -44,19 +37,15 @@ public sealed class TablesController(DiscordDbContext db, SchemaCatalog catalog)
         return Ok(tables);
     }
 
-    /// <summary>Column metadata for a single table (drives client-side cell rendering).</summary>
     [HttpGet("{table}/columns")]
     public ActionResult<IReadOnlyList<ColumnMetadataDto>> GetColumns(string table)
     {
         if (!catalog.TryGetTable(table, out var meta))
-        {
             return BadRequest(new { error = $"Unknown table '{table}'." });
-        }
 
         return Ok(meta.Columns.Select(ColumnMetadataDto.From).ToList());
     }
 
-    /// <summary>Paginated rows for a table. Each row is a snake_case-keyed property bag.</summary>
     [HttpGet("{table}")]
     public async Task<ActionResult<PagedResult<Dictionary<string, object?>>>> GetRows(
         string table,
@@ -69,19 +58,13 @@ public sealed class TablesController(DiscordDbContext db, SchemaCatalog catalog)
         CancellationToken ct = default)
     {
         if (!catalog.TryGetTable(table, out var meta))
-        {
             return BadRequest(new { error = $"Unknown table '{table}'." });
-        }
 
         if (sort is not null && !meta.HasColumn(sort))
-        {
             return BadRequest(new { error = $"Unknown sort column '{sort}'." });
-        }
 
         if (filterColumn is not null && !meta.HasColumn(filterColumn))
-        {
             return BadRequest(new { error = $"Unknown filter column '{filterColumn}'." });
-        }
 
         page = Math.Max(1, page);
         pageSize = Math.Clamp(pageSize, 1, MaxPageSize);
@@ -103,9 +86,7 @@ public sealed class TablesController(DiscordDbContext db, SchemaCatalog catalog)
 
         var connection = (NpgsqlConnection)db.Database.GetDbConnection();
         if (connection.State != ConnectionState.Open)
-        {
             await connection.OpenAsync(ct);
-        }
 
         var total = await CountAsync(connection, quotedTable, where, filter, ct);
 
@@ -116,9 +97,7 @@ public sealed class TablesController(DiscordDbContext db, SchemaCatalog catalog)
                 $"SELECT * FROM {quotedTable}{where} " +
                 $"ORDER BY {Quote(sortColumn)} {direction} LIMIT @limit OFFSET @offset";
             if (hasFilter)
-            {
                 cmd.Parameters.AddWithValue("filter", $"%{filter}%");
-            }
             cmd.Parameters.AddWithValue("limit", pageSize);
             cmd.Parameters.AddWithValue("offset", offset);
 
@@ -129,14 +108,12 @@ public sealed class TablesController(DiscordDbContext db, SchemaCatalog catalog)
                 for (var i = 0; i < reader.FieldCount; i++)
                 {
                     var name = reader.GetName(i);
-                    object? value = await reader.IsDBNullAsync(i, ct) ? null : reader.GetValue(i);
+                    var value = await reader.IsDBNullAsync(i, ct) ? null : reader.GetValue(i);
 
                     // Snowflakes are stored as bigint; box back to ulong so the global
                     // JSON converter emits them as strings (JS number precision).
                     if (value is long l && meta.Column(name)?.Kind == ColumnKind.Snowflake)
-                    {
                         value = unchecked((ulong)l);
-                    }
 
                     row[name] = value;
                 }
@@ -153,9 +130,7 @@ public sealed class TablesController(DiscordDbContext db, SchemaCatalog catalog)
         await using var cmd = connection.CreateCommand();
         cmd.CommandText = $"SELECT COUNT(*) FROM {quotedTable}{where}";
         if (where.Length > 0)
-        {
             cmd.Parameters.AddWithValue("filter", $"%{filter}%");
-        }
         var result = await cmd.ExecuteScalarAsync(ct);
         return result is long l ? l : Convert.ToInt64(result);
     }
@@ -165,9 +140,7 @@ public sealed class TablesController(DiscordDbContext db, SchemaCatalog catalog)
         var counts = new Dictionary<string, long>(StringComparer.Ordinal);
         var connection = (NpgsqlConnection)db.Database.GetDbConnection();
         if (connection.State != ConnectionState.Open)
-        {
             await connection.OpenAsync(ct);
-        }
 
         await using var cmd = connection.CreateCommand();
         cmd.CommandText = "SELECT relname, n_live_tup FROM pg_stat_user_tables";

--- a/src/DiscordEventService/Controllers/TimelineController.cs
+++ b/src/DiscordEventService/Controllers/TimelineController.cs
@@ -8,11 +8,8 @@ using Microsoft.EntityFrameworkCore;
 
 namespace DiscordEventService.Controllers;
 
-/// <summary>
-/// Unified, time-ordered activity feed over raw_event_logs (the single append-only
-/// source of every gateway event). Keyset pagination on (received_at_utc DESC, id)
-/// — both indexed — so deep pages stay fast and never skip/duplicate rows.
-/// </summary>
+// Keyset pagination on (received_at_utc DESC, id) — both indexed — so deep pages stay
+// fast and never skip/duplicate rows.
 [ApiController]
 [Route("api/timeline")]
 public sealed class TimelineController(DiscordDbContext db) : ControllerBase
@@ -51,13 +48,9 @@ public sealed class TimelineController(DiscordDbContext db) : ControllerBase
             query = query.Where(r => types.Contains(r.EventType));
         }
         if (userId is not null)
-        {
             query = query.Where(r => r.UserDiscordId == userId.Value);
-        }
         if (channelId is not null)
-        {
             query = query.Where(r => r.ChannelDiscordId == channelId.Value);
-        }
 
         if (TryDecodeCursor(cursor, out var cursorTs, out var cursorId))
         {
@@ -87,9 +80,7 @@ public sealed class TimelineController(DiscordDbContext db) : ControllerBase
 
         var hasMore = rows.Count > pageSize;
         if (hasMore)
-        {
             rows.RemoveAt(rows.Count - 1);
-        }
 
         var events = rows.Select(r => new TimelineEventDto(
             r.Id,
@@ -120,17 +111,13 @@ public sealed class TimelineController(DiscordDbContext db) : ControllerBase
         receivedAtUtc = default;
         id = default;
         if (string.IsNullOrEmpty(cursor))
-        {
             return false;
-        }
 
         try
         {
             var parts = Encoding.UTF8.GetString(Convert.FromBase64String(cursor)).Split('|', 2);
             if (parts.Length != 2)
-            {
                 return false;
-            }
             receivedAtUtc = DateTime.Parse(parts[0], CultureInfo.InvariantCulture, DateTimeStyles.RoundtripKind);
             return Guid.TryParse(parts[1], out id);
         }

--- a/src/DiscordEventService/Data/Configurations/BotHeartbeatEntityConfiguration.cs
+++ b/src/DiscordEventService/Data/Configurations/BotHeartbeatEntityConfiguration.cs
@@ -6,10 +6,8 @@ namespace DiscordEventService.Data.Configurations;
 
 internal sealed class BotHeartbeatEntityConfiguration : IEntityTypeConfiguration<BotHeartbeatEntity>
 {
-    public void Configure(EntityTypeBuilder<BotHeartbeatEntity> builder)
-    {
-        // Index on LastHeartbeatUtc — append-only table, "most recent tick"
-        // lookups via OrderByDescending(LastHeartbeatUtc).First() use this.
+    // Index on LastHeartbeatUtc — append-only table, "most recent tick"
+    // lookups via OrderByDescending(LastHeartbeatUtc).First() use this.
+    public void Configure(EntityTypeBuilder<BotHeartbeatEntity> builder) =>
         builder.HasIndex(h => h.LastHeartbeatUtc);
-    }
 }

--- a/src/DiscordEventService/Data/Configurations/GuildEntityConfiguration.cs
+++ b/src/DiscordEventService/Data/Configurations/GuildEntityConfiguration.cs
@@ -6,8 +6,5 @@ namespace DiscordEventService.Data.Configurations;
 
 internal sealed class GuildEntityConfiguration : IEntityTypeConfiguration<GuildEntity>
 {
-    public void Configure(EntityTypeBuilder<GuildEntity> builder)
-    {
-        builder.HasIndex(g => g.DiscordId).IsUnique();
-    }
+    public void Configure(EntityTypeBuilder<GuildEntity> builder) => builder.HasIndex(g => g.DiscordId).IsUnique();
 }

--- a/src/DiscordEventService/Data/Configurations/GuildEventEntityConfiguration.cs
+++ b/src/DiscordEventService/Data/Configurations/GuildEventEntityConfiguration.cs
@@ -6,8 +6,6 @@ namespace DiscordEventService.Data.Configurations;
 
 internal sealed class GuildEventEntityConfiguration : IEntityTypeConfiguration<GuildEventEntity>
 {
-    public void Configure(EntityTypeBuilder<GuildEventEntity> builder)
-    {
+    public void Configure(EntityTypeBuilder<GuildEventEntity> builder) =>
         builder.HasIndex(g => new { g.GuildDiscordId, g.EventTimestampUtc });
-    }
 }

--- a/src/DiscordEventService/Data/Configurations/IntegrationEventEntityConfiguration.cs
+++ b/src/DiscordEventService/Data/Configurations/IntegrationEventEntityConfiguration.cs
@@ -6,8 +6,6 @@ namespace DiscordEventService.Data.Configurations;
 
 internal sealed class IntegrationEventEntityConfiguration : IEntityTypeConfiguration<IntegrationEventEntity>
 {
-    public void Configure(EntityTypeBuilder<IntegrationEventEntity> builder)
-    {
+    public void Configure(EntityTypeBuilder<IntegrationEventEntity> builder) =>
         builder.HasIndex(i => new { i.GuildDiscordId, i.EventTimestampUtc });
-    }
 }

--- a/src/DiscordEventService/Data/Configurations/InviteEventEntityConfiguration.cs
+++ b/src/DiscordEventService/Data/Configurations/InviteEventEntityConfiguration.cs
@@ -6,8 +6,6 @@ namespace DiscordEventService.Data.Configurations;
 
 internal sealed class InviteEventEntityConfiguration : IEntityTypeConfiguration<InviteEventEntity>
 {
-    public void Configure(EntityTypeBuilder<InviteEventEntity> builder)
-    {
+    public void Configure(EntityTypeBuilder<InviteEventEntity> builder) =>
         builder.HasIndex(i => new { i.GuildDiscordId, i.EventTimestampUtc });
-    }
 }

--- a/src/DiscordEventService/Data/Configurations/LifecycleFactConstraint.cs
+++ b/src/DiscordEventService/Data/Configurations/LifecycleFactConstraint.cs
@@ -1,12 +1,7 @@
 namespace DiscordEventService.Data.Configurations;
 
-/// <summary>
-/// Shared CHECK constraint body for lifecycle-fact entities (Ban, Activity), enforcing the
-/// CONTEXT.md invariant <c>is_active = false ⇔ end-timestamp IS NOT NULL</c> at the DB level.
-/// Distinct from <see cref="SoftDeleteConstraint"/>: lifecycle facts use domain-specific end
-/// columns (<c>unbanned_at_utc</c> / <c>ended_at_utc</c>), not the soft-delete convention — the
-/// shared boolean shape is a coincidence, the semantics differ.
-/// </summary>
+// Distinct from SoftDeleteConstraint: lifecycle facts (Ban, Activity) use domain end columns
+// (unbanned_at_utc / ended_at_utc), not the soft-delete convention — the shared boolean shape is coincidental.
 internal static class LifecycleFactConstraint
 {
     public static string Check(string endColumn) =>

--- a/src/DiscordEventService/Data/Configurations/SoftDeleteConstraint.cs
+++ b/src/DiscordEventService/Data/Configurations/SoftDeleteConstraint.cs
@@ -1,9 +1,6 @@
 namespace DiscordEventService.Data.Configurations;
 
-/// <summary>
-/// Shared CHECK constraint body keeping <c>is_deleted</c> ↔ <c>deleted_at_utc IS NOT NULL</c> in
-/// sync (§P2.5). Applied per soft-deletable entity in its configuration.
-/// </summary>
+// Shared CHECK body keeping is_deleted <-> deleted_at_utc in sync (applied per soft-deletable entity).
 internal static class SoftDeleteConstraint
 {
     public const string Check =

--- a/src/DiscordEventService/Data/DbSetUpsertExtensions.cs
+++ b/src/DiscordEventService/Data/DbSetUpsertExtensions.cs
@@ -38,17 +38,10 @@ internal static class DbSetUpsertExtensions
         return await set.Where(match).Select(select).FirstOrDefaultAsync(cancellationToken);
     }
 
-    /// <summary>
-    /// Insert-or-get. Inserts <paramref name="create"/>; on a 23505 unique-violation race
-    /// (another writer inserted first), clears the failed Add and re-queries the existing row
-    /// <b>without modifying it</b>. Use when the conflicting row must be preserved as-is
-    /// (placeholder rows, snapshot insert-or-ignore, create-only message inserts) — routing
-    /// those through <see cref="UpsertAsync{TEntity,TResult}"/> would overwrite real data.
-    /// Returns <c>(Entity, Inserted)</c>: on the happy path the freshly-inserted entity (keys
-    /// populated, no extra query) with <c>Inserted = true</c>; on conflict the existing row with
-    /// <c>Inserted = false</c> (<c>Entity = null</c> only if the row vanished after the conflict).
-    /// Transaction-passive: never opens its own strategy/transaction.
-    /// </summary>
+    // Insert-or-get: on a 23505 race the existing row is returned UNMODIFIED (unlike UpsertAsync,
+    // which would overwrite it) — for rows that must be preserved as-is. Returns (Entity, Inserted):
+    // Inserted=true with the fresh entity on the happy path; Inserted=false with the existing row on
+    // conflict (Entity=null only if the row vanished after the conflict).
     public static async Task<(TEntity? Entity, bool Inserted)> GetOrInsertAsync<TEntity>(
         this DbSet<TEntity> set,
         Expression<Func<TEntity, bool>> match,

--- a/src/DiscordEventService/Data/DiscordDbContext.cs
+++ b/src/DiscordEventService/Data/DiscordDbContext.cs
@@ -7,7 +7,6 @@ namespace DiscordEventService.Data;
 
 public class DiscordDbContext(DbContextOptions<DiscordDbContext> options) : DbContext(options)
 {
-    // Core entities
     public DbSet<GuildEntity> Guilds => Set<GuildEntity>();
     public DbSet<ChannelEntity> Channels => Set<ChannelEntity>();
     public DbSet<UserEntity> Users => Set<UserEntity>();
@@ -30,33 +29,27 @@ public class DiscordDbContext(DbContextOptions<DiscordDbContext> options) : DbCo
     // Member role snapshots (SCD for historical role membership)
     public DbSet<MemberRoleSnapshotEntity> MemberRoleSnapshots => Set<MemberRoleSnapshotEntity>();
 
-    // User name history
     public DbSet<UserNameHistoryEntity> UserNameHistory => Set<UserNameHistoryEntity>();
 
-    // Event entities - Messages & Reactions
     public DbSet<MessageEventEntity> MessageEvents => Set<MessageEventEntity>();
     public DbSet<ReactionEventEntity> ReactionEvents => Set<ReactionEventEntity>();
     public DbSet<PollEventEntity> PollEvents => Set<PollEventEntity>();
     public DbSet<PinEventEntity> PinEvents => Set<PinEventEntity>();
 
-    // Event entities - Voice & Presence
     public DbSet<VoiceStateEventEntity> VoiceStateEvents => Set<VoiceStateEventEntity>();
     public DbSet<VoiceServerEventEntity> VoiceServerEvents => Set<VoiceServerEventEntity>();
     public DbSet<PresenceEventEntity> PresenceEvents => Set<PresenceEventEntity>();
 
-    // Event entities - Members
     public DbSet<MemberEventEntity> MemberEvents => Set<MemberEventEntity>();
     public DbSet<BanEventEntity> BanEvents => Set<BanEventEntity>();
     public DbSet<GuildMembersChunkEventEntity> GuildMembersChunkEvents => Set<GuildMembersChunkEventEntity>();
 
-    // Event entities - Channels & Threads
     public DbSet<ChannelEventEntity> ChannelEvents => Set<ChannelEventEntity>();
     public DbSet<RoleEventEntity> RoleEvents => Set<RoleEventEntity>();
     public DbSet<ThreadEventEntity> ThreadEvents => Set<ThreadEventEntity>();
     public DbSet<ThreadSyncEventEntity> ThreadSyncEvents => Set<ThreadSyncEventEntity>();
     public DbSet<StageInstanceEventEntity> StageInstanceEvents => Set<StageInstanceEventEntity>();
 
-    // Event entities - Guild
     public DbSet<GuildEventEntity> GuildEvents => Set<GuildEventEntity>();
     public DbSet<EmojiEventEntity> EmojiEvents => Set<EmojiEventEntity>();
     public DbSet<StickerEventEntity> StickerEvents => Set<StickerEventEntity>();
@@ -64,20 +57,16 @@ public class DiscordDbContext(DbContextOptions<DiscordDbContext> options) : DbCo
     public DbSet<IntegrationEventEntity> IntegrationEvents => Set<IntegrationEventEntity>();
     public DbSet<AuditLogEventEntity> AuditLogEvents => Set<AuditLogEventEntity>();
 
-    // Event entities - Scheduled & AutoMod
     public DbSet<ScheduledEventEntity> ScheduledEvents => Set<ScheduledEventEntity>();
     public DbSet<AutoModEventEntity> AutoModEvents => Set<AutoModEventEntity>();
     public DbSet<AutoModRuleEventEntity> AutoModRuleEvents => Set<AutoModRuleEventEntity>();
     public DbSet<InviteEventEntity> InviteEvents => Set<InviteEventEntity>();
     public DbSet<TypingEventEntity> TypingEvents => Set<TypingEventEntity>();
 
-    // Raw event logging for debugging
     public DbSet<RawEventLogEntity> RawEventLogs => Set<RawEventLogEntity>();
 
-    // Dead-letter queue for failed events
     public DbSet<FailedEventEntity> FailedEvents => Set<FailedEventEntity>();
 
-    // Backfill checkpoints
     public DbSet<BackfillCheckpointEntity> BackfillCheckpoints => Set<BackfillCheckpointEntity>();
 
     // Bot downtime intervals
@@ -98,7 +87,6 @@ public class DiscordDbContext(DbContextOptions<DiscordDbContext> options) : DbCo
         modelBuilder.HasPostgresExtension("unaccent");
         modelBuilder.HasPostgresExtension("pg_trgm");
 
-        // Apply snowflake converter to all ulong properties
         var snowflakeConverter = new ValueConverter<ulong, long>(
             v => unchecked((long)v),
             v => unchecked((ulong)v));
@@ -108,9 +96,7 @@ public class DiscordDbContext(DbContextOptions<DiscordDbContext> options) : DbCo
             foreach (var property in entityType.GetProperties())
             {
                 if (property.ClrType == typeof(ulong))
-                {
                     property.SetValueConverter(snowflakeConverter);
-                }
                 else if (property.ClrType == typeof(ulong?))
                 {
                     property.SetValueConverter(new ValueConverter<ulong?, long?>(
@@ -164,14 +150,11 @@ public static class UuidV7Extensions
 {
     public static void ConfigureUuidGeneration(this ModelBuilder modelBuilder)
     {
-        // Configure all Guid Id properties to use PostgreSQL's uuidv7() for generation
         foreach (var entityType in modelBuilder.Model.GetEntityTypes())
         {
             var idProperty = entityType.FindProperty("Id");
             if (idProperty != null && idProperty.ClrType == typeof(Guid))
-            {
                 idProperty.SetDefaultValueSql("uuidv7()");
-            }
         }
     }
 }

--- a/src/DiscordEventService/Data/Entities/Core/ActivityEntity.cs
+++ b/src/DiscordEventService/Data/Entities/Core/ActivityEntity.cs
@@ -26,14 +26,11 @@ public class ActivityEntity
     [MaxLength(1024)]
     public string? State { get; set; }
 
-    // Application info
     public ulong? ApplicationId { get; set; }
 
-    // Timestamps
     public DateTime? StartedAtUtc { get; set; }
     public DateTime? EndsAtUtc { get; set; }
 
-    // Rich presence images
     [MaxLength(512)]
     public string? LargeImageUrl { get; set; }
 
@@ -46,13 +43,11 @@ public class ActivityEntity
     [MaxLength(256)]
     public string? SmallImageText { get; set; }
 
-    // Party info
     [MaxLength(256)]
     public string? PartyId { get; set; }
     public int? PartyCurrentSize { get; set; }
     public int? PartyMaxSize { get; set; }
 
-    // Spotify-specific fields
     [MaxLength(256)]
     public string? SpotifyTrackId { get; set; }
 
@@ -71,11 +66,9 @@ public class ActivityEntity
     public DateTime? SpotifyTrackStartUtc { get; set; }
     public DateTime? SpotifyTrackEndUtc { get; set; }
 
-    // Streaming-specific fields
     [MaxLength(512)]
     public string? StreamUrl { get; set; }
 
-    // Custom status emoji
     public ulong? CustomStatusEmojiId { get; set; }
 
     [MaxLength(256)]
@@ -84,7 +77,6 @@ public class ActivityEntity
     // Buttons (JSON array)
     public string? ButtonsJson { get; set; }
 
-    // Tracking
     public bool IsActive { get; set; } = true;
     public DateTime FirstSeenAtUtc { get; set; } = DateTime.UtcNow;
     public DateTime LastSeenAtUtc { get; set; } = DateTime.UtcNow;

--- a/src/DiscordEventService/Data/Entities/Core/BackfillCheckpointEntity.cs
+++ b/src/DiscordEventService/Data/Entities/Core/BackfillCheckpointEntity.cs
@@ -7,18 +7,15 @@ public class BackfillCheckpointEntity : ITimestamped
     public BackfillType Type { get; set; }
     public BackfillStatus Status { get; set; }
 
-    // Progress tracking
     public ulong? LastProcessedId { get; set; }
     public ulong? CurrentChannelId { get; set; }
     public int ProcessedCount { get; set; }
     public int? TotalCount { get; set; }
 
-    // Error handling
     public int ErrorCount { get; set; }
     public string? LastError { get; set; }
     public DateTime? LastErrorAtUtc { get; set; }
 
-    // Hangfire job tracking
     public string? HangfireJobId { get; set; }
 
     public DateTime StartedAtUtc { get; set; }

--- a/src/DiscordEventService/Data/Entities/Events/AuditLogEventEntity.cs
+++ b/src/DiscordEventService/Data/Entities/Events/AuditLogEventEntity.cs
@@ -15,6 +15,5 @@ public class AuditLogEventEntity
     public DateTime EventTimestampUtc { get; set; }
     public DateTime ReceivedAtUtc { get; set; }
 
-    /// <summary>Raw serialized event args from DSharpPlus for debugging</summary>
     public string? RawEventJson { get; set; }
 }

--- a/src/DiscordEventService/Data/Entities/Events/AutoModEventEntity.cs
+++ b/src/DiscordEventService/Data/Entities/Events/AutoModEventEntity.cs
@@ -31,6 +31,5 @@ public class AutoModEventEntity
     public DateTime EventTimestampUtc { get; set; }
     public DateTime ReceivedAtUtc { get; set; }
 
-    /// <summary>Raw serialized event args from DSharpPlus for debugging</summary>
     public string? RawEventJson { get; set; }
 }

--- a/src/DiscordEventService/Data/Entities/Events/AutoModRuleEventEntity.cs
+++ b/src/DiscordEventService/Data/Entities/Events/AutoModRuleEventEntity.cs
@@ -23,6 +23,5 @@ public class AutoModRuleEventEntity
     public DateTime EventTimestampUtc { get; set; }
     public DateTime ReceivedAtUtc { get; set; }
 
-    /// <summary>Raw serialized event args from DSharpPlus for debugging</summary>
     public string? RawEventJson { get; set; }
 }

--- a/src/DiscordEventService/Data/Entities/Events/BanEventEntity.cs
+++ b/src/DiscordEventService/Data/Entities/Events/BanEventEntity.cs
@@ -17,6 +17,5 @@ public class BanEventEntity
     public DateTime EventTimestampUtc { get; set; }
     public DateTime ReceivedAtUtc { get; set; }
 
-    /// <summary>Raw serialized event args from DSharpPlus for debugging</summary>
     public string? RawEventJson { get; set; }
 }

--- a/src/DiscordEventService/Data/Entities/Events/ChannelEventEntity.cs
+++ b/src/DiscordEventService/Data/Entities/Events/ChannelEventEntity.cs
@@ -24,6 +24,5 @@ public class ChannelEventEntity
     public DateTime EventTimestampUtc { get; set; }
     public DateTime ReceivedAtUtc { get; set; }
 
-    /// <summary>Raw serialized event args from DSharpPlus for debugging</summary>
     public string? RawEventJson { get; set; }
 }

--- a/src/DiscordEventService/Data/Entities/Events/EmojiEventEntity.cs
+++ b/src/DiscordEventService/Data/Entities/Events/EmojiEventEntity.cs
@@ -12,6 +12,5 @@ public class EmojiEventEntity
     public DateTime EventTimestampUtc { get; set; }
     public DateTime ReceivedAtUtc { get; set; }
 
-    /// <summary>Raw serialized event args from DSharpPlus for debugging</summary>
     public string? RawEventJson { get; set; }
 }

--- a/src/DiscordEventService/Data/Entities/Events/FailedEventEntity.cs
+++ b/src/DiscordEventService/Data/Entities/Events/FailedEventEntity.cs
@@ -2,94 +2,46 @@ using System.ComponentModel.DataAnnotations;
 
 namespace DiscordEventService.Data.Entities.Events;
 
-/// <summary>
-/// Dead-letter table for Discord events that failed to process.
-/// Allows investigation and potential replay of failed events.
-/// </summary>
 public class FailedEventEntity
 {
     public Guid Id { get; set; }
 
-    /// <summary>
-    /// The type of event that failed (e.g., "MessageCreated", "VoiceStateUpdated")
-    /// </summary>
     [Required]
     [MaxLength(100)]
     public string EventType { get; set; } = string.Empty;
 
-    /// <summary>
-    /// The handler class that failed to process the event
-    /// </summary>
     [Required]
     [MaxLength(200)]
     public string HandlerName { get; set; } = string.Empty;
 
-    /// <summary>
-    /// Guild ID if applicable
-    /// </summary>
     public ulong? GuildDiscordId { get; set; }
 
-    /// <summary>
-    /// Channel ID if applicable
-    /// </summary>
     public ulong? ChannelDiscordId { get; set; }
 
-    /// <summary>
-    /// User ID if applicable
-    /// </summary>
     public ulong? UserDiscordId { get; set; }
 
-    /// <summary>
-    /// The serialized event args for potential replay
-    /// </summary>
+    // Serialized event args retained for potential replay.
     public string? EventJson { get; set; }
 
-    /// <summary>
-    /// The exception type that caused the failure
-    /// </summary>
     [Required]
     [MaxLength(500)]
     public string ExceptionType { get; set; } = string.Empty;
 
-    /// <summary>
-    /// The exception message
-    /// </summary>
     [Required]
     public string ExceptionMessage { get; set; } = string.Empty;
 
-    /// <summary>
-    /// Full stack trace for debugging
-    /// </summary>
     public string? StackTrace { get; set; }
 
-    /// <summary>
-    /// Number of times this event has been retried
-    /// </summary>
     public int RetryCount { get; set; }
 
-    /// <summary>
-    /// When the failure occurred
-    /// </summary>
     public DateTime FailedAtUtc { get; set; } = DateTime.UtcNow;
 
-    /// <summary>
-    /// When the event was originally received
-    /// </summary>
     public DateTime EventReceivedAtUtc { get; set; }
 
-    /// <summary>
-    /// Whether this failed event has been acknowledged/resolved
-    /// </summary>
     public bool IsResolved { get; set; }
 
-    /// <summary>
-    /// When the event was resolved (if applicable)
-    /// </summary>
     public DateTime? ResolvedAtUtc { get; set; }
 
-    /// <summary>
-    /// Notes about resolution
-    /// </summary>
     public string? ResolutionNotes { get; set; }
 
     public Guid? CorrelationId { get; set; }

--- a/src/DiscordEventService/Data/Entities/Events/GuildEventEntity.cs
+++ b/src/DiscordEventService/Data/Entities/Events/GuildEventEntity.cs
@@ -23,6 +23,5 @@ public class GuildEventEntity
     public DateTime EventTimestampUtc { get; set; }
     public DateTime ReceivedAtUtc { get; set; }
 
-    /// <summary>Raw serialized event args from DSharpPlus for debugging</summary>
     public string? RawEventJson { get; set; }
 }

--- a/src/DiscordEventService/Data/Entities/Events/GuildMembersChunkEventEntity.cs
+++ b/src/DiscordEventService/Data/Entities/Events/GuildMembersChunkEventEntity.cs
@@ -10,21 +10,16 @@ public class GuildMembersChunkEventEntity
     public int ChunkCount { get; set; }
     public int MemberCount { get; set; }
 
-    // JSON array of member IDs received in this chunk
     public string? MemberIdsJson { get; set; }
 
-    // JSON array of presence data if requested
     public string? PresencesJson { get; set; }
 
-    // Nonce used to identify the request
     public string? Nonce { get; set; }
 
-    // JSON array of members that were not found (if querying specific users)
     public string? NotFoundIdsJson { get; set; }
 
     public DateTime EventTimestampUtc { get; set; }
     public DateTime ReceivedAtUtc { get; set; }
 
-    /// <summary>Raw serialized event args from DSharpPlus for debugging</summary>
     public string? RawEventJson { get; set; }
 }

--- a/src/DiscordEventService/Data/Entities/Events/IntegrationEventEntity.cs
+++ b/src/DiscordEventService/Data/Entities/Events/IntegrationEventEntity.cs
@@ -22,6 +22,5 @@ public class IntegrationEventEntity
     public DateTime EventTimestampUtc { get; set; }
     public DateTime ReceivedAtUtc { get; set; }
 
-    /// <summary>Raw serialized event args from DSharpPlus for debugging</summary>
     public string? RawEventJson { get; set; }
 }

--- a/src/DiscordEventService/Data/Entities/Events/InviteEventEntity.cs
+++ b/src/DiscordEventService/Data/Entities/Events/InviteEventEntity.cs
@@ -23,6 +23,5 @@ public class InviteEventEntity
     public DateTime EventTimestampUtc { get; set; }
     public DateTime ReceivedAtUtc { get; set; }
 
-    /// <summary>Raw serialized event args from DSharpPlus for debugging</summary>
     public string? RawEventJson { get; set; }
 }

--- a/src/DiscordEventService/Data/Entities/Events/MemberEventEntity.cs
+++ b/src/DiscordEventService/Data/Entities/Events/MemberEventEntity.cs
@@ -31,10 +31,10 @@ public class MemberEventEntity
     public bool? IsDeafenedBefore { get; set; }
     public bool? IsDeafenedAfter { get; set; }
     public string? BanReason { get; set; }
-    /// <summary>For Joined events, populated from Member.JoinedAt. For Left/Updated/Banned/Unbanned, DSharpPlus does not expose a per-event timestamp; equals ReceivedAtUtc by design.</summary>
+    // For Joined, from Member.JoinedAt. For Left/Updated/Banned/Unbanned, DSharpPlus exposes no per-event
+    // timestamp; equals ReceivedAtUtc by design.
     public DateTime EventTimestampUtc { get; set; }
     public DateTime ReceivedAtUtc { get; set; }
 
-    /// <summary>Raw serialized event args from DSharpPlus for debugging</summary>
     public string? RawEventJson { get; set; }
 }

--- a/src/DiscordEventService/Data/Entities/Events/MessageEventEntity.cs
+++ b/src/DiscordEventService/Data/Entities/Events/MessageEventEntity.cs
@@ -27,6 +27,5 @@ public class MessageEventEntity
     public DateTime EventTimestampUtc { get; set; }
     public DateTime ReceivedAtUtc { get; set; }
 
-    /// <summary>Raw serialized event args from DSharpPlus for debugging</summary>
     public string? RawEventJson { get; set; }
 }

--- a/src/DiscordEventService/Data/Entities/Events/PinEventEntity.cs
+++ b/src/DiscordEventService/Data/Entities/Events/PinEventEntity.cs
@@ -10,6 +10,5 @@ public class PinEventEntity
     public DateTime EventTimestampUtc { get; set; }
     public DateTime ReceivedAtUtc { get; set; }
 
-    /// <summary>Raw serialized event args from DSharpPlus for debugging</summary>
     public string? RawEventJson { get; set; }
 }

--- a/src/DiscordEventService/Data/Entities/Events/PollEventEntity.cs
+++ b/src/DiscordEventService/Data/Entities/Events/PollEventEntity.cs
@@ -19,6 +19,5 @@ public class PollEventEntity
     public DateTime EventTimestampUtc { get; set; }
     public DateTime ReceivedAtUtc { get; set; }
 
-    /// <summary>Raw serialized event args from DSharpPlus for debugging</summary>
     public string? RawEventJson { get; set; }
 }

--- a/src/DiscordEventService/Data/Entities/Events/PresenceEventEntity.cs
+++ b/src/DiscordEventService/Data/Entities/Events/PresenceEventEntity.cs
@@ -27,10 +27,9 @@ public class PresenceEventEntity
     public string? ActivitiesBeforeJson { get; set; }
     public string? ActivitiesAfterJson { get; set; }
 
-    /// <summary>DSharpPlus does not expose a per-event timestamp for presence updates; equals ReceivedAtUtc by design.</summary>
+    // DSharpPlus does not expose a per-event timestamp for presence updates; equals ReceivedAtUtc by design.
     public DateTime EventTimestampUtc { get; set; }
     public DateTime ReceivedAtUtc { get; set; }
 
-    /// <summary>Raw serialized event args from DSharpPlus for debugging</summary>
     public string? RawEventJson { get; set; }
 }

--- a/src/DiscordEventService/Data/Entities/Events/RawEventLogEntity.cs
+++ b/src/DiscordEventService/Data/Entities/Events/RawEventLogEntity.cs
@@ -2,57 +2,30 @@ using System.ComponentModel.DataAnnotations;
 
 namespace DiscordEventService.Data.Entities.Events;
 
-/// <summary>
-/// Stores raw JSON of all Discord events for debugging and future data extraction.
-/// </summary>
 public class RawEventLogEntity
 {
     public Guid Id { get; set; }
 
-    /// <summary>
-    /// The type of event (e.g., "MessageCreated", "PresenceUpdated", "VoiceStateUpdated")
-    /// </summary>
     [Required]
     [MaxLength(100)]
     public string EventType { get; set; } = string.Empty;
 
-    /// <summary>
-    /// Guild ID if applicable (0 for DM events)
-    /// </summary>
     public ulong GuildDiscordId { get; set; }
 
-    /// <summary>
-    /// Channel ID if applicable
-    /// </summary>
     public ulong? ChannelDiscordId { get; set; }
 
-    /// <summary>
-    /// User ID if applicable (the user who triggered the event)
-    /// </summary>
     public ulong? UserDiscordId { get; set; }
 
-    /// <summary>
-    /// The full serialized event args object from DSharpPlus
-    /// </summary>
     [Required]
     public string EventJson { get; set; } = string.Empty;
 
-    /// <summary>
-    /// Size of the JSON in bytes (for monitoring storage)
-    /// </summary>
     public int JsonSizeBytes { get; set; }
 
-    /// <summary>
-    /// When the event was received
-    /// </summary>
     public DateTime ReceivedAtUtc { get; set; } = DateTime.UtcNow;
 
     public Guid? CorrelationId { get; set; }
 
-    /// <summary>
-    /// True when <see cref="EventJson"/> is a diagnostic stub written because the event args
-    /// could not be serialized — the original payload is unrecoverable, so this row must be
-    /// excluded from replay. Queryable marker; supersedes matching the stub's error string.
-    /// </summary>
+    // True when EventJson is a diagnostic stub written because the event args could not be
+    // serialized — the original payload is unrecoverable, so this row must be excluded from replay.
     public bool SerializationFailed { get; set; }
 }

--- a/src/DiscordEventService/Data/Entities/Events/ReactionEventEntity.cs
+++ b/src/DiscordEventService/Data/Entities/Events/ReactionEventEntity.cs
@@ -21,10 +21,9 @@ public class ReactionEventEntity
     public bool IsAnimated { get; set; }
     public bool IsBurst { get; set; }
     public ReactionEventType EventType { get; set; }
-    /// <summary>DSharpPlus does not expose a per-event timestamp for reactions; equals ReceivedAtUtc by design.</summary>
+    // DSharpPlus does not expose a per-event timestamp for reactions; equals ReceivedAtUtc by design.
     public DateTime EventTimestampUtc { get; set; }
     public DateTime ReceivedAtUtc { get; set; }
 
-    /// <summary>Raw serialized event args from DSharpPlus for debugging</summary>
     public string? RawEventJson { get; set; }
 }

--- a/src/DiscordEventService/Data/Entities/Events/RoleEventEntity.cs
+++ b/src/DiscordEventService/Data/Entities/Events/RoleEventEntity.cs
@@ -19,10 +19,9 @@ public class RoleEventEntity
     public int? ColorAfter { get; set; }
     public long? PermissionsBefore { get; set; }
     public long? PermissionsAfter { get; set; }
-    /// <summary>DSharpPlus does not expose a per-event timestamp for role events; equals ReceivedAtUtc by design.</summary>
+    // DSharpPlus does not expose a per-event timestamp for role events; equals ReceivedAtUtc by design.
     public DateTime EventTimestampUtc { get; set; }
     public DateTime ReceivedAtUtc { get; set; }
 
-    /// <summary>Raw serialized event args from DSharpPlus for debugging</summary>
     public string? RawEventJson { get; set; }
 }

--- a/src/DiscordEventService/Data/Entities/Events/ScheduledEventEntity.cs
+++ b/src/DiscordEventService/Data/Entities/Events/ScheduledEventEntity.cs
@@ -33,6 +33,6 @@ public class ScheduledEventEntity
     public DateTime EventTimestampUtc { get; set; }
     public DateTime ReceivedAtUtc { get; set; }
 
-    /// <summary>Raw serialized event args from DSharpPlus for debugging</summary>
+    // Raw serialized event args from DSharpPlus for debugging
     public string? RawEventJson { get; set; }
 }

--- a/src/DiscordEventService/Data/Entities/Events/StageInstanceEventEntity.cs
+++ b/src/DiscordEventService/Data/Entities/Events/StageInstanceEventEntity.cs
@@ -23,6 +23,6 @@ public class StageInstanceEventEntity
     public DateTime EventTimestampUtc { get; set; }
     public DateTime ReceivedAtUtc { get; set; }
 
-    /// <summary>Raw serialized event args from DSharpPlus for debugging</summary>
+    // Raw serialized event args from DSharpPlus for debugging.
     public string? RawEventJson { get; set; }
 }

--- a/src/DiscordEventService/Data/Entities/Events/StickerEventEntity.cs
+++ b/src/DiscordEventService/Data/Entities/Events/StickerEventEntity.cs
@@ -12,6 +12,5 @@ public class StickerEventEntity
     public DateTime EventTimestampUtc { get; set; }
     public DateTime ReceivedAtUtc { get; set; }
 
-    /// <summary>Raw serialized event args from DSharpPlus for debugging</summary>
     public string? RawEventJson { get; set; }
 }

--- a/src/DiscordEventService/Data/Entities/Events/ThreadEventEntity.cs
+++ b/src/DiscordEventService/Data/Entities/Events/ThreadEventEntity.cs
@@ -25,6 +25,5 @@ public class ThreadEventEntity
     public DateTime EventTimestampUtc { get; set; }
     public DateTime ReceivedAtUtc { get; set; }
 
-    /// <summary>Raw serialized event args from DSharpPlus for debugging</summary>
     public string? RawEventJson { get; set; }
 }

--- a/src/DiscordEventService/Data/Entities/Events/ThreadSyncEventEntity.cs
+++ b/src/DiscordEventService/Data/Entities/Events/ThreadSyncEventEntity.cs
@@ -6,21 +6,16 @@ public class ThreadSyncEventEntity
 
     public ulong GuildDiscordId { get; set; }
 
-    // Number of threads synced
     public int ThreadCount { get; set; }
 
-    // JSON array of thread IDs that were synced
     public string? ThreadIdsJson { get; set; }
 
-    // JSON array of channel IDs whose threads are being synced
     public string? ChannelIdsJson { get; set; }
 
-    // JSON array of thread member objects
     public string? MembersJson { get; set; }
 
     public DateTime EventTimestampUtc { get; set; }
     public DateTime ReceivedAtUtc { get; set; }
 
-    /// <summary>Raw serialized event args from DSharpPlus for debugging</summary>
     public string? RawEventJson { get; set; }
 }

--- a/src/DiscordEventService/Data/Entities/Events/TypingEventEntity.cs
+++ b/src/DiscordEventService/Data/Entities/Events/TypingEventEntity.cs
@@ -10,6 +10,6 @@ public class TypingEventEntity
     public DateTime StartedAt { get; set; }
     public DateTime ReceivedAtUtc { get; set; }
 
-    /// <summary>Raw serialized event args from DSharpPlus for debugging</summary>
+    // Raw serialized event args from DSharpPlus for debugging
     public string? RawEventJson { get; set; }
 }

--- a/src/DiscordEventService/Data/Entities/Events/VoiceServerEventEntity.cs
+++ b/src/DiscordEventService/Data/Entities/Events/VoiceServerEventEntity.cs
@@ -15,6 +15,6 @@ public class VoiceServerEventEntity
     public DateTime EventTimestampUtc { get; set; }
     public DateTime ReceivedAtUtc { get; set; }
 
-    /// <summary>Raw serialized event args from DSharpPlus for debugging</summary>
+    // Raw serialized event args from DSharpPlus for debugging.
     public string? RawEventJson { get; set; }
 }

--- a/src/DiscordEventService/Data/Entities/Events/VoiceStateEventEntity.cs
+++ b/src/DiscordEventService/Data/Entities/Events/VoiceStateEventEntity.cs
@@ -36,10 +36,9 @@ public class VoiceStateEventEntity
     public bool IsSuppressed { get; set; }
 
     public string? SessionId { get; set; }
-    /// <summary>DSharpPlus does not expose a per-event timestamp for voice state updates; equals ReceivedAtUtc by design.</summary>
+    // DSharpPlus does not expose a per-event timestamp for voice state updates; equals ReceivedAtUtc by design.
     public DateTime EventTimestampUtc { get; set; }
     public DateTime ReceivedAtUtc { get; set; }
 
-    /// <summary>Raw serialized event args from DSharpPlus for debugging</summary>
     public string? RawEventJson { get; set; }
 }

--- a/src/DiscordEventService/Data/Entities/Events/WebhookEventEntity.cs
+++ b/src/DiscordEventService/Data/Entities/Events/WebhookEventEntity.cs
@@ -9,6 +9,5 @@ public class WebhookEventEntity
     public DateTime EventTimestampUtc { get; set; }
     public DateTime ReceivedAtUtc { get; set; }
 
-    /// <summary>Raw serialized event args from DSharpPlus for debugging</summary>
     public string? RawEventJson { get; set; }
 }

--- a/src/DiscordEventService/Dtos/EntityDtos.cs
+++ b/src/DiscordEventService/Dtos/EntityDtos.cs
@@ -1,9 +1,5 @@
 namespace DiscordEventService.Dtos;
 
-// Typed, hand-crafted projections for the rich entity browser. Snowflakes are
-// ulong and serialize as strings via the global converter; enums are pre-decoded
-// to their names. Joins are core-to-core by Guid FK.
-
 public sealed record UserListDto(
     Guid Id,
     ulong DiscordId,

--- a/src/DiscordEventService/Dtos/ExplorerDtos.cs
+++ b/src/DiscordEventService/Dtos/ExplorerDtos.cs
@@ -2,7 +2,6 @@ using DiscordEventService.Infrastructure;
 
 namespace DiscordEventService.Dtos;
 
-/// <summary>One explorable table in the generic schema explorer.</summary>
 public sealed record TableInfoDto(
     string Name,
     string DisplayName,
@@ -10,7 +9,6 @@ public sealed record TableInfoDto(
     long RowCount,
     bool Populated);
 
-/// <summary>Column metadata that drives client-side rendering of explorer rows.</summary>
 public sealed record ColumnMetadataDto(
     string Name,
     string Kind,
@@ -18,7 +16,7 @@ public sealed record ColumnMetadataDto(
     bool IsNullable,
     IReadOnlyList<EnumValueDto>? EnumValues)
 {
-    public static ColumnMetadataDto From(ColumnMeta meta) => new(
+    public static ColumnMetadataDto From(ColumnMeta meta) => new ColumnMetadataDto(
         meta.Name,
         // camelCase the enum kind so it lands as e.g. "snowflake", "timestamp" in JSON.
         char.ToLowerInvariant(meta.Kind.ToString()[0]) + meta.Kind.ToString()[1..],

--- a/src/DiscordEventService/Dtos/PagedResult.cs
+++ b/src/DiscordEventService/Dtos/PagedResult.cs
@@ -1,6 +1,5 @@
 namespace DiscordEventService.Dtos;
 
-/// <summary>Offset-paginated result envelope shared by the explorer and entity endpoints.</summary>
 public sealed record PagedResult<T>(
     IReadOnlyList<T> Items,
     long TotalCount,

--- a/src/DiscordEventService/Dtos/RawEventDtos.cs
+++ b/src/DiscordEventService/Dtos/RawEventDtos.cs
@@ -2,7 +2,6 @@ using System.Text.Json;
 
 namespace DiscordEventService.Dtos;
 
-/// <summary>Lightweight raw-event row (no payload) for the explorer grid.</summary>
 public sealed record RawEventSummaryDto(
     Guid Id,
     string EventType,
@@ -13,7 +12,6 @@ public sealed record RawEventSummaryDto(
     int JsonSizeBytes,
     bool SerializationFailed);
 
-/// <summary>A single raw event with its full parsed payload.</summary>
 public sealed record RawEventDetailDto(
     Guid Id,
     string EventType,
@@ -26,5 +24,4 @@ public sealed record RawEventDetailDto(
     Guid? CorrelationId,
     JsonElement Payload);
 
-/// <summary>An event type with its total count, for the explorer's filter dropdown.</summary>
 public sealed record RawEventTypeDto(string EventType, int Count);

--- a/src/DiscordEventService/Dtos/StatsDtos.cs
+++ b/src/DiscordEventService/Dtos/StatsDtos.cs
@@ -1,30 +1,22 @@
 namespace DiscordEventService.Dtos;
 
-// Stats aggregation results. Time buckets are computed in guild-local time
-// (Europe/Warsaw) server-side. Snowflakes are ulong (serialize as strings).
-
-// Volume & trends
 public sealed record VolumeDailyDto(string Day, long Count);
 public sealed record VolumeByTypeDto(string EventType, long Count);
 public sealed record VolumeHourlyDto(int Hour, long Count);
 
-// People
 public sealed record UserStatDto(string? Username, ulong UserDiscordId, long Count, string? AvatarHash);
 public sealed record VoiceStatDto(string? Username, ulong UserDiscordId, long Minutes, string? AvatarHash);
 
-// Places
 public sealed record ChannelActivityDto(
     string ChannelName,
     ulong ChannelDiscordId,
     long MessageCount,
     long ReactionCount);
 
-// Behavior
 public sealed record EmojiStatDto(string EmoteName, ulong? EmoteDiscordId, bool IsCustom, long Count);
 public sealed record ActivityStatDto(string Name, long Count);
 public sealed record HeatmapCellDto(int DayOfWeek, int Hour, long Count);
 
-// Overview (home dashboard)
 public sealed record WindowCountsDto(long Today, long Week, long Month, long Total);
 public sealed record DailyPointDto(string Day, long Count);
 
@@ -42,8 +34,6 @@ public sealed record OverviewDto(
     IReadOnlyList<DailyPointDto> MessagesDaily,
     IReadOnlyList<EmojiStatDto> TopEmojis);
 
-// ---- Guild (server header) ----
-
 public sealed record GuildOnlineDto(ulong UserDiscordId, string? Username, string? AvatarHash, string Status);
 
 public sealed record GuildDto(
@@ -56,11 +46,7 @@ public sealed record GuildDto(
     DateTime? EventSpanStartUtc,
     IReadOnlyList<GuildOnlineDto> Online);
 
-// ---- Community (windowed stats + leaderboards) ----
-
-// A single metric: value in the current window, value in the immediately
-// preceding equal-length window (null for range=all), and a dense daily series
-// spanning the current window (oldest -> newest).
+// Prev is the immediately preceding equal-length window (null for range=all); Spark is a dense daily series, oldest -> newest.
 public sealed record CommunityMetricDto(long Value, long? Prev, IReadOnlyList<long> Spark);
 
 public sealed record CommunityLeaderEntryDto(string? Username, ulong UserDiscordId, string? AvatarHash, long Value);
@@ -86,8 +72,6 @@ public sealed record CommunityDto(
     CommunityMetricsDto Metrics,
     CommunityLeaderboardsDto Leaderboards);
 
-// ---- Spotify ----
-
 public sealed record SpotifyNowPlayingDto(
     ulong UserDiscordId,
     string? Username,
@@ -104,8 +88,6 @@ public sealed record SpotifyTrackDto(string Track, string? Artist, string? Album
 public sealed record SpotifyDto(
     IReadOnlyList<SpotifyNowPlayingDto> NowPlaying,
     IReadOnlyList<SpotifyTrackDto> TopTracks);
-
-// ---- People profile ----
 
 public sealed record ProfileFavoriteEmoteDto(string EmoteName, ulong? EmoteDiscordId, bool IsCustom);
 

--- a/src/DiscordEventService/Dtos/TimelineDtos.cs
+++ b/src/DiscordEventService/Dtos/TimelineDtos.cs
@@ -2,7 +2,6 @@ using System.Text.Json;
 
 namespace DiscordEventService.Dtos;
 
-/// <summary>One entry in the unified activity feed (a row of raw_event_logs).</summary>
 public sealed record TimelineEventDto(
     Guid Id,
     string EventType,
@@ -14,7 +13,6 @@ public sealed record TimelineEventDto(
     bool SerializationFailed,
     JsonElement Payload);
 
-/// <summary>A keyset-paginated page of the timeline feed.</summary>
 public sealed record TimelinePage(
     IReadOnlyList<TimelineEventDto> Events,
     string? NextCursor,

--- a/src/DiscordEventService/Endpoints/BackfillEndpoints.cs
+++ b/src/DiscordEventService/Endpoints/BackfillEndpoints.cs
@@ -36,14 +36,11 @@ public static class BackfillEndpoints
         GuildBackfillOrchestrator orchestrator,
         DiscordDbContext db)
     {
-        // Check if backfill already in progress
         var existingInProgress = await db.BackfillCheckpoints
             .AnyAsync(c => c.GuildDiscordId == guildId && c.Status == BackfillStatus.InProgress);
 
         if (existingInProgress)
-        {
             return Results.BadRequest(new { error = "Backfill already in progress for this guild" });
-        }
 
         var options = request?.ToOptions() ?? BackfillOptions.Default;
         var jobId = orchestrator.StartBackfill(guildId, options);
@@ -81,8 +78,8 @@ public static class BackfillEndpoints
                 ErrorCount = c.ErrorCount,
                 LastError = c.LastError,
                 StartedAt = c.StartedAtUtc,
-                CompletedAt = c.CompletedAtUtc
-            }).ToList()
+                CompletedAt = c.CompletedAtUtc,
+            }).ToList(),
         });
     }
 
@@ -98,9 +95,7 @@ public static class BackfillEndpoints
         foreach (var checkpoint in inProgress)
         {
             if (!string.IsNullOrEmpty(checkpoint.HangfireJobId))
-            {
                 jobClient.Delete(checkpoint.HangfireJobId);
-            }
             checkpoint.Status = BackfillStatus.Cancelled;
         }
 
@@ -128,10 +123,10 @@ public record BackfillRequest
     public bool IncludeMessages { get; init; } = true;
     public bool IncludeReactions { get; init; } = true;
 
-    public BackfillOptions ToOptions() => new()
+    public BackfillOptions ToOptions() => new BackfillOptions
     {
         IncludeMessages = IncludeMessages,
-        IncludeReactions = IncludeReactions
+        IncludeReactions = IncludeReactions,
     };
 }
 

--- a/src/DiscordEventService/Endpoints/MemeBenchmarkEndpoints.cs
+++ b/src/DiscordEventService/Endpoints/MemeBenchmarkEndpoints.cs
@@ -46,7 +46,7 @@ public static class MemeBenchmarkEndpoints
         {
             HangfireJobId = jobId,
             SampleSize = size,
-            Models = openRouterOptions.Value.BenchmarkModels
+            Models = openRouterOptions.Value.BenchmarkModels,
         });
     }
 
@@ -76,7 +76,7 @@ public static class MemeBenchmarkEndpoints
         {
             HangfireJobId = jobId,
             SampleSize = size,
-            Models = openRouterOptions.Value.BenchmarkModels
+            Models = openRouterOptions.Value.BenchmarkModels,
         });
     }
 

--- a/src/DiscordEventService/Endpoints/MemeIndexEndpoints.cs
+++ b/src/DiscordEventService/Endpoints/MemeIndexEndpoints.cs
@@ -50,7 +50,7 @@ public static class MemeIndexEndpoints
             HangfireJobId = jobId,
             GuildId = guildId,
             Model = openRouterOptions.Value.Model,
-            MaxImagesPerRun = memeIndexOptions.Value.MaxImagesPerRun
+            MaxImagesPerRun = memeIndexOptions.Value.MaxImagesPerRun,
         });
     }
 
@@ -68,7 +68,7 @@ public static class MemeIndexEndpoints
                 ErrorCount = c.ErrorCount,
                 LastError = c.LastError,
                 StartedAt = c.StartedAtUtc,
-                CompletedAt = c.CompletedAtUtc
+                CompletedAt = c.CompletedAtUtc,
             })
             .ToListAsync();
 
@@ -85,7 +85,7 @@ public static class MemeIndexEndpoints
                 Pending = countsByStatus.GetValueOrDefault(MemeIndexStatus.Pending),
                 Indexed = countsByStatus.GetValueOrDefault(MemeIndexStatus.Indexed),
                 Failed = countsByStatus.GetValueOrDefault(MemeIndexStatus.Failed),
-                Skipped = countsByStatus.GetValueOrDefault(MemeIndexStatus.Skipped)
+                Skipped = countsByStatus.GetValueOrDefault(MemeIndexStatus.Skipped),
             }
         });
     }

--- a/src/DiscordEventService/Endpoints/OpsEndpoints.cs
+++ b/src/DiscordEventService/Endpoints/OpsEndpoints.cs
@@ -43,9 +43,7 @@ public static class OpsEndpoints
         DowntimeTrackerService tracker)
     {
         if (!Enum.IsDefined(type))
-        {
             return Results.BadRequest(new { error = $"Unknown downtime type: {(int)type}" });
-        }
 
         var result = await tracker.OpenDowntimeAsync(
             type,
@@ -56,7 +54,7 @@ public static class OpsEndpoints
         {
             Id = result.Id,
             Type = result.ActualType.ToString(),
-            Created = result.Created
+            Created = result.Created,
         });
     }
 
@@ -66,9 +64,7 @@ public static class OpsEndpoints
         CancellationToken ct)
     {
         if (!string.Equals(event_type, "GuildMemberUpdated", StringComparison.Ordinal))
-        {
             return Results.BadRequest(new { error = $"event_type '{event_type}' not yet supported" });
-        }
 
         var result = await svc.ReplayMemberUpdateOrphansAsync(ct);
         return Results.Ok(result);

--- a/src/DiscordEventService/Infrastructure/DateTimeQueryExtensions.cs
+++ b/src/DiscordEventService/Infrastructure/DateTimeQueryExtensions.cs
@@ -2,13 +2,7 @@ namespace DiscordEventService.Infrastructure;
 
 internal static class DateTimeQueryExtensions
 {
-    /// <summary>
-    /// Normalises a <see cref="DateTime"/> bound from a query string to a UTC instant.
-    /// Query-string binding yields <see cref="DateTimeKind.Unspecified"/> (no offset in
-    /// the text) or <see cref="DateTimeKind.Local"/> (text ended in 'Z'); writing either
-    /// to a <c>timestamptz</c> parameter throws in Npgsql 10. Local values are converted
-    /// (preserving the instant); unspecified values are assumed UTC.
-    /// </summary>
+    // Npgsql 10 throws when a non-UTC-kind DateTime is bound to a timestamptz param; normalise query-string bounds.
     public static DateTime ToUtcInstant(this DateTime value) => value.Kind switch
     {
         DateTimeKind.Utc => value,

--- a/src/DiscordEventService/Infrastructure/JsonPayload.cs
+++ b/src/DiscordEventService/Infrastructure/JsonPayload.cs
@@ -2,8 +2,7 @@ using System.Text.Json;
 
 namespace DiscordEventService.Infrastructure;
 
-/// <summary>Parses a stored jsonb payload to a <see cref="JsonElement"/>, falling back
-/// to a wrapper object for diagnostic stubs / malformed text rather than throwing.</summary>
+// Falls back to a wrapper object for diagnostic stubs / malformed jsonb rather than throwing.
 internal static class JsonPayload
 {
     public static JsonElement Parse(string json)

--- a/src/DiscordEventService/Infrastructure/PresenceStatus.cs
+++ b/src/DiscordEventService/Infrastructure/PresenceStatus.cs
@@ -2,14 +2,8 @@ using DSharpPlus.Entities;
 
 namespace DiscordEventService.Infrastructure;
 
-/// <summary>
-/// Derives a user's presence status from per-device DSharpPlus statuses. The
-/// <see cref="DiscordUserStatus"/> enum is NOT ordered by online-ness (Offline=0,
-/// Online=1, Idle=2, DoNotDisturb=4, Invisible=5; Invisible reads as offline), so the
-/// overall status is a client-status priority pick (online &gt; idle &gt; dnd &gt;
-/// offline), never a numeric max. Status names are the lowercase strings the dashboard
-/// and DTOs expect.
-/// </summary>
+// DiscordUserStatus is NOT ordered by online-ness (Offline=0, Online=1, Idle=2, DoNotDisturb=4,
+// Invisible=5), so overall status is a priority pick (online > idle > dnd > offline), never a max.
 internal static class PresenceStatus
 {
     public const string Online = "online";
@@ -17,10 +11,6 @@ internal static class PresenceStatus
     public const string Dnd = "dnd";
     public const string Offline = "offline";
 
-    /// <summary>
-    /// Aggregates a user's three device statuses into one by client-status priority —
-    /// not a numeric max, since the enum values are not ordered by activity.
-    /// </summary>
     public static string Overall(int desktop, int mobile, int web)
     {
         int[] devices = [desktop, mobile, web];
@@ -30,7 +20,7 @@ internal static class PresenceStatus
         return Offline;
     }
 
-    /// <summary>Sort key (lower = more active) for ordering a "who's online" list.</summary>
+    // Sort key (lower = more active) for ordering a "who's online" list.
     public static int Rank(string status) => status switch
     {
         Online => 0,

--- a/src/DiscordEventService/Infrastructure/ReactionEventQueryExtensions.cs
+++ b/src/DiscordEventService/Infrastructure/ReactionEventQueryExtensions.cs
@@ -4,12 +4,9 @@ namespace DiscordEventService.Infrastructure;
 
 internal static class ReactionEventQueryExtensions
 {
-    /// <summary>
-    /// Filters to reactions that are "present" on a message: Added (live) + Backfilled
-    /// (historical import). Removed/Cleared/EmojiCleared are excluded. Backfill imported
-    /// ~26k of these, so filtering to Added alone under-counts reactions ~30x. (This is
-    /// reactions-ever-added, not net-of-removals — fine for the stats views.)
-    /// </summary>
+    // Added (live) + Backfilled (historical import); Removed/Cleared/EmojiCleared excluded. Backfill imported
+    // ~26k Backfilled rows, so filtering to Added alone under-counts reactions ~30x. This is reactions-ever-added,
+    // not net-of-removals — fine for the stats views.
     public static IQueryable<ReactionEventEntity> WherePresent(this IQueryable<ReactionEventEntity> reactions) =>
         reactions.Where(r =>
             r.EventType == ReactionEventType.Added || r.EventType == ReactionEventType.Backfilled);

--- a/src/DiscordEventService/Infrastructure/SchemaCatalog.cs
+++ b/src/DiscordEventService/Infrastructure/SchemaCatalog.cs
@@ -3,10 +3,7 @@ using Microsoft.EntityFrameworkCore.Metadata;
 
 namespace DiscordEventService.Infrastructure;
 
-/// <summary>
-/// Logical type of a column, derived from EF model metadata. Drives both how the
-/// generic explorer coerces raw SQL values and how the frontend renders each cell.
-/// </summary>
+// Logical column type from EF metadata — drives both raw-SQL value coercion and frontend cell rendering.
 public enum ColumnKind
 {
     String,
@@ -46,22 +43,14 @@ public sealed class TableMeta
 
     public ColumnMeta? Column(string column) => ByName.GetValueOrDefault(column);
 
-    /// <summary>Stable default sort: the single-column PK if present, else the first column.</summary>
+    // Stable default sort: the single-column PK if present, else the first column.
     public string DefaultSortColumn =>
         Columns.FirstOrDefault(c => c.IsPrimaryKey)?.Name ?? Columns[0].Name;
 }
 
-/// <summary>
-/// Startup-cached whitelist of explorable tables and their columns, built from the
-/// EF Core model. This is the security boundary for the generic explorer: only table
-/// and column identifiers present here are ever emitted into SQL, and the emitted
-/// literal is the trusted model value — never client-supplied text.
-/// <para>
-/// Hangfire tables are not EF entities (Hangfire uses its own storage) so they never
-/// appear here; <c>__EFMigrationsHistory</c> is not an EF entity either, but is filtered
-/// defensively.
-/// </para>
-/// </summary>
+// Security boundary for the generic explorer: only table/column identifiers present here are ever emitted
+// into SQL, and the emitted literal is the trusted model value — never client-supplied text. Hangfire and
+// __EFMigrationsHistory are not EF entities so they never appear here (the latter filtered defensively).
 public sealed class SchemaCatalog
 {
     private readonly Dictionary<string, TableMeta> _tables;
@@ -80,15 +69,11 @@ public sealed class SchemaCatalog
         foreach (var entityType in model.GetEntityTypes())
         {
             if (entityType.IsOwned())
-            {
                 continue;
-            }
 
             var tableName = entityType.GetTableName();
             if (string.IsNullOrEmpty(tableName) || tableName == "__EFMigrationsHistory")
-            {
                 continue;
-            }
 
             var storeObject = StoreObjectIdentifier.Table(tableName, entityType.GetSchema());
             var pkColumns = entityType.FindPrimaryKey()?.Properties
@@ -101,9 +86,7 @@ public sealed class SchemaCatalog
             {
                 var columnName = property.GetColumnName(storeObject);
                 if (columnName is null)
-                {
                     continue;
-                }
 
                 var kind = DetermineKind(property);
                 columns.Add(new ColumnMeta(
@@ -115,9 +98,7 @@ public sealed class SchemaCatalog
             }
 
             if (columns.Count == 0)
-            {
                 continue;
-            }
 
             tables[tableName] = new TableMeta
             {
@@ -143,21 +124,15 @@ public sealed class SchemaCatalog
 
         var columnType = property.GetColumnType();
         if (columnType is not null && columnType.Contains("json", StringComparison.OrdinalIgnoreCase))
-        {
             return ColumnKind.Json;
-        }
 
         if (clrType == typeof(string)) return ColumnKind.String;
         if (clrType == typeof(int) || clrType == typeof(short) || clrType == typeof(byte)
             || clrType == typeof(sbyte) || clrType == typeof(uint) || clrType == typeof(ushort))
-        {
             return ColumnKind.Int;
-        }
         if (clrType == typeof(long)) return ColumnKind.Long;
         if (clrType == typeof(decimal) || clrType == typeof(double) || clrType == typeof(float))
-        {
             return ColumnKind.Number;
-        }
 
         return ColumnKind.Other;
     }

--- a/src/DiscordEventService/Infrastructure/SnowflakeJsonConverter.cs
+++ b/src/DiscordEventService/Infrastructure/SnowflakeJsonConverter.cs
@@ -4,13 +4,7 @@ using System.Text.Json.Serialization;
 
 namespace DiscordEventService.Infrastructure;
 
-/// <summary>
-/// Serializes Discord snowflakes (<see cref="ulong"/>) as JSON strings. Snowflakes
-/// exceed 2^53 and would lose precision if a browser parsed them as JS numbers, so
-/// the entire dashboard API emits them as quoted strings. Registered globally in
-/// <c>AddControllers().AddJsonOptions(...)</c>; also fires for boxed <c>ulong</c>
-/// values inside the generic explorer's <c>Dictionary&lt;string, object?&gt;</c> rows.
-/// </summary>
+// Snowflakes exceed 2^53 and would lose precision if a browser parsed them as JS numbers, so they're emitted as quoted strings.
 internal sealed class SnowflakeJsonConverter : JsonConverter<ulong>
 {
     public override ulong Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
@@ -25,7 +19,7 @@ internal sealed class SnowflakeJsonConverter : JsonConverter<ulong>
         => writer.WriteStringValue(value.ToString(CultureInfo.InvariantCulture));
 }
 
-/// <summary>Nullable counterpart to <see cref="SnowflakeJsonConverter"/>.</summary>
+// Nullable counterpart to SnowflakeJsonConverter — same 2^53 JS-precision rationale.
 internal sealed class NullableSnowflakeJsonConverter : JsonConverter<ulong?>
 {
     public override ulong? Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
@@ -39,21 +33,12 @@ internal sealed class NullableSnowflakeJsonConverter : JsonConverter<ulong?>
 
     public override void Write(Utf8JsonWriter writer, ulong? value, JsonSerializerOptions options)
     {
-        if (value.HasValue)
-        {
-            writer.WriteStringValue(value.Value.ToString(CultureInfo.InvariantCulture));
-        }
-        else
-        {
-            writer.WriteNullValue();
-        }
+        if (value.HasValue) writer.WriteStringValue(value.Value.ToString(CultureInfo.InvariantCulture));
+        else writer.WriteNullValue();
     }
 }
 
-/// <summary>
-/// Builds the <see cref="JsonSerializerOptions"/> the dashboard API uses, so tests can
-/// assert serialization (e.g. snowflake-as-string) through the exact same pipeline.
-/// </summary>
+// Builds the dashboard API's JsonSerializerOptions so tests can assert serialization through the exact same pipeline.
 internal static class DashboardJson
 {
     public static void Configure(JsonSerializerOptions options)

--- a/src/DiscordEventService/Jobs/BackfillJobBase.cs
+++ b/src/DiscordEventService/Jobs/BackfillJobBase.cs
@@ -3,11 +3,9 @@ using DiscordEventService.Data.Entities.Core;
 
 namespace DiscordEventService.Jobs;
 
-/// <summary>
-/// Per-item progress helpers shared by every backfill job. The job lifecycle (scope, checkpoint
-/// get-or-create, status transitions) lives in <see cref="BackfillJobExecutor"/>; only the
-/// mid-loop progress/error book-keeping that runs inside a job's work delegate stays here.
-/// </summary>
+// Per-item progress helpers shared by every backfill job. The job lifecycle (scope, checkpoint
+// get-or-create, status transitions) lives in BackfillJobExecutor; only the mid-loop progress/error
+// book-keeping that runs inside a job's work delegate stays here.
 public abstract class BackfillJobBase
 {
     protected abstract BackfillType BackfillType { get; }
@@ -20,26 +18,14 @@ public abstract class BackfillJobBase
         await db.SaveChangesAsync();
     }
 
-    protected async Task SaveProgressAsync(DiscordDbContext db, BackfillCheckpointEntity checkpoint)
-    {
-        await db.SaveChangesAsync();
-    }
+    protected Task SaveProgressAsync(DiscordDbContext db, BackfillCheckpointEntity checkpoint) => db.SaveChangesAsync();
 
-    /// <summary>
-    /// Drives the per-item resume-cursor loop shared by the history jobs (Messages, Reactions):
-    /// skip to the channel a genuinely-interrupted run stopped on (<c>CurrentChannelId</c>, already
-    /// reset to null by <see cref="BackfillJobExecutor"/> after a terminal run), then walk the rest,
-    /// stamping <c>CurrentChannelId</c> per item and clearing the per-channel batch cursor
-    /// (<c>LastProcessedId</c>) only AFTER an item finishes — so the resume channel still sees its
-    /// saved batch cursor on entry. A per-item failure (non-cancellation) is recorded and the loop
-    /// continues with the next item; cancellation propagates to the executor's terminal handling.
-    /// <para>
-    /// <paramref name="items"/> MUST be in a stable, deterministic order across runs (the jobs
-    /// guarantee this via <c>OrderBy(c =&gt; c.Id)</c>); otherwise resume would skip the wrong items.
-    /// The per-batch <c>LastProcessedId</c> write stays inside <paramref name="processItem"/> — the
-    /// inner paging body is job-specific and not extracted here.
-    /// </para>
-    /// </summary>
+    // Drives the per-item resume-cursor loop shared by the history jobs (Messages, Reactions): skip to the
+    // channel a genuinely-interrupted run stopped on (CurrentChannelId, reset to null by the executor after a
+    // terminal run), then walk the rest, clearing the per-channel batch cursor (LastProcessedId) only AFTER an
+    // item finishes — so the resume channel still sees its saved batch cursor on entry.
+    // items MUST be in a stable, deterministic order across runs (jobs guarantee this via OrderBy(c => c.Id));
+    // otherwise resume would skip the wrong items.
     protected async Task IterateWithCheckpointAsync<T>(
         DiscordDbContext db,
         BackfillCheckpointEntity checkpoint,

--- a/src/DiscordEventService/Jobs/BackfillJobExecutor.cs
+++ b/src/DiscordEventService/Jobs/BackfillJobExecutor.cs
@@ -4,14 +4,8 @@ using Microsoft.EntityFrameworkCore;
 
 namespace DiscordEventService.Jobs;
 
-/// <summary>
-/// Owns the lifecycle every backfill job shares: a fresh DI scope + DbContext, checkpoint
-/// get-or-create, the InProgress flip (with resume-cursor reset), and the four terminal
-/// transitions — Completed, short-circuit→Failed, cancelled→Failed (no rethrow), faulted→Failed
-/// (rethrow). Jobs supply only guild resolution + per-item work as a delegate, keeping
-/// <c>DiscordClient</c> out of the executor so its transitions are unit-testable against a real
-/// DbContext with no gateway.
-/// </summary>
+// Jobs supply only per-item work as a delegate, keeping DiscordClient out of the executor so its
+// checkpoint transitions are unit-testable against a real DbContext with no gateway.
 public sealed class BackfillJobExecutor(
     IServiceScopeFactory scopeFactory,
     ILogger<BackfillJobExecutor> logger)

--- a/src/DiscordEventService/Jobs/GuildBackfillOrchestrator.cs
+++ b/src/DiscordEventService/Jobs/GuildBackfillOrchestrator.cs
@@ -9,12 +9,8 @@ public class GuildBackfillOrchestrator(
     public string StartBackfill(ulong guildId, BackfillOptions? options = null)
         => EnqueueChain(guildId, options ?? BackfillOptions.Default, afterTimestampUtc: null);
 
-    /// <summary>
-    /// Enqueues the full backfill chain (Roles → Emojis → Stickers → Channels →
-    /// Members → optional Messages → optional Reactions), passing afterTimestampUtc
-    /// to Messages/Reactions so they stop scrolling once they're older than the
-    /// window. Used by reconnect-driven and historical-gap-driven backfills.
-    /// </summary>
+    // afterTimestampUtc stops Messages/Reactions scrolling once older than the window;
+    // used by reconnect-driven and historical-gap-driven backfills.
     public string EnqueueBackfillFrom(ulong guildId, DateTime afterTimestampUtc, BackfillOptions? options = null)
         => EnqueueChain(guildId, options ?? BackfillOptions.Default, afterTimestampUtc);
 
@@ -39,7 +35,7 @@ public class GuildBackfillOrchestrator(
         var membersJobId = backgroundJobClient.ContinueJobWith<MembersBackfillJob>(
             channelsJobId, j => j.ExecuteAsync(guildId, CancellationToken.None));
 
-        string finalJobId = membersJobId;
+        var finalJobId = membersJobId;
 
         if (options.IncludeMessages)
         {
@@ -67,5 +63,5 @@ public record BackfillOptions
     public bool IncludeMessages { get; init; } = true;
     public bool IncludeReactions { get; init; } = true;
 
-    public static BackfillOptions Default => new();
+    public static BackfillOptions Default => new BackfillOptions();
 }

--- a/src/DiscordEventService/Jobs/HealthCheckJob.cs
+++ b/src/DiscordEventService/Jobs/HealthCheckJob.cs
@@ -17,8 +17,8 @@ public class HealthCheckJob(
     private static DateTime _lastIngestStallAlert = DateTime.MinValue;
     private static DateTime _lastEventRatioAlert = DateTime.MinValue;
     private static DateTime _lastCrashLoopAlert = DateTime.MinValue;
-    private static readonly Dictionary<string, int> _eventRatioDropStreaks = new Dictionary<string, int>();
-    private static readonly object _lock = new();
+    private static readonly Dictionary<string, int> _eventRatioDropStreaks = [];
+    private static readonly object _lock = new object();
     private static readonly TimeSpan WebhookTimeout = TimeSpan.FromSeconds(10);
 
     public async Task ExecuteAsync()

--- a/src/DiscordEventService/Jobs/MembersBackfillJob.cs
+++ b/src/DiscordEventService/Jobs/MembersBackfillJob.cs
@@ -1,6 +1,7 @@
 using DiscordEventService.Data.Entities.Core;
 using DiscordEventService.Services;
 using DSharpPlus;
+using DSharpPlus.Entities;
 using Microsoft.EntityFrameworkCore;
 
 namespace DiscordEventService.Jobs;
@@ -25,11 +26,9 @@ public sealed class MembersBackfillJob(
 
             // Get all members - requires GUILD_MEMBERS privileged intent
             // DSharpPlus v5 returns IAsyncEnumerable
-            var membersList = new List<DSharpPlus.Entities.DiscordMember>();
+            List<DiscordMember> membersList = [];
             await foreach (var member in guild.GetAllMembersAsync())
-            {
                 membersList.Add(member);
-            }
 
             ctx.Checkpoint.TotalCount = membersList.Count;
             await ctx.Db.SaveChangesAsync(cancellationToken);
@@ -49,7 +48,6 @@ public sealed class MembersBackfillJob(
                     await RecordErrorAsync(ctx.Db, ctx.Checkpoint, ex);
                 }
 
-                // Save progress periodically (every 100 members)
                 if (ctx.Checkpoint.ProcessedCount % 100 == 0)
                     await ctx.Db.SaveChangesAsync(cancellationToken);
             }

--- a/src/DiscordEventService/Jobs/MemeBenchmarkJob.cs
+++ b/src/DiscordEventService/Jobs/MemeBenchmarkJob.cs
@@ -6,14 +6,6 @@ using Microsoft.Extensions.Options;
 
 namespace DiscordEventService.Jobs;
 
-// #219: runs a stratified sample of meme-channel images through each candidate
-// vision model and writes a side-by-side markdown report for the human model
-// pick. Deliberately stateless — no meme_index writes; that's §3 (#221).
-//
-// Two entry points: RunAsync samples from this instance's own DB (prod use);
-// RunFromFileAsync consumes a links file exported from the prod DB, so the
-// benchmark can run locally — stored URLs are revived via refresh-urls, no
-// guild access or gateway needed.
 public sealed class MemeBenchmarkJob(
     MemeSampleService sampleService,
     AttachmentUrlRefreshService urlRefreshService,
@@ -91,9 +83,7 @@ public sealed class MemeBenchmarkJob(
             items.Add(await BenchmarkOneAsync(sampleItem, models, freshUrls, cancellationToken));
 
             if (processed % 10 == 0)
-            {
                 logger.LogInformation("Meme benchmark progress: {Processed}/{Total} images", processed, sample.Count);
-            }
         }
 
         var run = new BenchmarkRun(startedUtc, DateTime.UtcNow, requestedSampleSize, models, items);
@@ -144,10 +134,8 @@ public sealed class MemeBenchmarkJob(
             cells.Add(new BenchmarkCell(model, result, stopwatch.Elapsed.TotalSeconds));
 
             if (result.Outcome == MemeAnalysisOutcome.Error)
-            {
                 logger.LogWarning("Benchmark cell failed: message {MessageId}, model {Model}: {Error}",
                     sampleItem.MessageDiscordId, model, result.Error);
-            }
 
             await Task.Delay(TimeSpan.FromMilliseconds(openRouterOptions.Value.RequestDelayMs), cancellationToken);
         }

--- a/src/DiscordEventService/Jobs/MemeIndexSweepJob.cs
+++ b/src/DiscordEventService/Jobs/MemeIndexSweepJob.cs
@@ -7,15 +7,10 @@ using Microsoft.Extensions.Options;
 
 namespace DiscordEventService.Jobs;
 
-/// <summary>
-/// Weekly meme-index healing sweep (#222). The live MessageCreated hook indexes
-/// new memes within seconds; this catches what it misses — attachments posted
-/// during downtime, live-path enqueue failures, and Failed rows still under the
-/// attempt cap. Mirrors <see cref="PeriodicFullBackfillJob"/>: a parameterless
-/// coordinator that enqueues one per-guild job, skipping guilds whose meme
-/// indexing is already running. A clean week is a cheap no-op (one candidate
-/// query, zero model calls).
-/// </summary>
+// Weekly healing sweep: the live MessageCreated hook indexes new memes within
+// seconds; this catches what it misses — attachments posted during downtime,
+// live-path enqueue failures, and Failed rows still under the attempt cap.
+// Skips guilds whose meme indexing is already running.
 public sealed class MemeIndexSweepJob(
     IServiceScopeFactory scopeFactory,
     IBackgroundJobClient backgroundJobClient,

--- a/src/DiscordEventService/Jobs/MemeIndexingJob.cs
+++ b/src/DiscordEventService/Jobs/MemeIndexingJob.cs
@@ -7,18 +7,6 @@ using Microsoft.Extensions.Options;
 
 namespace DiscordEventService.Jobs;
 
-// #221: walks every image attachment in the configured meme channels and
-// produces Indexed meme rows. Purely DB-driven (binding comment on #221):
-// candidates come from messages.attachments_json, expired CDN URLs are
-// re-signed via attachments/refresh-urls — no channel-history pagination, no
-// gateway. Idempotent: terminal rows (Indexed/Skipped) are skipped on re-run,
-// Failed rows are retried. Not part of the weekly full-backfill chain.
-//
-// Three entry points (#222): ExecuteAsync is the operator-triggered backfill
-// (Failed retries uncapped — deliberate, see PR #228), ExecuteSweepAsync is the
-// weekly healing sweep (Failed retries capped so an autonomous recurring job
-// can't re-bill permanently-broken rows forever), and IndexMessageAsync is the
-// live single-message path enqueued by MessageEventHandler.
 public sealed class MemeIndexingJob(
     BackfillJobExecutor executor,
     IServiceScopeFactory scopeFactory,
@@ -34,12 +22,6 @@ public sealed class MemeIndexingJob(
     public Task ExecuteSweepAsync(ulong guildId, CancellationToken cancellationToken)
         => RunAsync(guildId, SweepMaxFailedAttempts, cancellationToken);
 
-    // #222 live path: index every image attachment of one freshly-posted
-    // message. No checkpoint — checkpoints are unique per (guild, type) and
-    // belong to the backfill/sweep runs; live jobs are small, frequent, and
-    // idempotent (terminal rows are skipped), so a Hangfire retry after a
-    // mid-run crash is safe and a concurrent backfill at worst costs one
-    // duplicate model call resolved by the unique attachment index.
     public async Task IndexMessageAsync(ulong guildId, ulong messageDiscordId, CancellationToken cancellationToken)
     {
         using var scope = scopeFactory.CreateScope();

--- a/src/DiscordEventService/Jobs/MessagesBackfillJob.cs
+++ b/src/DiscordEventService/Jobs/MessagesBackfillJob.cs
@@ -34,7 +34,6 @@ public sealed class MessagesBackfillJob(
             if (guildEntity is null)
                 return BackfillOutcome.ShortCircuit($"Guild {guildId} not found in database");
 
-            // Filter to text-based channels
             var textChannels = channels
                 .Where(c => c.Type is DSharpPlus.Entities.DiscordChannelType.Text
                          or DSharpPlus.Entities.DiscordChannelType.News
@@ -70,15 +69,13 @@ public sealed class MessagesBackfillJob(
         var channelEntity = await db.Channels.FirstOrDefaultAsync(c => c.DiscordId == channel.Id, cancellationToken);
 
         if (channelEntity is null)
-        {
             logger.LogWarning("Channel {ChannelId} not found in database, messages will have null channel FK", channel.Id);
-        }
 
-        ulong? beforeId = checkpoint.LastProcessedId;
-        bool hasMore = true;
-        int batchNum = 0;
-        int totalInserted = 0;
-        string exitReason = "unknown";
+        var beforeId = checkpoint.LastProcessedId;
+        var hasMore = true;
+        var batchNum = 0;
+        var totalInserted = 0;
+        var exitReason = "unknown";
 
         // #124 diagnostic: trace exactly why per-channel loops terminated at ~one batch
         // in auto-startup runs but went deep when manually triggered.
@@ -100,9 +97,7 @@ public sealed class MessagesBackfillJob(
 
                 messages = [];
                 await foreach (var msg in asyncMessages)
-                {
                     messages.Add(msg);
-                }
             }
             catch (DSharpPlus.Exceptions.UnauthorizedException ex)
             {
@@ -149,7 +144,6 @@ public sealed class MessagesBackfillJob(
 
                     var authorEntity = await db.Users.FirstOrDefaultAsync(u => u.DiscordId == message.Author.Id, cancellationToken);
 
-                    // Check if message exists
                     var exists = await db.Messages.AnyAsync(m => m.DiscordId == message.Id, cancellationToken);
                     if (!exists)
                     {

--- a/src/DiscordEventService/Jobs/PeriodicFullBackfillJob.cs
+++ b/src/DiscordEventService/Jobs/PeriodicFullBackfillJob.cs
@@ -4,14 +4,9 @@ using Microsoft.EntityFrameworkCore;
 
 namespace DiscordEventService.Jobs;
 
-/// <summary>
-/// Weekly safety-net backfill. Reconnect-backfill is capped to 2 days,
-/// so anything older needs this periodic sweep. Scoped to the last 2 weeks
-/// to avoid full-history crawls that take hours on large guilds.
-///
-/// Skips guilds with an InProgress checkpoint to avoid stepping on the
-/// reconnect path or the operator-triggered /api/backfill endpoint.
-/// </summary>
+// Reconnect-backfill is capped to 2 days, so anything older needs this periodic sweep;
+// skips guilds with an InProgress checkpoint to avoid stepping on the reconnect path or
+// the operator-triggered /api/backfill endpoint.
 public class PeriodicFullBackfillJob(
     IServiceScopeFactory scopeFactory,
     ILogger<PeriodicFullBackfillJob> logger)

--- a/src/DiscordEventService/Jobs/ReactionsBackfillJob.cs
+++ b/src/DiscordEventService/Jobs/ReactionsBackfillJob.cs
@@ -32,7 +32,6 @@ public sealed class ReactionsBackfillJob(
             if (guildEntity is null)
                 return BackfillOutcome.ShortCircuit($"Guild {guildId} not found in database");
 
-            // Get all text channels
             var textChannels = channels
                 .Where(c => c.Type is DiscordChannelType.Text
                          or DiscordChannelType.News
@@ -66,8 +65,8 @@ public sealed class ReactionsBackfillJob(
         CancellationToken cancellationToken)
     {
         const int messageBatchSize = 100;
-        ulong? beforeId = checkpoint.LastProcessedId;
-        bool hasMore = true;
+        var beforeId = checkpoint.LastProcessedId;
+        var hasMore = true;
 
         while (hasMore)
         {
@@ -82,9 +81,7 @@ public sealed class ReactionsBackfillJob(
 
                 messages = [];
                 await foreach (var msg in asyncMessages)
-                {
                     messages.Add(msg);
-                }
             }
             catch (DSharpPlus.Exceptions.UnauthorizedException ex)
             {
@@ -105,7 +102,6 @@ public sealed class ReactionsBackfillJob(
                 break;
             }
 
-            // Filter to messages with reactions
             var messagesWithReactions = messages
                 .Where(m => m.Reactions != null && m.Reactions.Count > 0)
                 .ToList();
@@ -128,7 +124,6 @@ public sealed class ReactionsBackfillJob(
                 }
             }
 
-            // Save all reactions from this batch
             beforeId = messages.Last().Id;
             checkpoint.LastProcessedId = beforeId;
             await db.SaveChangesAsync(cancellationToken);
@@ -166,7 +161,6 @@ public sealed class ReactionsBackfillJob(
 
                 await userService.UpsertUserAsync(user);
 
-                // Check if this reaction event already exists
                 var exists = await db.ReactionEvents.AnyAsync(r =>
                     r.MessageDiscordId == message.Id &&
                     r.UserDiscordId == user.Id &&

--- a/src/DiscordEventService/Program.cs
+++ b/src/DiscordEventService/Program.cs
@@ -20,10 +20,7 @@ using Microsoft.Extensions.Options;
 // Load .env from repo root (two levels up from project directory)
 var repoRoot = Path.GetFullPath(Path.Combine(AppContext.BaseDirectory, "..", "..", "..", "..", ".."));
 var envPath = Path.Combine(repoRoot, ".env");
-if (File.Exists(envPath))
-{
-    Env.Load(envPath);
-}
+if (File.Exists(envPath)) Env.Load(envPath);
 
 var builder = WebApplication.CreateBuilder(args);
 
@@ -38,7 +35,6 @@ builder.Host.UseDefaultServiceProvider(opts =>
     opts.ValidateScopes = builder.Environment.IsDevelopment();
 });
 
-// Configuration with validation
 builder.Services.AddOptions<DatabaseOptions>()
     .Bind(builder.Configuration.GetSection(DatabaseOptions.SectionName));
 
@@ -120,45 +116,34 @@ builder.Services.AddSingleton(rootSp =>
         services.AddMemoryCache();
     });
 
-    // Event handlers
     clientBuilder.ConfigureEventHandlers(b => b
-        // Messages & Reactions
         .AddEventHandlers<MessageEventHandler>(ServiceLifetime.Scoped)
         .AddEventHandlers<ReactionEventHandler>(ServiceLifetime.Scoped)
         .AddEventHandlers<PollEventHandler>(ServiceLifetime.Scoped)
         .AddEventHandlers<PinEventHandler>(ServiceLifetime.Scoped)
-        // Voice & Presence
         .AddEventHandlers<VoiceEventHandler>(ServiceLifetime.Scoped)
         .AddEventHandlers<VoiceServerEventHandler>(ServiceLifetime.Scoped)
         .AddEventHandlers<PresenceEventHandler>(ServiceLifetime.Scoped)
-        // Members & Bans
         .AddEventHandlers<MemberEventHandler>(ServiceLifetime.Scoped)
         .AddEventHandlers<BanEventHandler>(ServiceLifetime.Scoped)
         .AddEventHandlers<GuildMembersChunkHandler>(ServiceLifetime.Scoped)
-        // Guild updates
         .AddEventHandlers<GuildEventHandler>(ServiceLifetime.Scoped)
         .AddEventHandlers<GuildUpdateEventHandler>(ServiceLifetime.Scoped)
         .AddEventHandlers<EmojiEventHandler>(ServiceLifetime.Scoped)
         .AddEventHandlers<StickerEventHandler>(ServiceLifetime.Scoped)
-        // Channels, Roles & Threads
         .AddEventHandlers<ChannelEventHandler>(ServiceLifetime.Scoped)
         .AddEventHandlers<RoleEventHandler>(ServiceLifetime.Scoped)
         .AddEventHandlers<ThreadEventHandler>(ServiceLifetime.Scoped)
         .AddEventHandlers<ThreadSyncHandler>(ServiceLifetime.Scoped)
         .AddEventHandlers<StageInstanceEventHandler>(ServiceLifetime.Scoped)
-        // Scheduled Events & AutoMod
         .AddEventHandlers<ScheduledEventHandler>(ServiceLifetime.Scoped)
         .AddEventHandlers<AutoModEventHandler>(ServiceLifetime.Scoped)
         .AddEventHandlers<AutoModRuleEventHandler>(ServiceLifetime.Scoped)
-        // Invites & Typing
         .AddEventHandlers<InviteEventHandler>(ServiceLifetime.Scoped)
         .AddEventHandlers<TypingEventHandler>(ServiceLifetime.Scoped)
-        // Webhooks & Integrations
         .AddEventHandlers<WebhookEventHandler>(ServiceLifetime.Scoped)
         .AddEventHandlers<IntegrationEventHandler>(ServiceLifetime.Scoped)
-        // Audit Log
         .AddEventHandlers<AuditLogEventHandler>(ServiceLifetime.Scoped)
-        // Socket lifecycle (downtime tracking)
         .AddEventHandlers<SocketLifecycleHandler>(ServiceLifetime.Scoped)
     );
 
@@ -178,7 +163,6 @@ builder.Services.AddSingleton(rootSp =>
     return clientBuilder.Build();
 });
 
-// Hosted Service
 // Order is load-bearing: DiscordHostedService.StartAsync runs InferStartupGapAsync
 // (against the stale last_heartbeat_utc) before HeartbeatBackgroundService can write
 // a fresh tick that would mask the gap. Do not reorder.
@@ -197,7 +181,6 @@ builder.Services.AddScoped<ThreadChannelBackfillService>();
 builder.Services.AddScoped<MemberRoleSnapshotBackfillService>();
 builder.Services.AddScoped<MessageMentionsBackfillService>();
 
-// Health checks
 builder.Services.AddHealthChecks()
     .AddDbContextCheck<DiscordDbContext>();
 
@@ -273,7 +256,6 @@ builder.Services.AddHangfireServer(options =>
     options.Queues = ["backfill", "default"];
 });
 
-// Backfill jobs
 builder.Services.AddScoped<BackfillJobExecutor>();
 builder.Services.AddScoped<RolesBackfillJob>();
 builder.Services.AddScoped<EmojisBackfillJob>();
@@ -307,7 +289,6 @@ if (Environment.GetEnvironmentVariable("VALIDATE_AND_EXIT") == "1")
     return;
 }
 
-// Apply migrations if configured
 var dbOptions = app.Services.GetRequiredService<IOptions<DatabaseOptions>>().Value;
 if (dbOptions.AutoMigrate)
 {
@@ -322,12 +303,10 @@ if (dbOptions.AutoMigrate)
 app.UseDefaultFiles();
 app.UseStaticFiles();
 
-// Dashboard read API
 app.MapControllers();
 
 app.MapHealthChecks("/health");
 
-// Hangfire dashboard
 app.MapHangfireDashboard("/hangfire");
 
 // Weekly full backfill safety net — catches anything reconnect-backfill misses
@@ -351,13 +330,10 @@ RecurringJob.AddOrUpdate<MemeIndexSweepJob>(
     j => j.ExecuteAsync(),
     "0 5 * * 0"); // Sundays 05:00 UTC
 
-// Backfill API
 app.MapBackfillEndpoints();
 
-// Operations API
 app.MapOpsEndpoints();
 
-// Meme benchmark API (#219)
 app.MapMemeBenchmarkEndpoints();
 app.MapMemeIndexEndpoints();
 

--- a/src/DiscordEventService/Services/BootQuickSyncService.cs
+++ b/src/DiscordEventService/Services/BootQuickSyncService.cs
@@ -1,10 +1,10 @@
+using System.Text.Json;
 using DiscordEventService.Data;
 using DiscordEventService.Data.Entities.Core;
 using DiscordEventService.Data.Entities.Events;
 using DSharpPlus;
 using DSharpPlus.Entities;
 using Microsoft.EntityFrameworkCore;
-using System.Text.Json;
 
 namespace DiscordEventService.Services;
 
@@ -13,7 +13,7 @@ public class BootQuickSyncService(
     DiscordClient discordClient,
     ILogger<BootQuickSyncService> logger)
 {
-    private static readonly JsonSerializerOptions JsonOptions = new()
+    private static readonly JsonSerializerOptions JsonOptions = new JsonSerializerOptions
     {
         PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
         WriteIndented = false
@@ -39,17 +39,15 @@ public class BootQuickSyncService(
             .Where(c => c.Type is DiscordChannelType.Text or DiscordChannelType.News)
             .ToList();
 
-        int totalInserted = 0;
+        var totalInserted = 0;
 
         foreach (var channel in textChannels)
         {
             try
             {
-                var messages = new List<DiscordMessage>();
+                List<DiscordMessage> messages = [];
                 await foreach (var msg in channel.GetMessagesAsync(50))
-                {
                     messages.Add(msg);
-                }
 
                 if (messages.Count == 0) continue;
 
@@ -161,8 +159,8 @@ public class BootQuickSyncService(
         var db = scope.ServiceProvider.GetRequiredService<DiscordDbContext>();
         var userService = scope.ServiceProvider.GetRequiredService<UserService>();
 
-        int presenceSnapshots = 0;
-        int activitiesInserted = 0;
+        var presenceSnapshots = 0;
+        var activitiesInserted = 0;
         var now = DateTime.UtcNow;
 
         var guildGuid = await db.Guilds
@@ -172,11 +170,9 @@ public class BootQuickSyncService(
 
         if (guildGuid is null) return (0, 0);
 
-        var members = new List<DiscordMember>();
+        List<DiscordMember> members = [];
         await foreach (var member in guild.GetAllMembersAsync())
-        {
             members.Add(member);
-        }
 
         foreach (var member in members)
         {

--- a/src/DiscordEventService/Services/CoreServiceRegistration.cs
+++ b/src/DiscordEventService/Services/CoreServiceRegistration.cs
@@ -4,12 +4,8 @@ using DiscordEventService.Services.Pipeline;
 
 namespace DiscordEventService.Services;
 
-/// <summary>
-/// Single source of truth for the scoped services that both the root (ASP.NET Core) and the
-/// DSharpPlus child DI container need. Registration loops over <see cref="CoreServiceTypes"/> and
-/// <see cref="StartupValidator"/> validates the same list, so adding a service is one line here and
-/// it is registered in both containers and validated at startup.
-/// </summary>
+// Single source of truth for the scoped services both the root (ASP.NET Core) and the DSharpPlus
+// child DI container need — registration and StartupValidator both loop over CoreServiceTypes.
 public static class CoreServiceRegistration
 {
     public static readonly Type[] CoreServiceTypes =

--- a/src/DiscordEventService/Services/DiscordHostedService.cs
+++ b/src/DiscordEventService/Services/DiscordHostedService.cs
@@ -22,9 +22,7 @@ public class DiscordHostedService(
             var tracker = scope.ServiceProvider.GetRequiredService<DowntimeTrackerService>();
             var closed = await tracker.CloseOpenDowntimeAsync(DateTime.UtcNow);
             if (closed == 0)
-            {
                 await tracker.InferStartupGapAsync();
-            }
         }
         catch (Exception ex)
         {

--- a/src/DiscordEventService/Services/DowntimeTrackerService.cs
+++ b/src/DiscordEventService/Services/DowntimeTrackerService.cs
@@ -55,22 +55,16 @@ public class DowntimeTrackerService(DiscordDbContext db, ILogger<DowntimeTracker
         // manually-opened Deploy/HostDown row from the ops endpoint.
         var query = db.BotDowntimeIntervals.Where(x => x.EndedAtUtc == null);
         if (onlyType.HasValue)
-        {
             query = query.Where(x => x.Type == onlyType.Value);
-        }
 
         var affected = await query.ExecuteUpdateAsync(s => s
             .SetProperty(x => x.EndedAtUtc, endedAtUtc)
             .SetProperty(x => x.LastUpdatedUtc, endedAtUtc));
 
         if (affected > 1)
-        {
             logger.LogWarning("Closed {Count} open downtime rows (expected at most 1)", affected);
-        }
         else if (affected == 1)
-        {
             logger.LogInformation("Closed open downtime row at {EndedAt:O} (filter={Filter})", endedAtUtc, onlyType?.ToString() ?? "any");
-        }
         return affected;
     }
 
@@ -121,15 +115,11 @@ public class DowntimeTrackerService(DiscordDbContext db, ILogger<DowntimeTracker
         var now = DateTime.UtcNow;
         var result = await GetLastAliveAtUtcAsync();
         if (result.LastAliveUtc is null)
-        {
             return null;
-        }
 
         var gap = now - result.LastAliveUtc.Value;
         if (gap < StartupGapThreshold)
-        {
             return null;
-        }
 
         var row = new BotDowntimeIntervalEntity
         {

--- a/src/DiscordEventService/Services/EventHandlers/AuditLogEventHandler.cs
+++ b/src/DiscordEventService/Services/EventHandlers/AuditLogEventHandler.cs
@@ -29,7 +29,7 @@ public sealed class AuditLogEventHandler(EventPipeline pipeline) :
                         ? e.AuditLogEntry.CreationTimestamp.UtcDateTime
                         : ctx.ReceivedAtUtc,
                     ReceivedAtUtc = ctx.ReceivedAtUtc,
-                    RawEventJson = ctx.RawJson
+                    RawEventJson = ctx.RawJson,
                 });
 
                 await ctx.Db.SaveChangesAsync();

--- a/src/DiscordEventService/Services/EventHandlers/AutoModEventHandler.cs
+++ b/src/DiscordEventService/Services/EventHandlers/AutoModEventHandler.cs
@@ -27,7 +27,7 @@ public sealed class AutoModEventHandler(EventPipeline pipeline) :
                     TriggerType = (int)e.Rule.TriggerType,
                     EventTimestampUtc = ctx.ReceivedAtUtc,
                     ReceivedAtUtc = ctx.ReceivedAtUtc,
-                    RawEventJson = ctx.RawJson
+                    RawEventJson = ctx.RawJson,
                 });
 
                 await ctx.Db.SaveChangesAsync();
@@ -50,7 +50,7 @@ public sealed class AutoModEventHandler(EventPipeline pipeline) :
                     TriggerType = (int)e.Rule.TriggerType,
                     EventTimestampUtc = ctx.ReceivedAtUtc,
                     ReceivedAtUtc = ctx.ReceivedAtUtc,
-                    RawEventJson = ctx.RawJson
+                    RawEventJson = ctx.RawJson,
                 });
 
                 await ctx.Db.SaveChangesAsync();
@@ -73,7 +73,7 @@ public sealed class AutoModEventHandler(EventPipeline pipeline) :
                     TriggerType = (int)e.Rule.TriggerType,
                     EventTimestampUtc = ctx.ReceivedAtUtc,
                     ReceivedAtUtc = ctx.ReceivedAtUtc,
-                    RawEventJson = ctx.RawJson
+                    RawEventJson = ctx.RawJson,
                 });
 
                 await ctx.Db.SaveChangesAsync();
@@ -101,7 +101,7 @@ public sealed class AutoModEventHandler(EventPipeline pipeline) :
                     MatchedContent = e.Rule.MatchedContent,
                     EventTimestampUtc = ctx.ReceivedAtUtc,
                     ReceivedAtUtc = ctx.ReceivedAtUtc,
-                    RawEventJson = ctx.RawJson
+                    RawEventJson = ctx.RawJson,
                 });
 
                 await ctx.Db.SaveChangesAsync();

--- a/src/DiscordEventService/Services/EventHandlers/AutoModRuleEventHandler.cs
+++ b/src/DiscordEventService/Services/EventHandlers/AutoModRuleEventHandler.cs
@@ -1,10 +1,10 @@
+using System.Text.Json;
 using DiscordEventService.Data.Entities.Core;
 using DiscordEventService.Data.Entities.Events;
 using DiscordEventService.Services.Pipeline;
 using DSharpPlus;
 using DSharpPlus.EventArgs;
 using Microsoft.EntityFrameworkCore;
-using System.Text.Json;
 
 namespace DiscordEventService.Services.EventHandlers;
 
@@ -47,7 +47,7 @@ public sealed class AutoModRuleEventHandler(EventPipeline pipeline) :
                     EventType = (int)e.Rule.EventType,
                     TriggerType = (int)e.Rule.TriggerType,
                     IsEnabled = e.Rule.IsEnabled,
-                    ActionsJson = e.Rule.Actions != null ? JsonSerializer.Serialize(e.Rule.Actions) : null
+                    ActionsJson = e.Rule.Actions != null ? JsonSerializer.Serialize(e.Rule.Actions) : null,
                 });
 
                 ctx.Db.AutoModRuleEvents.Add(new AutoModRuleEventEntity
@@ -61,7 +61,7 @@ public sealed class AutoModRuleEventHandler(EventPipeline pipeline) :
                     IsEnabled = e.Rule.IsEnabled,
                     EventTimestampUtc = ctx.ReceivedAtUtc,
                     ReceivedAtUtc = ctx.ReceivedAtUtc,
-                    RawEventJson = ctx.RawJson
+                    RawEventJson = ctx.RawJson,
                 });
 
                 await ctx.Db.SaveChangesAsync();
@@ -94,7 +94,7 @@ public sealed class AutoModRuleEventHandler(EventPipeline pipeline) :
                     IsEnabled = e.Rule.IsEnabled,
                     EventTimestampUtc = ctx.ReceivedAtUtc,
                     ReceivedAtUtc = ctx.ReceivedAtUtc,
-                    RawEventJson = ctx.RawJson
+                    RawEventJson = ctx.RawJson,
                 });
 
                 await ctx.Db.SaveChangesAsync();
@@ -123,7 +123,7 @@ public sealed class AutoModRuleEventHandler(EventPipeline pipeline) :
                     Name = e.Rule.Name ?? string.Empty,
                     EventTimestampUtc = ctx.ReceivedAtUtc,
                     ReceivedAtUtc = ctx.ReceivedAtUtc,
-                    RawEventJson = ctx.RawJson
+                    RawEventJson = ctx.RawJson,
                 });
 
                 await ctx.Db.SaveChangesAsync();

--- a/src/DiscordEventService/Services/EventHandlers/BanEventHandler.cs
+++ b/src/DiscordEventService/Services/EventHandlers/BanEventHandler.cs
@@ -38,7 +38,7 @@ public sealed class BanEventHandler(EventPipeline pipeline) :
                             GuildId = guildGuid,
                             UserId = userGuid,
                             IsActive = true,
-                            BannedAtUtc = ctx.ReceivedAtUtc
+                            BannedAtUtc = ctx.ReceivedAtUtc,
                         });
                     }
                 }
@@ -50,7 +50,7 @@ public sealed class BanEventHandler(EventPipeline pipeline) :
                     EventType = BanEventType.Added,
                     EventTimestampUtc = ctx.ReceivedAtUtc,
                     ReceivedAtUtc = ctx.ReceivedAtUtc,
-                    RawEventJson = ctx.RawJson
+                    RawEventJson = ctx.RawJson,
                 });
 
                 await ctx.Db.SaveChangesAsync();
@@ -87,7 +87,7 @@ public sealed class BanEventHandler(EventPipeline pipeline) :
                     EventType = BanEventType.Removed,
                     EventTimestampUtc = ctx.ReceivedAtUtc,
                     ReceivedAtUtc = ctx.ReceivedAtUtc,
-                    RawEventJson = ctx.RawJson
+                    RawEventJson = ctx.RawJson,
                 });
 
                 await ctx.Db.SaveChangesAsync();

--- a/src/DiscordEventService/Services/EventHandlers/ChannelEventHandler.cs
+++ b/src/DiscordEventService/Services/EventHandlers/ChannelEventHandler.cs
@@ -23,7 +23,7 @@ public sealed class ChannelEventHandler(EventPipeline pipeline) :
                 var guildUpsert = ctx.Services.GetRequiredService<GuildUpsertService>();
                 var guildGuid = (await guildUpsert.UpsertGuildAsync(e.Guild)).Value;
 
-                ChannelEventEntity NewChannelEvent() => new()
+                ChannelEventEntity NewChannelEvent() => new ChannelEventEntity
                 {
                     ChannelDiscordId = e.Channel.Id,
                     GuildDiscordId = e.Guild.Id,
@@ -34,7 +34,7 @@ public sealed class ChannelEventHandler(EventPipeline pipeline) :
                     PositionAfter = e.Channel.Position,
                     EventTimestampUtc = ctx.ReceivedAtUtc,
                     ReceivedAtUtc = ctx.ReceivedAtUtc,
-                    RawEventJson = ctx.RawJson
+                    RawEventJson = ctx.RawJson,
                 };
 
                 // Upsert the channel (handles the 23505 race internally) before staging the event,
@@ -75,7 +75,7 @@ public sealed class ChannelEventHandler(EventPipeline pipeline) :
                             UserLimit = e.Channel.UserLimit,
                             RateLimitPerUser = e.Channel.PerUserRateLimit,
                             IsNsfw = e.Channel.IsNSFW,
-                            IsDeleted = false
+                            IsDeleted = false,
                         },
                         c => c.Id);
 
@@ -95,9 +95,7 @@ public sealed class ChannelEventHandler(EventPipeline pipeline) :
                     .FirstOrDefaultAsync(c => c.DiscordId == e.ChannelAfter.Id);
 
                 if (channelEntity != null)
-                {
                     UpdateChannelEntity(channelEntity, e.ChannelAfter);
-                }
 
                 var channelEvent = new ChannelEventEntity
                 {
@@ -107,7 +105,7 @@ public sealed class ChannelEventHandler(EventPipeline pipeline) :
                     EventType = ChannelEventType.Updated,
                     EventTimestampUtc = ctx.ReceivedAtUtc,
                     ReceivedAtUtc = ctx.ReceivedAtUtc,
-                    RawEventJson = ctx.RawJson
+                    RawEventJson = ctx.RawJson,
                 };
 
                 if (e.ChannelBefore.Name != e.ChannelAfter.Name)
@@ -158,7 +156,7 @@ public sealed class ChannelEventHandler(EventPipeline pipeline) :
                     PositionBefore = e.Channel.Position,
                     EventTimestampUtc = ctx.ReceivedAtUtc,
                     ReceivedAtUtc = ctx.ReceivedAtUtc,
-                    RawEventJson = ctx.RawJson
+                    RawEventJson = ctx.RawJson,
                 });
 
                 await ctx.Db.SaveChangesAsync();
@@ -178,7 +176,7 @@ public sealed class ChannelEventHandler(EventPipeline pipeline) :
                     EventType = ChannelEventType.PinsUpdated,
                     EventTimestampUtc = e.LastPinTimestamp?.UtcDateTime ?? ctx.ReceivedAtUtc,
                     ReceivedAtUtc = ctx.ReceivedAtUtc,
-                    RawEventJson = ctx.RawJson
+                    RawEventJson = ctx.RawJson,
                 });
 
                 await ctx.Db.SaveChangesAsync();

--- a/src/DiscordEventService/Services/EventHandlers/EmojiEventHandler.cs
+++ b/src/DiscordEventService/Services/EventHandlers/EmojiEventHandler.cs
@@ -1,10 +1,10 @@
+using System.Text.Json;
 using DiscordEventService.Data.Entities.Core;
 using DiscordEventService.Data.Entities.Events;
 using DiscordEventService.Services.Pipeline;
 using DSharpPlus;
 using DSharpPlus.EventArgs;
 using Microsoft.EntityFrameworkCore;
-using System.Text.Json;
 
 namespace DiscordEventService.Services.EventHandlers;
 
@@ -42,7 +42,7 @@ public sealed class EmojiEventHandler(EventPipeline pipeline) :
                             GuildId = guildGuid,
                             Name = emoji.Name,
                             IsAnimated = emoji.IsAnimated,
-                            IsAvailable = emoji.IsAvailable
+                            IsAvailable = emoji.IsAvailable,
                         });
                     }
                     else
@@ -87,7 +87,7 @@ public sealed class EmojiEventHandler(EventPipeline pipeline) :
                         : null,
                     EventTimestampUtc = ctx.ReceivedAtUtc,
                     ReceivedAtUtc = ctx.ReceivedAtUtc,
-                    RawEventJson = ctx.RawJson
+                    RawEventJson = ctx.RawJson,
                 });
 
                 await ctx.Db.SaveChangesAsync();

--- a/src/DiscordEventService/Services/EventHandlers/GuildEventHandler.cs
+++ b/src/DiscordEventService/Services/EventHandlers/GuildEventHandler.cs
@@ -46,7 +46,7 @@ public sealed class GuildEventHandler(EventPipeline pipeline) :
                             Name = e.Guild.Name,
                             IconHash = e.Guild.IconHash,
                             OwnerId = e.Guild.OwnerId,
-                            LeftAtUtc = null
+                            LeftAtUtc = null,
                         },
                         g => g.Id);
 
@@ -57,11 +57,9 @@ public sealed class GuildEventHandler(EventPipeline pipeline) :
             });
     }
 
-    public Task HandleEventAsync(DiscordClient sender, GuildAvailableEventArgs e)
-    {
-        // GuildAvailable fires during initial connection - delegate to GuildCreated handler
-        return HandleEventAsync(sender, (GuildCreatedEventArgs)e);
-    }
+    // GuildAvailable fires during initial connection - delegate to GuildCreated handler
+    public Task HandleEventAsync(DiscordClient sender, GuildAvailableEventArgs e) =>
+        HandleEventAsync(sender, (GuildCreatedEventArgs)e);
 
     public async Task HandleEventAsync(DiscordClient sender, GuildUpdatedEventArgs e)
     {
@@ -133,7 +131,7 @@ public sealed class GuildEventHandler(EventPipeline pipeline) :
                     RateLimitPerUser = channel.PerUserRateLimit,
                     IsNsfw = false,
                     Position = channel.Position,
-                    IsDeleted = false
+                    IsDeleted = false,
                 },
                 c => c.Id);
         }
@@ -164,7 +162,7 @@ public sealed class GuildEventHandler(EventPipeline pipeline) :
                     Permissions = permissions,
                     IsManaged = role.IsManaged,
                     IsMentionable = role.IsMentionable,
-                    IsDeleted = false
+                    IsDeleted = false,
                 },
                 r => r.Id);
         }

--- a/src/DiscordEventService/Services/EventHandlers/GuildMembersChunkHandler.cs
+++ b/src/DiscordEventService/Services/EventHandlers/GuildMembersChunkHandler.cs
@@ -1,18 +1,18 @@
+using System.Text.Json;
 using DiscordEventService.Data.Entities.Events;
 using DiscordEventService.Services.Pipeline;
 using DSharpPlus;
 using DSharpPlus.EventArgs;
-using System.Text.Json;
 
 namespace DiscordEventService.Services.EventHandlers;
 
 public sealed class GuildMembersChunkHandler(EventPipeline pipeline) :
     IEventHandler<GuildMembersChunkedEventArgs>
 {
-    private static readonly JsonSerializerOptions JsonOptions = new()
+    private static readonly JsonSerializerOptions JsonOptions = new JsonSerializerOptions
     {
         PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
-        WriteIndented = false
+        WriteIndented = false,
     };
 
     public async Task HandleEventAsync(DiscordClient sender, GuildMembersChunkedEventArgs args)
@@ -23,9 +23,7 @@ public sealed class GuildMembersChunkHandler(EventPipeline pipeline) :
                 var userService = ctx.Services.GetRequiredService<UserService>();
 
                 foreach (var member in args.Members)
-                {
                     await userService.UpsertUserAsync(member);
-                }
 
                 ctx.Db.GuildMembersChunkEvents.Add(new GuildMembersChunkEventEntity
                 {
@@ -48,7 +46,7 @@ public sealed class GuildMembersChunkHandler(EventPipeline pipeline) :
                         : null,
                     EventTimestampUtc = ctx.ReceivedAtUtc,
                     ReceivedAtUtc = ctx.ReceivedAtUtc,
-                    RawEventJson = ctx.RawJson
+                    RawEventJson = ctx.RawJson,
                 });
 
                 await ctx.Db.SaveChangesAsync();

--- a/src/DiscordEventService/Services/EventHandlers/GuildUpdateEventHandler.cs
+++ b/src/DiscordEventService/Services/EventHandlers/GuildUpdateEventHandler.cs
@@ -19,7 +19,7 @@ public sealed class GuildUpdateEventHandler(EventPipeline pipeline) :
                     EventType = GuildEventType.Updated,
                     EventTimestampUtc = ctx.ReceivedAtUtc,
                     ReceivedAtUtc = ctx.ReceivedAtUtc,
-                    RawEventJson = ctx.RawJson
+                    RawEventJson = ctx.RawJson,
                 };
 
                 if (e.GuildBefore.Name != e.GuildAfter.Name)

--- a/src/DiscordEventService/Services/EventHandlers/IntegrationEventHandler.cs
+++ b/src/DiscordEventService/Services/EventHandlers/IntegrationEventHandler.cs
@@ -26,7 +26,7 @@ public sealed class IntegrationEventHandler(EventPipeline pipeline) :
                     GuildId = guildGuid,
                     Name = e.Integration.Name,
                     Type = e.Integration.Type,
-                    IsEnabled = e.Integration.IsEnabled
+                    IsEnabled = e.Integration.IsEnabled,
                 });
 
                 ctx.Db.IntegrationEvents.Add(new IntegrationEventEntity
@@ -39,7 +39,7 @@ public sealed class IntegrationEventHandler(EventPipeline pipeline) :
                     IsEnabled = e.Integration.IsEnabled,
                     EventTimestampUtc = ctx.ReceivedAtUtc,
                     ReceivedAtUtc = ctx.ReceivedAtUtc,
-                    RawEventJson = ctx.RawJson
+                    RawEventJson = ctx.RawJson,
                 });
 
                 await ctx.Db.SaveChangesAsync();
@@ -67,7 +67,7 @@ public sealed class IntegrationEventHandler(EventPipeline pipeline) :
                     IsEnabled = e.Integration.IsEnabled,
                     EventTimestampUtc = ctx.ReceivedAtUtc,
                     ReceivedAtUtc = ctx.ReceivedAtUtc,
-                    RawEventJson = ctx.RawJson
+                    RawEventJson = ctx.RawJson,
                 });
 
                 await ctx.Db.SaveChangesAsync();
@@ -92,7 +92,7 @@ public sealed class IntegrationEventHandler(EventPipeline pipeline) :
                     EventType = IntegrationEventType.Deleted,
                     EventTimestampUtc = ctx.ReceivedAtUtc,
                     ReceivedAtUtc = ctx.ReceivedAtUtc,
-                    RawEventJson = ctx.RawJson
+                    RawEventJson = ctx.RawJson,
                 });
 
                 await ctx.Db.SaveChangesAsync();

--- a/src/DiscordEventService/Services/EventHandlers/InviteEventHandler.cs
+++ b/src/DiscordEventService/Services/EventHandlers/InviteEventHandler.cs
@@ -66,7 +66,7 @@ public sealed class InviteEventHandler(EventPipeline pipeline) :
                         ? invite.CreatedAt.UtcDateTime
                         : ctx.ReceivedAtUtc,
                     ReceivedAtUtc = ctx.ReceivedAtUtc,
-                    RawEventJson = ctx.RawJson
+                    RawEventJson = ctx.RawJson,
                 });
 
                 await ctx.Db.SaveChangesAsync();
@@ -92,7 +92,7 @@ public sealed class InviteEventHandler(EventPipeline pipeline) :
                     Code = e.Invite.Code,
                     EventTimestampUtc = ctx.ReceivedAtUtc,
                     ReceivedAtUtc = ctx.ReceivedAtUtc,
-                    RawEventJson = ctx.RawJson
+                    RawEventJson = ctx.RawJson,
                 });
 
                 await ctx.Db.SaveChangesAsync();

--- a/src/DiscordEventService/Services/EventHandlers/MemberEventHandler.cs
+++ b/src/DiscordEventService/Services/EventHandlers/MemberEventHandler.cs
@@ -1,3 +1,4 @@
+using System.Text.Json;
 using DiscordEventService.Data;
 using DiscordEventService.Data.Entities.Core;
 using DiscordEventService.Data.Entities.Events;
@@ -5,7 +6,6 @@ using DiscordEventService.Services.Pipeline;
 using DSharpPlus;
 using DSharpPlus.EventArgs;
 using Microsoft.EntityFrameworkCore;
-using System.Text.Json;
 
 namespace DiscordEventService.Services.EventHandlers;
 
@@ -35,7 +35,7 @@ public sealed class MemberEventHandler(EventPipeline pipeline) :
                         : null,
                     EventTimestampUtc = e.Member.JoinedAt.UtcDateTime,
                     ReceivedAtUtc = ctx.ReceivedAtUtc,
-                    RawEventJson = ctx.RawJson
+                    RawEventJson = ctx.RawJson,
                 });
 
                 await ctx.Db.SaveChangesAsync();
@@ -58,7 +58,7 @@ public sealed class MemberEventHandler(EventPipeline pipeline) :
                         : null,
                     EventTimestampUtc = ctx.ReceivedAtUtc,
                     ReceivedAtUtc = ctx.ReceivedAtUtc,
-                    RawEventJson = ctx.RawJson
+                    RawEventJson = ctx.RawJson,
                 });
 
                 await ctx.Db.SaveChangesAsync();
@@ -73,8 +73,8 @@ public sealed class MemberEventHandler(EventPipeline pipeline) :
                 var userService = ctx.Services.GetRequiredService<UserService>();
                 await userService.UpsertMemberAsync(e.Member);
 
-                var oldRoleIds = e.RolesBefore?.Select(r => r.Id).ToHashSet() ?? new HashSet<ulong>();
-                var newRoleIds = e.RolesAfter?.Select(r => r.Id).ToHashSet() ?? new HashSet<ulong>();
+                var oldRoleIds = e.RolesBefore?.Select(r => r.Id).ToHashSet() ?? [];
+                var newRoleIds = e.RolesAfter?.Select(r => r.Id).ToHashSet() ?? [];
 
                 var rolesAdded = newRoleIds.Except(oldRoleIds).ToList();
                 var rolesRemoved = oldRoleIds.Except(newRoleIds).ToList();
@@ -95,12 +95,12 @@ public sealed class MemberEventHandler(EventPipeline pipeline) :
                 var premiumAfter = e.Member.PremiumSince;
                 var premiumChanged = hasBefore && premiumBefore != premiumAfter;
 
-                bool? mutedBefore = memberBefore?.IsMuted;
-                bool mutedAfter = e.Member.IsMuted;
+                var mutedBefore = memberBefore?.IsMuted;
+                var mutedAfter = e.Member.IsMuted;
                 var mutedChanged = mutedBefore.HasValue && mutedBefore.Value != mutedAfter;
 
-                bool? deafenedBefore = memberBefore?.IsDeafened;
-                bool deafenedAfter = e.Member.IsDeafened;
+                var deafenedBefore = memberBefore?.IsDeafened;
+                var deafenedAfter = e.Member.IsDeafened;
                 var deafenedChanged = deafenedBefore.HasValue && deafenedBefore.Value != deafenedAfter;
 
                 if (nicknameChanged || rolesAdded.Any() || rolesRemoved.Any() || timeoutChanged
@@ -138,7 +138,7 @@ public sealed class MemberEventHandler(EventPipeline pipeline) :
                             IsDeafenedAfter = deafenedAfter,
                             EventTimestampUtc = ctx.ReceivedAtUtc,
                             ReceivedAtUtc = ctx.ReceivedAtUtc,
-                            RawEventJson = ctx.RawJson
+                            RawEventJson = ctx.RawJson,
                         };
 
                         ctx.Db.MemberEvents.Add(memberEvent);
@@ -185,7 +185,7 @@ public sealed class MemberEventHandler(EventPipeline pipeline) :
                     MemberId = member.Id,
                     RoleDiscordId = roleId,
                     GrantedAtUtc = eventTime,
-                    SourceEventId = sourceEventId
+                    SourceEventId = sourceEventId,
                 });
         }
 
@@ -219,7 +219,7 @@ public sealed class MemberEventHandler(EventPipeline pipeline) :
                     EventType = MemberEventType.Banned,
                     EventTimestampUtc = ctx.ReceivedAtUtc,
                     ReceivedAtUtc = ctx.ReceivedAtUtc,
-                    RawEventJson = ctx.RawJson
+                    RawEventJson = ctx.RawJson,
                 });
 
                 await ctx.Db.SaveChangesAsync();
@@ -241,7 +241,7 @@ public sealed class MemberEventHandler(EventPipeline pipeline) :
                     EventType = MemberEventType.Unbanned,
                     EventTimestampUtc = ctx.ReceivedAtUtc,
                     ReceivedAtUtc = ctx.ReceivedAtUtc,
-                    RawEventJson = ctx.RawJson
+                    RawEventJson = ctx.RawJson,
                 });
 
                 await ctx.Db.SaveChangesAsync();

--- a/src/DiscordEventService/Services/EventHandlers/MessageEventHandler.cs
+++ b/src/DiscordEventService/Services/EventHandlers/MessageEventHandler.cs
@@ -1,3 +1,5 @@
+using System.Text.Json;
+using System.Text.Json.Nodes;
 using DiscordEventService.Configuration;
 using DiscordEventService.Data;
 using DiscordEventService.Data.Entities.Core;
@@ -11,8 +13,6 @@ using DSharpPlus.EventArgs;
 using Hangfire;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Options;
-using System.Text.Json;
-using System.Text.Json.Nodes;
 
 namespace DiscordEventService.Services.EventHandlers;
 
@@ -36,12 +36,9 @@ public sealed class MessageEventHandler(EventPipeline pipeline) :
                     ? JsonSerializer.Serialize(e.Message.Embeds)
                     : null;
 
-                // Resolve FKs via upsert-if-missing. The 2026-05-03 incident left 69 messages with
-                // channel_id IS NULL because the prior FirstOrDefault path silently wrote null when
-                // the channel (a thread) wasn't yet in our DB. §P1.9 closes that hole; §P2.6 (#74)
-                // makes the FKs NOT NULL so any regression in the upsert services becomes a loud
-                // skip + FailedEvent instead of a silent NULL FK row. FkResolver concentrates that
-                // resolve + all-or-fail validation + failure recording.
+                // Resolve FKs via upsert-if-missing: a FirstOrDefault path would silently write a NULL
+                // FK when the channel (e.g. an uncached thread) isn't in our DB yet. Resolver does an
+                // all-or-fail validation so a missing FK becomes a loud skip, not a NULL-FK row.
                 var fks = await ctx.Services.GetRequiredService<FkResolver>()
                     .ResolveAsync(ctx, e.Guild, e.Channel, e.Author, $"MessageId={e.Message.Id}");
                 if (!fks.Success) return; // resolver already logged + recorded the failure
@@ -50,7 +47,7 @@ public sealed class MessageEventHandler(EventPipeline pipeline) :
                 var channelId = fks.ChannelId;
                 var authorId = fks.UserId;
 
-                MessageEventEntity NewMessageEvent() => new()
+                MessageEventEntity NewMessageEvent() => new MessageEventEntity
                 {
                     MessageDiscordId = e.Message.Id,
                     ChannelDiscordId = e.Channel.Id,
@@ -65,7 +62,7 @@ public sealed class MessageEventHandler(EventPipeline pipeline) :
                     EmbedsJson = embedsJson,
                     EventTimestampUtc = e.Message.Timestamp.UtcDateTime,
                     ReceivedAtUtc = ctx.ReceivedAtUtc,
-                    RawEventJson = ctx.RawJson
+                    RawEventJson = ctx.RawJson,
                 };
 
                 // Wrap message + event + mentions in one transaction so they commit atomically.
@@ -96,7 +93,7 @@ public sealed class MessageEventHandler(EventPipeline pipeline) :
                             AttachmentsJson = attachmentsJson,
                             EmbedsJson = embedsJson,
                             Flags = (int)(e.Message.Flags ?? 0),
-                            CreatedAtUtc = e.Message.Timestamp.UtcDateTime
+                            CreatedAtUtc = e.Message.Timestamp.UtcDateTime,
                         });
 
                     var messageId = messageEntity!.Id;
@@ -145,7 +142,7 @@ public sealed class MessageEventHandler(EventPipeline pipeline) :
                         ? JsonSerializer.Serialize(beforeForEmbeds.Embeds)
                         : null)
                     : message?.EmbedsJson;
-                int? flagsBefore = e.MessageBefore is { } before
+                var flagsBefore = e.MessageBefore is { } before
                     ? (int)(before.Flags ?? 0)
                     : message?.Flags;
 
@@ -185,7 +182,7 @@ public sealed class MessageEventHandler(EventPipeline pipeline) :
                         EmbedsJson = embedsJson,
                         EventTimestampUtc = editedAt,
                         ReceivedAtUtc = ctx.ReceivedAtUtc,
-                        RawEventJson = ctx.RawJson
+                        RawEventJson = ctx.RawJson,
                     });
 
                     var contentChanged = contentBefore != normalizedContent;
@@ -212,16 +209,14 @@ public sealed class MessageEventHandler(EventPipeline pipeline) :
                             FlagsBefore = flagsBefore,
                             FlagsAfter = flagsAfter,
                             EditedAtUtc = editedAt,
-                            RecordedAtUtc = ctx.ReceivedAtUtc
+                            RecordedAtUtc = ctx.ReceivedAtUtc,
                         });
                     }
 
                     await ctx.Db.SaveChangesAsync();
 
                     if (messageGuid is Guid mentionMid)
-                    {
                         await ExtractAndSaveMentionsAsync(ctx.Db, mentionMid, e.Message);
-                    }
 
                     await tx.CommitAsync();
                 });
@@ -251,7 +246,7 @@ public sealed class MessageEventHandler(EventPipeline pipeline) :
                     Content = NormalizeContent(e.Message.Content),
                     EventTimestampUtc = ctx.ReceivedAtUtc,
                     ReceivedAtUtc = ctx.ReceivedAtUtc,
-                    RawEventJson = ctx.RawJson
+                    RawEventJson = ctx.RawJson,
                 });
 
                 await ctx.Db.SaveChangesAsync();
@@ -282,7 +277,7 @@ public sealed class MessageEventHandler(EventPipeline pipeline) :
                     Content = NormalizeContent(msg.Content),
                     EventTimestampUtc = ctx.ReceivedAtUtc,
                     ReceivedAtUtc = ctx.ReceivedAtUtc,
-                    RawEventJson = ctx.RawJson
+                    RawEventJson = ctx.RawJson,
                 });
 
                 ctx.Db.MessageEvents.AddRange(events);
@@ -290,10 +285,8 @@ public sealed class MessageEventHandler(EventPipeline pipeline) :
             });
     }
 
-    // #222 live path: a message with image attachments in a configured meme
-    // channel gets a single-message index job enqueued once its row has
-    // committed. Failures are swallowed (warning only) — indexing must never
-    // break message persistence, and the weekly sweep heals anything missed.
+    // Failures are swallowed (warning only) — indexing must never break message persistence,
+    // and the weekly sweep heals anything missed.
     private static void EnqueueMemeIndexing(EventContext ctx, MessageCreatedEventArgs e)
     {
         try
@@ -325,7 +318,7 @@ public sealed class MessageEventHandler(EventPipeline pipeline) :
             .Where(m => m.MessageId == messageId)
             .ExecuteDeleteAsync();
 
-        var mentions = new List<MessageMentionEntity>();
+        List<MessageMentionEntity> mentions = [];
 
         if (message.MentionedUsers is { Count: > 0 })
         {
@@ -335,7 +328,7 @@ public sealed class MessageEventHandler(EventPipeline pipeline) :
                 {
                     MessageId = messageId,
                     MentionedUserDiscordId = user.Id,
-                    MentionType = MessageMentionType.User
+                    MentionType = MessageMentionType.User,
                 });
             }
         }
@@ -348,7 +341,7 @@ public sealed class MessageEventHandler(EventPipeline pipeline) :
                 {
                     MessageId = messageId,
                     MentionedRoleDiscordId = role.Id,
-                    MentionType = MessageMentionType.Role
+                    MentionType = MessageMentionType.Role,
                 });
             }
         }
@@ -361,7 +354,7 @@ public sealed class MessageEventHandler(EventPipeline pipeline) :
                 {
                     MessageId = messageId,
                     MentionedChannelDiscordId = channel.Id,
-                    MentionType = MessageMentionType.Channel
+                    MentionType = MessageMentionType.Channel,
                 });
             }
         }

--- a/src/DiscordEventService/Services/EventHandlers/PinEventHandler.cs
+++ b/src/DiscordEventService/Services/EventHandlers/PinEventHandler.cs
@@ -22,7 +22,7 @@ public sealed class PinEventHandler(EventPipeline pipeline) :
                     LastPinTimestampUtc = e.LastPinTimestamp?.UtcDateTime,
                     EventTimestampUtc = ctx.ReceivedAtUtc,
                     ReceivedAtUtc = ctx.ReceivedAtUtc,
-                    RawEventJson = ctx.RawJson
+                    RawEventJson = ctx.RawJson,
                 });
 
                 await ctx.Db.SaveChangesAsync();

--- a/src/DiscordEventService/Services/EventHandlers/PresenceEventHandler.cs
+++ b/src/DiscordEventService/Services/EventHandlers/PresenceEventHandler.cs
@@ -1,3 +1,4 @@
+using System.Text.Json;
 using DiscordEventService.Data;
 using DiscordEventService.Data.Entities.Core;
 using DiscordEventService.Data.Entities.Events;
@@ -6,14 +7,13 @@ using DSharpPlus;
 using DSharpPlus.Entities;
 using DSharpPlus.EventArgs;
 using Microsoft.EntityFrameworkCore;
-using System.Text.Json;
 
 namespace DiscordEventService.Services.EventHandlers;
 
 public sealed class PresenceEventHandler(EventPipeline pipeline) :
     IEventHandler<PresenceUpdatedEventArgs>
 {
-    private static readonly JsonSerializerOptions JsonOptions = new()
+    private static readonly JsonSerializerOptions JsonOptions = new JsonSerializerOptions
     {
         PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
         WriteIndented = false
@@ -114,15 +114,12 @@ public sealed class PresenceEventHandler(EventPipeline pipeline) :
         IReadOnlyList<DiscordActivity>? activitiesAfter,
         DateTime now)
     {
-        // Find activities that ended (were in before but not in after)
         var endedActivities = activitiesBefore?.Where(b =>
-            !activitiesAfter?.Any(a => IsSameActivity(a, b)) ?? true) ?? Enumerable.Empty<DiscordActivity>();
+            !activitiesAfter?.Any(a => IsSameActivity(a, b)) ?? true) ?? [];
 
-        // Find activities that started (are in after but not in before)
         var startedActivities = activitiesAfter?.Where(a =>
-            !activitiesBefore?.Any(b => IsSameActivity(a, b)) ?? true) ?? Enumerable.Empty<DiscordActivity>();
+            !activitiesBefore?.Any(b => IsSameActivity(a, b)) ?? true) ?? [];
 
-        // Mark ended activities
         foreach (var ended in endedActivities)
         {
             var existingActivity = await dbContext.Activities
@@ -137,7 +134,6 @@ public sealed class PresenceEventHandler(EventPipeline pipeline) :
             }
         }
 
-        // Add new activities
         foreach (var started in startedActivities)
         {
             var activity = new ActivityEntity
@@ -160,8 +156,7 @@ public sealed class PresenceEventHandler(EventPipeline pipeline) :
             await dbContext.Activities.AddAsync(activity);
         }
 
-        // Update existing activities that are still active
-        var continuingActivities = (activitiesAfter ?? Enumerable.Empty<DiscordActivity>())
+        var continuingActivities = (activitiesAfter ?? [])
             .Where(current => activitiesBefore?.Any(b => IsSameActivity(current, b)) == true);
 
         foreach (var current in continuingActivities)
@@ -170,31 +165,21 @@ public sealed class PresenceEventHandler(EventPipeline pipeline) :
                 .Where(a => a.UserId == userGuid && a.IsActive && a.Name == current.Name && a.ActivityType == (int)current.ActivityType)
                 .FirstOrDefaultAsync();
 
-            if (existingActivity != null)
-            {
-                existingActivity.LastSeenAtUtc = now;
-            }
+            if (existingActivity is not null) existingActivity.LastSeenAtUtc = now;
         }
     }
 
-    private static bool IsSameActivity(DiscordActivity a, DiscordActivity b)
-    {
-        return a.Name == b.Name && a.ActivityType == b.ActivityType;
-    }
+    private static bool IsSameActivity(DiscordActivity a, DiscordActivity b) =>
+        a.Name == b.Name && a.ActivityType == b.ActivityType;
 
-    private static int GetStatusValue(Optional<DiscordUserStatus>? status)
-    {
-        if (status?.HasValue == true)
-            return (int)status.Value.Value;
-        return (int)DiscordUserStatus.Offline;
-    }
+    private static int GetStatusValue(Optional<DiscordUserStatus>? status) =>
+        status is { HasValue: true } ? (int)status.Value.Value : (int)DiscordUserStatus.Offline;
 
     private static string? SerializeActivities(IReadOnlyList<DiscordActivity>? activities)
     {
         if (activities == null || activities.Count == 0)
             return null;
 
-        // Serialize the core activity data that's definitely available
         var activityData = activities.Select(a => new
         {
             Name = a.Name,

--- a/src/DiscordEventService/Services/EventHandlers/RoleEventHandler.cs
+++ b/src/DiscordEventService/Services/EventHandlers/RoleEventHandler.cs
@@ -22,7 +22,7 @@ public sealed class RoleEventHandler(EventPipeline pipeline) :
                 var guildUpsert = ctx.Services.GetRequiredService<GuildUpsertService>();
                 var guildGuid = (await guildUpsert.UpsertGuildAsync(e.Guild)).Value;
 
-                RoleEventEntity NewRoleEvent() => new()
+                RoleEventEntity NewRoleEvent() => new RoleEventEntity
                 {
                     RoleDiscordId = e.Role.Id,
                     GuildDiscordId = e.Guild.Id,
@@ -90,9 +90,7 @@ public sealed class RoleEventHandler(EventPipeline pipeline) :
                     .FirstOrDefaultAsync(r => r.DiscordId == e.RoleAfter.Id);
 
                 if (roleEntity != null)
-                {
                     UpdateRoleEntity(roleEntity, e.RoleAfter);
-                }
 
                 var roleEvent = new RoleEventEntity
                 {

--- a/src/DiscordEventService/Services/EventHandlers/ScheduledEventHandler.cs
+++ b/src/DiscordEventService/Services/EventHandlers/ScheduledEventHandler.cs
@@ -180,13 +180,13 @@ public sealed class ScheduledEventHandler(EventPipeline pipeline) :
             .Where(g => g.DiscordId == evt.GuildId)
             .Select(g => g.Id)
             .FirstOrDefaultAsync();
-        Guid? channelGuid = evt.ChannelId.HasValue
+        var channelGuid = evt.ChannelId.HasValue
             ? await db.Channels
                 .Where(c => c.DiscordId == evt.ChannelId.Value)
                 .Select(c => (Guid?)c.Id)
                 .FirstOrDefaultAsync()
             : null;
-        Guid? creatorGuid = creatorDiscordId.HasValue
+        var creatorGuid = creatorDiscordId.HasValue
             ? await db.Users
                 .Where(u => u.DiscordId == creatorDiscordId.Value)
                 .Select(u => (Guid?)u.Id)

--- a/src/DiscordEventService/Services/EventHandlers/SocketLifecycleHandler.cs
+++ b/src/DiscordEventService/Services/EventHandlers/SocketLifecycleHandler.cs
@@ -113,9 +113,7 @@ public sealed class SocketLifecycleHandler(
                         "GuildDownloadCompleted: gap {Gap:c} below threshold, running quick-sync only",
                         gap);
                     foreach (var guildId in e.Guilds.Keys)
-                    {
                         await quickSyncService.SyncAsync(guildId);
-                    }
                     return;
                 }
 

--- a/src/DiscordEventService/Services/EventHandlers/StickerEventHandler.cs
+++ b/src/DiscordEventService/Services/EventHandlers/StickerEventHandler.cs
@@ -1,10 +1,10 @@
+using System.Text.Json;
 using DiscordEventService.Data.Entities.Core;
 using DiscordEventService.Data.Entities.Events;
 using DiscordEventService.Services.Pipeline;
 using DSharpPlus;
 using DSharpPlus.EventArgs;
 using Microsoft.EntityFrameworkCore;
-using System.Text.Json;
 
 namespace DiscordEventService.Services.EventHandlers;
 

--- a/src/DiscordEventService/Services/EventHandlers/ThreadSyncHandler.cs
+++ b/src/DiscordEventService/Services/EventHandlers/ThreadSyncHandler.cs
@@ -1,15 +1,15 @@
+using System.Text.Json;
 using DiscordEventService.Data.Entities.Events;
 using DiscordEventService.Services.Pipeline;
 using DSharpPlus;
 using DSharpPlus.EventArgs;
-using System.Text.Json;
 
 namespace DiscordEventService.Services.EventHandlers;
 
 public sealed class ThreadSyncHandler(EventPipeline pipeline) :
     IEventHandler<ThreadListSyncedEventArgs>
 {
-    private static readonly JsonSerializerOptions JsonOptions = new()
+    private static readonly JsonSerializerOptions JsonOptions = new JsonSerializerOptions
     {
         PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
         WriteIndented = false

--- a/src/DiscordEventService/Services/EventHandlers/VoiceEventHandler.cs
+++ b/src/DiscordEventService/Services/EventHandlers/VoiceEventHandler.cs
@@ -23,7 +23,6 @@ public sealed class VoiceEventHandler(EventPipeline pipeline) :
                     ChannelDiscordIdAfter = args.After?.Channel?.Id,
                     EventType = eventType,
 
-                    // Before state flags
                     WasSelfMuted = args.Before?.IsSelfMuted ?? false,
                     WasSelfDeafened = args.Before?.IsSelfDeafened ?? false,
                     WasServerMuted = args.Before?.IsServerMuted ?? false,
@@ -32,7 +31,6 @@ public sealed class VoiceEventHandler(EventPipeline pipeline) :
                     WasVideo = args.Before?.IsSelfVideo ?? false,
                     WasSuppressed = args.Before?.IsSuppressed ?? false,
 
-                    // After state flags
                     IsSelfMuted = args.After?.IsSelfMuted ?? false,
                     IsSelfDeafened = args.After?.IsSelfDeafened ?? false,
                     IsServerMuted = args.After?.IsServerMuted ?? false,
@@ -59,19 +57,15 @@ public sealed class VoiceEventHandler(EventPipeline pipeline) :
         var beforeChannelId = args.Before?.Channel?.Id;
         var afterChannelId = args.After?.Channel?.Id;
 
-        // Joined: before channel null, after not null
         if (beforeChannelId == null && afterChannelId != null)
             return VoiceEventType.Joined;
 
-        // Left: before not null, after null
         if (beforeChannelId != null && afterChannelId == null)
             return VoiceEventType.Left;
 
-        // Moved: both not null, different
         if (beforeChannelId != null && afterChannelId != null && beforeChannelId != afterChannelId)
             return VoiceEventType.Moved;
 
-        // StateChanged: same channel, flags changed
         return VoiceEventType.StateChanged;
     }
 }

--- a/src/DiscordEventService/Services/FailedEventService.cs
+++ b/src/DiscordEventService/Services/FailedEventService.cs
@@ -7,7 +7,7 @@ namespace DiscordEventService.Services;
 
 public class FailedEventService(DiscordDbContext db, ILogger<FailedEventService> logger, IHostEnvironment env)
 {
-    private static readonly SemaphoreSlim _fallbackFileLock = new(1, 1);
+    private static readonly SemaphoreSlim _fallbackFileLock = new SemaphoreSlim(1, 1);
 
     public async Task RecordFailureAsync(
         string eventType,
@@ -93,22 +93,9 @@ public class FailedEventService(DiscordDbContext db, ILogger<FailedEventService>
         }
     }
 
-    /// <summary>
-    /// Acknowledges/resolves a failed event so the <c>HealthCheckJob</c> alert (which counts
-    /// <c>!IsResolved</c> rows in a window) can clear by explicit operator action rather than only
-    /// by aging out. Idempotent: filters on <c>!IsResolved</c>, so re-resolving or a missing id is a
-    /// no-op returning <c>false</c>. A single set-based update — no transaction ceremony.
-    /// </summary>
-    /// <remarks>
-    /// This is the feasible dead-letter kernel (ack/annotate). Automatic replay via
-    /// <c>EventJson</c> reconstruction is deliberately NOT implemented: that payload is lossy
-    /// (BypassRecursiveConverterResolver, MaxDepth, snowflake-dict shape) and DSharpPlus
-    /// <c>*EventArgs</c> have no deserialization path, so a handler cannot be re-driven from it
-    /// (deferred — OrphanReplayService OD#5). <see cref="FailedEventEntity.RetryCount"/> stays
-    /// reserved for a future per-event-type replayer that re-drives from current state.
-    /// Unresolved rows are the manual-review bucket; record transient-vs-permanent context in
-    /// <paramref name="notes"/>.
-    /// </remarks>
+    // Idempotent ack/annotate: filters on !IsResolved, so re-resolving or a missing id is a no-op
+    // returning false. Automatic replay from EventJson is deliberately not implemented — that
+    // payload is lossy and DSharpPlus *EventArgs have no deserialization path.
     public async Task<bool> ResolveAsync(Guid id, string? notes, CancellationToken cancellationToken = default)
     {
         var resolved = await db.FailedEvents

--- a/src/DiscordEventService/Services/HeartbeatBackgroundService.cs
+++ b/src/DiscordEventService/Services/HeartbeatBackgroundService.cs
@@ -35,9 +35,7 @@ public class HeartbeatBackgroundService(
             try
             {
                 if (!await timer.WaitForNextTickAsync(stoppingToken))
-                {
                     break;
-                }
             }
             catch (OperationCanceledException)
             {

--- a/src/DiscordEventService/Services/MemberRoleSnapshotBackfillService.cs
+++ b/src/DiscordEventService/Services/MemberRoleSnapshotBackfillService.cs
@@ -1,10 +1,10 @@
+using System.Text.Json;
 using DiscordEventService.Data;
 using DiscordEventService.Data.Entities.Core;
 using DiscordEventService.Data.Entities.Events;
 using DSharpPlus;
 using DSharpPlus.Exceptions;
 using Microsoft.EntityFrameworkCore;
-using System.Text.Json;
 
 namespace DiscordEventService.Services;
 
@@ -21,7 +21,9 @@ public class MemberRoleSnapshotBackfillService(
 
     public async Task<Result> BackfillAsync(CancellationToken ct)
     {
-        int eventsProcessed = 0, created = 0, closed = 0;
+        var eventsProcessed = 0;
+        var created = 0;
+        var closed = 0;
 
         var memberLookup = await db.Members
             .Include(m => m.User)
@@ -115,7 +117,7 @@ public class MemberRoleSnapshotBackfillService(
         Dictionary<(ulong UserDiscordId, ulong GuildDiscordId), Guid> memberLookup,
         CancellationToken ct)
     {
-        int seeded = 0;
+        var seeded = 0;
         var guildIds = memberLookup.Keys.Select(k => k.GuildDiscordId).Distinct();
 
         foreach (var guildDiscordId in guildIds)
@@ -135,9 +137,7 @@ public class MemberRoleSnapshotBackfillService(
 
             var members = new List<DSharpPlus.Entities.DiscordMember>();
             await foreach (var member in guild.GetAllMembersAsync())
-            {
                 members.Add(member);
-            }
 
             logger.LogInformation("Seeding current roles for {Count} members in guild {Guild}",
                 members.Count, guildDiscordId);

--- a/src/DiscordEventService/Services/MemeIndexing/AttachmentUrlRefreshService.cs
+++ b/src/DiscordEventService/Services/MemeIndexing/AttachmentUrlRefreshService.cs
@@ -6,10 +6,6 @@ using Microsoft.Extensions.Options;
 
 namespace DiscordEventService.Services.MemeIndexing;
 
-// Stored attachment URLs are signed and expire ~24h after capture (ADR-0004).
-// Discord's attachments/refresh-urls endpoint re-signs them — verified to work
-// with any bot token, no guild membership required — which makes indexing
-// purely DB-driven: no gateway, no message re-fetch, ~50 URLs per call.
 public sealed class AttachmentUrlRefreshService(
     IHttpClientFactory httpClientFactory,
     IOptions<DiscordOptions> discordOptions,
@@ -20,8 +16,6 @@ public sealed class AttachmentUrlRefreshService(
     private const int BatchSize = 50;
     private static readonly TimeSpan DelayBetweenBatches = TimeSpan.FromMilliseconds(300);
 
-    // Returns a map keyed by StripQuery(stored url) → freshly signed URL.
-    // URLs Discord declined to refresh are simply absent from the map.
     public async Task<Dictionary<string, string>> RefreshAsync(
         IReadOnlyCollection<string> storedUrls,
         CancellationToken cancellationToken)

--- a/src/DiscordEventService/Services/MemeIndexing/BenchmarkReportWriter.cs
+++ b/src/DiscordEventService/Services/MemeIndexing/BenchmarkReportWriter.cs
@@ -18,9 +18,6 @@ public sealed record BenchmarkRun(
     string[] Models,
     List<BenchmarkItem> Items);
 
-// Pure markdown rendering of a benchmark run — side-by-side model outputs per
-// meme so the winner can be picked by eyeballing (#219). Inline images use the
-// fresh signed CDN URLs, which stay valid ~24h after the run.
 public static class BenchmarkReportWriter
 {
     public static string Render(BenchmarkRun run)
@@ -89,6 +86,7 @@ public static class BenchmarkReportWriter
         sb.AppendLine();
         if (item.FreshUrl is not null)
         {
+            // Fresh signed CDN URL — stays valid only ~24h after the run.
             sb.AppendLine($"![meme]({item.FreshUrl})");
             sb.AppendLine();
         }
@@ -107,10 +105,8 @@ public static class BenchmarkReportWriter
         sb.AppendLine();
     }
 
-    private static void AppendRow(StringBuilder sb, string field, List<BenchmarkCell> cells, Func<BenchmarkCell, string?> value)
-    {
+    private static void AppendRow(StringBuilder sb, string field, List<BenchmarkCell> cells, Func<BenchmarkCell, string?> value) =>
         sb.AppendLine($"| {field} | {string.Join(" | ", cells.Select(c => Escape(value(c) ?? "—")))} |");
-    }
 
     private static string JumpLink(MemeSampleItem sample) =>
         $"https://discord.com/channels/{sample.GuildDiscordId}/{sample.ChannelDiscordId}/{sample.MessageDiscordId}";

--- a/src/DiscordEventService/Services/MemeIndexing/ImageMagic.cs
+++ b/src/DiscordEventService/Services/MemeIndexing/ImageMagic.cs
@@ -1,8 +1,5 @@
 namespace DiscordEventService.Services.MemeIndexing;
 
-// Magic-byte MIME sniffing for the formats in indexing scope. Attachment
-// filenames lie often enough (FB_IMG_*.jpg that is really png) that the
-// bytes, not the extension, decide what we tell the vision model.
 public static class ImageMagic
 {
     private static readonly string[] ImageExtensions = ["jpg", "jpeg", "png", "webp", "gif"];
@@ -13,6 +10,7 @@ public static class ImageMagic
         return ImageExtensions.Contains(ext);
     }
 
+    // Filenames lie (FB_IMG_*.jpg that is really png) — bytes decide what we tell the vision model.
     public static string? SniffMimeType(ReadOnlySpan<byte> bytes)
     {
         if (bytes.Length < 12)

--- a/src/DiscordEventService/Services/MemeIndexing/MemeAttachmentIndexer.cs
+++ b/src/DiscordEventService/Services/MemeIndexing/MemeAttachmentIndexer.cs
@@ -20,11 +20,7 @@ public sealed class MemeIndexRunCounters
     public decimal CostUsd { get; set; }
 }
 
-// The per-attachment indexing pipeline (#221): download → MIME sniff → sha256
-// repost dedupe → vision model → status lifecycle. Extracted from
-// MemeIndexingJob so the live single-message path (#222) and the backfill/sweep
-// runs share one implementation. The DbContext stays a parameter — callers own
-// the unit of work and decide when to flush.
+// The DbContext stays a parameter — callers own the unit of work and decide when to flush.
 public sealed class MemeAttachmentIndexer(
     OpenRouterClient openRouterClient,
     IHttpClientFactory httpClientFactory,
@@ -49,7 +45,7 @@ public sealed class MemeAttachmentIndexer(
             AttachmentDiscordId = item.AttachmentDiscordId,
             FileName = item.FileName,
             FileSizeBytes = item.FileSizeBytes,
-            Status = MemeIndexStatus.Pending
+            Status = MemeIndexStatus.Pending,
         };
         db.MemeIndex.Add(row);
         return row;

--- a/src/DiscordEventService/Services/MemeIndexing/MemeMetadata.cs
+++ b/src/DiscordEventService/Services/MemeIndexing/MemeMetadata.cs
@@ -2,8 +2,6 @@ using System.Text.Json.Serialization;
 
 namespace DiscordEventService.Services.MemeIndexing;
 
-// The vision-model output contract for one image (ADR-0004/0005, #219).
-// Bilingual on purpose: tags mix PL+EN so either query language lands.
 public sealed record MemeMetadata
 {
     [JsonPropertyName("description_pl")]
@@ -37,7 +35,7 @@ public enum MemeAnalysisOutcome
     Refusal,
 
     // Transport/API/parse failure. Transient flavours are retryable.
-    Error
+    Error,
 }
 
 public sealed record MemeAnalysisUsage(int PromptTokens, int CompletionTokens, decimal? CostUsd);

--- a/src/DiscordEventService/Services/MemeIndexing/MemeSampleService.cs
+++ b/src/DiscordEventService/Services/MemeIndexing/MemeSampleService.cs
@@ -6,10 +6,7 @@ using Microsoft.Extensions.Options;
 
 namespace DiscordEventService.Services.MemeIndexing;
 
-// One image attachment in a meme channel: snowflakes for the jump link plus
-// the stored (expired) CDN URL, which AttachmentUrlRefreshService re-signs.
-// The trailing defaults keep pre-#221 benchmark links files deserializable —
-// old exports simply lack MessageId/FileSizeBytes.
+// Trailing defaults keep pre-#221 benchmark links files deserializable — old exports lack MessageId/FileSizeBytes.
 public sealed record MemeSampleItem(
     ulong GuildDiscordId,
     ulong ChannelDiscordId,
@@ -29,10 +26,6 @@ public sealed class MemeSampleService(
     // Matches the 4-field shape MessageEventHandler/MessagesBackfillJob serialize.
     private sealed record StoredAttachment(ulong Id, string? Url, string? FileName, int FileSize);
 
-    // Stratified-by-year random sample of image attachments from the configured
-    // meme channels. Old low-res memes must be represented in the benchmark, so
-    // quota is distributed round-robin across years rather than uniformly over
-    // rows (recent years would otherwise dominate).
     public async Task<List<MemeSampleItem>> SampleAsync(int sampleSize, CancellationToken cancellationToken)
     {
         var candidates = await GetCandidatesAsync(cancellationToken);
@@ -45,8 +38,7 @@ public sealed class MemeSampleService(
         return picked;
     }
 
-    // Shared by the DB path above and the links-file path (prod export run
-    // locally): round-robin across years so old low-res memes are represented.
+    // Round-robin across years so old low-res memes are represented, not drowned out by recent years.
     public static List<MemeSampleItem> Stratify(IReadOnlyCollection<MemeSampleItem> candidates, int sampleSize)
     {
         var byYear = candidates
@@ -70,14 +62,9 @@ public sealed class MemeSampleService(
         return picked;
     }
 
-    // Also the candidate source for the indexing job (#221) — every image
-    // attachment in the configured meme channels, no sampling.
     public Task<List<MemeSampleItem>> GetCandidatesAsync(CancellationToken cancellationToken)
         => GetCandidatesCoreAsync(messageDiscordId: null, cancellationToken);
 
-    // #222 live path: the candidates of ONE message (empty when the message is
-    // not in a configured meme channel — the job-level guard behind the
-    // handler's channel filter).
     public Task<List<MemeSampleItem>> GetCandidatesForMessageAsync(
         ulong messageDiscordId, CancellationToken cancellationToken)
         => GetCandidatesCoreAsync(messageDiscordId, cancellationToken);

--- a/src/DiscordEventService/Services/MemeIndexing/MemeSearchService.cs
+++ b/src/DiscordEventService/Services/MemeIndexing/MemeSearchService.cs
@@ -4,8 +4,6 @@ using Microsoft.EntityFrameworkCore;
 
 namespace DiscordEventService.Services.MemeIndexing;
 
-// One ranked /meme hit. Snowflakes for the jump link + fresh-URL re-fetch,
-// descriptions for the "why it matched" snippet.
 public sealed record MemeSearchHit(
     ulong ChannelDiscordId,
     ulong MessageDiscordId,
@@ -17,12 +15,6 @@ public sealed record MemeSearchHit(
     DateTime MessageCreatedAtUtc,
     double Score);
 
-// #224 ranked hybrid search over Indexed memes (binding design on #224, column
-// semantics pinned by MemeIndexSchemaTests): an OR'd to_tsquery gate — NOT
-// websearch AND-semantics, the 'simple' config keeps stopwords so AND would
-// zero out natural-language queries — plus a word_similarity trigram rescue
-// for Polish inflections and typos (no Polish stemmer exists). Relevance comes
-// from the rank blend, not the gate; recency breaks ties.
 public sealed class MemeSearchService(DiscordDbContext db)
 {
     public const int DefaultLimit = 5;
@@ -44,8 +36,9 @@ public sealed class MemeSearchService(DiscordDbContext db)
         if (tokens.Count == 0)
             return [];
 
-        // Tokens are alphanumeric-only, so joining with the OR operator cannot
-        // inject other tsquery syntax (&, !, parentheses, prefix stars).
+        // OR not AND: the 'simple' config keeps stopwords, so AND-semantics would
+        // zero out natural-language queries. Tokens are alphanumeric-only, so the
+        // OR operator cannot inject other tsquery syntax (&, !, parens, prefix stars).
         var orQuery = string.Join(" | ", tokens);
         var guild = (long)guildId;
         var indexed = (int)MemeIndexStatus.Indexed;

--- a/src/DiscordEventService/Services/MemeIndexing/OpenRouterClient.cs
+++ b/src/DiscordEventService/Services/MemeIndexing/OpenRouterClient.cs
@@ -8,11 +8,6 @@ using Microsoft.Extensions.Options;
 
 namespace DiscordEventService.Services.MemeIndexing;
 
-// Thin typed client over OpenRouter's /chat/completions. Structured outputs
-// (response_format: json_schema, strict) make the model return the
-// MemeMetadata contract directly — no markdown-fence scraping like the old
-// image-contents-search-poc. usage.include=true gets the real cost back from
-// OpenRouter instead of us keeping price tables.
 public sealed class OpenRouterClient(
     IHttpClientFactory httpClientFactory,
     IOptions<OpenRouterOptions> options,
@@ -22,7 +17,7 @@ public sealed class OpenRouterClient(
 
     private static readonly JsonSerializerOptions JsonOptions = new JsonSerializerOptions
     {
-        DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull
+        DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull,
     };
 
     private const string SystemPrompt =
@@ -37,7 +32,8 @@ public sealed class OpenRouterClient(
         - template: the canonical meme template name (e.g. "drake", "distracted boyfriend", "doge"), or null if not a recognizable template.
         """;
 
-    // strict json_schema: every property required, nullability expressed in types.
+    // strict json_schema makes the model return the MemeMetadata contract directly (no
+    // markdown-fence scraping): every property required, nullability expressed in types.
     private static readonly object ResponseSchema = new
     {
         type = "json_schema",
@@ -57,10 +53,10 @@ public sealed class OpenRouterClient(
                     ocr_text = new { type = "string" },
                     tags = new { type = "array", items = new { type = "string" } },
                     source = new { type = new[] { "string", "null" } },
-                    template = new { type = new[] { "string", "null" } }
-                }
-            }
-        }
+                    template = new { type = new[] { "string", "null" } },
+                },
+            },
+        },
     };
 
     public async Task<MemeAnalysisResult> AnalyzeImageAsync(
@@ -87,10 +83,10 @@ public sealed class OpenRouterClient(
                         new
                         {
                             type = "image_url",
-                            image_url = new { url = $"data:{mimeType};base64,{Convert.ToBase64String(imageBytes)}" }
-                        }
-                    }
-                }
+                            image_url = new { url = $"data:{mimeType};base64,{Convert.ToBase64String(imageBytes)}" },
+                        },
+                    },
+                },
             },
             // No reasoning override: effort=low made gemini-2.5-flash return
             // empty content; the raised max_tokens budget is what thinking
@@ -98,7 +94,8 @@ public sealed class OpenRouterClient(
             response_format = ResponseSchema,
             max_tokens = opts.MaxOutputTokens,
             temperature = 0.2,
-            usage = new { include = true }
+            // include=true returns the real cost from OpenRouter instead of us keeping price tables.
+            usage = new { include = true },
         };
 
         using var request = new HttpRequestMessage(HttpMethod.Post, "chat/completions");

--- a/src/DiscordEventService/Services/MessageMentionsBackfillService.cs
+++ b/src/DiscordEventService/Services/MessageMentionsBackfillService.cs
@@ -39,10 +39,10 @@ public partial class MessageMentionsBackfillService(
         logger.LogInformation("Mention backfill: {Total} messages with content, {Skipped} already have mentions",
             messages.Count, alreadyProcessed.Count);
 
-        int scanned = messages.Count;
-        int skipped = 0;
-        int processed = 0;
-        int mentionsCreated = 0;
+        var scanned = messages.Count;
+        var skipped = 0;
+        var processed = 0;
+        var mentionsCreated = 0;
 
         foreach (var msg in messages)
         {

--- a/src/DiscordEventService/Services/OrphanReplayService.cs
+++ b/src/DiscordEventService/Services/OrphanReplayService.cs
@@ -8,20 +8,7 @@ public record OrphanReplayResult(int Scanned, int Inserted, int Skipped);
 
 public class OrphanReplayService(DiscordDbContext db, ILogger<OrphanReplayService> logger)
 {
-    // Scan-only for now. Reconstruction (BuildMemberUpdateEntityFromJson) is
-    // deferred until a real (non-stub) GuildMemberUpdated orphan appears in
-    // prod and we can sample its JSON shape — the Newtonsoft-with-[JsonProperty]
-    // field names for GuildMemberUpdatedEventArgs aren't predictable without one.
-    // Any such row is logged at Warn below so it can be reverse-engineered.
-    //
-    // Note for future reconstruction work: most non-stub orphans will NOT be
-    // handler crashes. MemberEventHandler.HandleEventAsync(GuildMemberUpdatedEventArgs)
-    // only inserts a MemberEventEntity when a watched field changed (nickname,
-    // roles, timeout, avatar, pending, premium, mute, deafen — see lines 146-180).
-    // GuildMemberUpdated for any other field (Member.Flags, UnusualDmActivityUntil,
-    // etc.) writes the raw log but intentionally skips the structured insert.
-    // Reconstruction must re-apply that same change-detection or it will
-    // resurrect rows the handler purposefully filtered out.
+    // Scan-only: JSON reconstruction is deferred until a real non-stub orphan is sampled in prod.
     public async Task<OrphanReplayResult> ReplayMemberUpdateOrphansAsync(CancellationToken ct)
     {
         var orphans = await db.RawEventLogs

--- a/src/DiscordEventService/Services/Pipeline/EventPipeline.cs
+++ b/src/DiscordEventService/Services/Pipeline/EventPipeline.cs
@@ -20,9 +20,7 @@ public sealed class EventPipeline(IServiceScopeFactory scopeFactory, ILoggerFact
         {
             string? rawJson = null;
 
-            // Records a FailedEvent in an isolated scope using this event's metadata. Used both
-            // by the pipeline's own exception path and by handlers that want to record a soft
-            // failure (e.g. an unresolved FK) and return without throwing.
+            // Isolated scope so a soft failure can be recorded even after the handler's scope faulted.
             async Task RecordFailureAsync(Exception ex)
             {
                 using var failureScope = scopeFactory.CreateScope();

--- a/src/DiscordEventService/Services/Pipeline/FkResolver.cs
+++ b/src/DiscordEventService/Services/Pipeline/FkResolver.cs
@@ -2,25 +2,11 @@ using DSharpPlus.Entities;
 
 namespace DiscordEventService.Services.Pipeline;
 
-/// <summary>
-/// Resolves a Discord guild/channel/user to their internal Guid FKs via the upsert services and
-/// validates that all three resolved. Concentrates the snowflake→Guid resolve + all-or-fail
-/// validation + failure-recording pattern that the required-FK handlers (e.g. MessageCreated)
-/// would otherwise repeat inline. Soft nullable-FK handlers keep consuming
-/// <see cref="UpsertResult{T}"/> directly and should NOT route through this resolver.
-/// </summary>
 public sealed class FkResolver(
     GuildUpsertService guildUpsert,
     ChannelUpsertService channelUpsert,
     UserService userService)
 {
-    /// <summary>
-    /// Upserts the guild, channel (under that guild), and user, then validates all resolved. On any
-    /// failure the resolver logs an aggregate line, records a <c>FailedEvent</c> via
-    /// <paramref name="ctx"/>, and returns <see cref="ResolvedFks.Failed"/> — the caller should
-    /// simply <c>return</c>. <paramref name="logContext"/> is appended to the failure log for
-    /// traceability (e.g. <c>"MessageId=123"</c>).
-    /// </summary>
     public async Task<ResolvedFks> ResolveAsync(
         EventContext ctx,
         DiscordGuild guild,
@@ -37,11 +23,6 @@ public sealed class FkResolver(
         return await ValidateAsync(ctx, guildResult, channelResult, userResult, logContext);
     }
 
-    /// <summary>
-    /// Pure validation seam: all three success → <see cref="ResolvedFks.Resolved"/>; otherwise log +
-    /// record failure + <see cref="ResolvedFks.Failed"/>. Takes already-resolved results so it is
-    /// unit-testable without constructing DSharpPlus entities.
-    /// </summary>
     internal static async Task<ResolvedFks> ValidateAsync(
         EventContext ctx,
         UpsertResult<Guid> guild,
@@ -60,13 +41,6 @@ public sealed class FkResolver(
         return ResolvedFks.Failed;
     }
 
-    /// <summary>
-    /// Guild+user variant of <see cref="ResolveAsync(EventContext, DiscordGuild, DiscordChannel, DiscordUser, string?)"/>
-    /// for required-FK handlers whose core row has no channel (e.g. <c>bans</c>). Upserts the guild
-    /// and user, then validates both resolved. On any failure the resolver logs, records a
-    /// <c>FailedEvent</c> via <paramref name="ctx"/>, and returns <see cref="ResolvedUserFks.Failed"/> —
-    /// the caller skips the core-row write (and, for a faithful timeline, may still log the event row).
-    /// </summary>
     public async Task<ResolvedUserFks> ResolveAsync(
         EventContext ctx,
         DiscordGuild guild,
@@ -79,12 +53,6 @@ public sealed class FkResolver(
         return await ValidateAsync(ctx, guildResult, userResult, logContext);
     }
 
-    /// <summary>
-    /// Pure guild+user validation seam, mirroring the three-FK <see cref="ValidateAsync(EventContext, UpsertResult{Guid}, UpsertResult{Guid}, UpsertResult{Guid}, string?)"/>:
-    /// both success → <see cref="ResolvedUserFks.Resolved"/>; otherwise log + record failure +
-    /// <see cref="ResolvedUserFks.Failed"/>. Takes already-resolved results so it is unit-testable
-    /// without constructing DSharpPlus entities.
-    /// </summary>
     internal static async Task<ResolvedUserFks> ValidateAsync(
         EventContext ctx,
         UpsertResult<Guid> guild,

--- a/src/DiscordEventService/Services/Pipeline/ResolvedFks.cs
+++ b/src/DiscordEventService/Services/Pipeline/ResolvedFks.cs
@@ -1,27 +1,16 @@
 namespace DiscordEventService.Services.Pipeline;
 
-/// <summary>
-/// Outcome of <see cref="FkResolver.ResolveAsync"/>: on success the three Guids are guaranteed
-/// resolved; on failure the resolver has already logged and recorded the failure, so the caller
-/// just returns. Mirrors <see cref="UpsertResult{T}"/>'s success/failure shape.
-/// </summary>
 public sealed record ResolvedFks(bool Success, Guid GuildId, Guid ChannelId, Guid UserId)
 {
     public static ResolvedFks Resolved(Guid guildId, Guid channelId, Guid userId) =>
-        new(true, guildId, channelId, userId);
+        new ResolvedFks(true, guildId, channelId, userId);
 
-    public static readonly ResolvedFks Failed = new(false, default, default, default);
+    public static readonly ResolvedFks Failed = new ResolvedFks(false, default, default, default);
 }
 
-/// <summary>
-/// Outcome of the guild+user <see cref="FkResolver.ResolveAsync(EventContext, DSharpPlus.Entities.DiscordGuild, DSharpPlus.Entities.DiscordUser, string?)"/>
-/// overload, for required-FK handlers whose core row carries only a guild and a user FK (e.g.
-/// <c>bans</c>) and so cannot use the channel-bearing <see cref="ResolvedFks"/>. Same success/failure
-/// contract, minus the channel.
-/// </summary>
 public sealed record ResolvedUserFks(bool Success, Guid GuildId, Guid UserId)
 {
-    public static ResolvedUserFks Resolved(Guid guildId, Guid userId) => new(true, guildId, userId);
+    public static ResolvedUserFks Resolved(Guid guildId, Guid userId) => new ResolvedUserFks(true, guildId, userId);
 
-    public static readonly ResolvedUserFks Failed = new(false, default, default);
+    public static readonly ResolvedUserFks Failed = new ResolvedUserFks(false, default, default);
 }

--- a/src/DiscordEventService/Services/RawEventLogService.cs
+++ b/src/DiscordEventService/Services/RawEventLogService.cs
@@ -1,15 +1,12 @@
+using System.Reflection;
 using DiscordEventService.Data;
 using DiscordEventService.Data.Entities.Events;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Serialization;
-using System.Reflection;
 
 namespace DiscordEventService.Services;
 
-/// <summary>
-/// Outcome of serializing an event. <see cref="Error"/> is non-null when serialization failed,
-/// in which case <see cref="Json"/> is a diagnostic stub (not the real payload).
-/// </summary>
+// Error is non-null when serialization failed; Json is then a diagnostic stub, not the real payload.
 public sealed record EventSerializationResult(string Json, Exception? Error)
 {
     public bool Failed => Error is not null;
@@ -17,10 +14,7 @@ public sealed record EventSerializationResult(string Json, Exception? Error)
 
 public class RawEventLogService(DiscordDbContext dbContext, ILogger<RawEventLogService> logger)
 {
-    /// <summary>
-    /// Marker value placed in the <c>error</c> field of a serialization-failure stub.
-    /// Kept as a constant so detectors don't hard-code the literal.
-    /// </summary>
+    // Marker in the error field of a serialization-failure stub — kept constant so detectors don't hard-code the literal.
     public const string SerializationFailedMarker = "Serialization failed";
 
     // #107 switched to Newtonsoft to fix System.Text.Json's
@@ -36,7 +30,7 @@ public class RawEventLogService(DiscordDbContext dbContext, ILogger<RawEventLogS
     // letting Newtonsoft fall back to default Dictionary serialization (the
     // resulting JSON shape is a dict of snowflakes instead of an array — fine
     // for raw_event_logs which is replay/debug, not a Discord-wire payload).
-    private static readonly JsonSerializerSettings JsonSettings = new()
+    private static readonly JsonSerializerSettings JsonSettings = new JsonSerializerSettings
     {
         ContractResolver = new BypassRecursiveConverterResolver(),
         ReferenceLoopHandling = ReferenceLoopHandling.Ignore,
@@ -44,12 +38,8 @@ public class RawEventLogService(DiscordDbContext dbContext, ILogger<RawEventLogS
         MaxDepth = 32,
     };
 
-    /// <summary>
-    /// Serializes an event args object to JSON. On failure returns a diagnostic stub and reports
-    /// the exception via <see cref="EventSerializationResult.Error"/> so the caller can flag the
-    /// row and record the failure — the failure is NOT swallowed here (no log; the caller owns it,
-    /// where it has handler/correlation context).
-    /// </summary>
+    // On failure returns a diagnostic stub and surfaces the exception via Error rather than swallowing it
+    // here — the caller owns the failure, where it has handler/correlation context.
     public EventSerializationResult SerializeEvent<T>(T eventArgs) where T : class
     {
         try
@@ -70,9 +60,6 @@ public class RawEventLogService(DiscordDbContext dbContext, ILogger<RawEventLogS
         }
     }
 
-    /// <summary>
-    /// Logs a raw event to the RawEventLog table.
-    /// </summary>
     public async Task LogRawEventAsync(
         string eventType,
         string eventJson,
@@ -106,9 +93,6 @@ public class RawEventLogService(DiscordDbContext dbContext, ILogger<RawEventLogS
         }
     }
 
-    /// <summary>
-    /// Convenience method to serialize and log in one call.
-    /// </summary>
     public async Task<EventSerializationResult> SerializeAndLogAsync<T>(
         T eventArgs,
         string eventType,
@@ -129,7 +113,7 @@ public class RawEventLogService(DiscordDbContext dbContext, ILogger<RawEventLogS
         // recursion. Strip it so the default object/dictionary serializer runs.
         private const string ProblemConverterName = "SnowflakeArrayAsDictionaryJsonConverter";
 
-        private static readonly HashSet<string> SensitiveProperties = new(StringComparer.OrdinalIgnoreCase)
+        private static readonly HashSet<string> SensitiveProperties = new HashSet<string>(StringComparer.OrdinalIgnoreCase)
         {
             "VoiceToken"
         };

--- a/src/DiscordEventService/Services/StartupValidator.cs
+++ b/src/DiscordEventService/Services/StartupValidator.cs
@@ -5,12 +5,8 @@ using Microsoft.Extensions.Caching.Memory;
 
 namespace DiscordEventService.Services;
 
-/// <summary>
-/// Validates that every service event handlers depend on is registered in the
-/// DSharpPlus child DI container. Without this, missing registrations only
-/// surface at runtime when the handler actually fires — sometimes hours after
-/// deploy, often only logged at Error level inside a handler's catch block.
-/// </summary>
+// Missing child-container registrations otherwise surface only at runtime when a handler
+// fires — sometimes hours after deploy, often only logged at Error inside a catch block.
 public static class StartupValidator
 {
     // Services event handlers resolve via scopeFactory.CreateScope().
@@ -39,9 +35,7 @@ public static class StartupValidator
             {
                 var service = scope.ServiceProvider.GetService(type);
                 if (service is null)
-                {
                     failures.Add($"{type.FullName} is not registered");
-                }
             }
             catch (Exception ex)
             {

--- a/src/DiscordEventService/Services/UpsertResult.cs
+++ b/src/DiscordEventService/Services/UpsertResult.cs
@@ -1,10 +1,6 @@
 namespace DiscordEventService.Services;
 
-/// <summary>
-/// Outcome of an upsert: success carries the resolved <typeparamref name="T"/>; failure carries a
-/// reason (already logged by the service). Replaces the prior <c>Guid.Empty</c>-as-error sentinel so
-/// callers branch on <see cref="IsSuccess"/> instead of pattern-matching a magic value.
-/// </summary>
+// Replaces the prior Guid.Empty-as-error sentinel so callers branch on IsSuccess, not a magic value.
 public sealed record UpsertResult<T>(bool IsSuccess, T? Value, string? FailureReason)
 {
     public static UpsertResult<T> Success(T value) => new(true, value, null);

--- a/tests/DiscordEventService.Tests/AttachmentUrlRefreshServiceTests.cs
+++ b/tests/DiscordEventService.Tests/AttachmentUrlRefreshServiceTests.cs
@@ -14,7 +14,7 @@ public sealed class AttachmentUrlRefreshServiceTests
     [Fact]
     public async Task RefreshAsync_StripsQueryBatchesAndMapsResults()
     {
-        var requests = new List<List<string>>();
+        List<List<string>> requests = [];
         var service = NewService(req =>
         {
             var body = req.Content!.ReadAsStringAsync().GetAwaiter().GetResult();
@@ -87,7 +87,8 @@ public sealed class AttachmentUrlRefreshServiceTests
     }
 
     private static AttachmentUrlRefreshService NewService(Func<HttpRequestMessage, HttpResponseMessage> respond) =>
-        new(new StubHttpClientFactory(new StubHandler(respond)),
+        new AttachmentUrlRefreshService(
+            new StubHttpClientFactory(new StubHandler(respond)),
             Options.Create(new DiscordOptions { Token = new string('x', 60) }),
             NullLogger<AttachmentUrlRefreshService>.Instance);
 

--- a/tests/DiscordEventService.Tests/CommunityStatsTests.cs
+++ b/tests/DiscordEventService.Tests/CommunityStatsTests.cs
@@ -106,7 +106,6 @@ public sealed class CommunityStatsTests(PostgresFixture fixture) : IClassFixture
         var thisWeek = DateTime.UtcNow.AddDays(-1);
         var priorWeek = DateTime.UtcNow.AddDays(-10); // inside prev 7-14d window
 
-        // This-week messages: alice x2 (one with attachment, one with embed), bob x1 (plain).
         _db.Messages.AddRange(
             Message(alice.Id, channel.Id, guild.Id, 1UL, thisWeek, attach: true),
             Message(alice.Id, channel.Id, guild.Id, 2UL, thisWeek, embed: true),
@@ -114,12 +113,10 @@ public sealed class CommunityStatsTests(PostgresFixture fixture) : IClassFixture
             // Prior-week message (counts in prev, excluded from current value).
             Message(alice.Id, channel.Id, guild.Id, 4UL, priorWeek));
 
-        // Reactions received on alice's messages this week: 2 added.
         _db.ReactionEvents.AddRange(
             Reaction(Bob, "👍", 1UL, thisWeek),
             Reaction(Bob, "🎉", 2UL, thisWeek));
 
-        // Voice: alice 12 min this week.
         var v = thisWeek;
         _db.VoiceStateEvents.AddRange(
             Voice(Alice, null, ChannelSf, VoiceEventType.Joined, v),
@@ -140,7 +137,7 @@ public sealed class CommunityStatsTests(PostgresFixture fixture) : IClassFixture
 
     private static MessageEntity Message(
         Guid authorId, Guid channelId, Guid guildId, ulong discordId, DateTime at,
-        bool attach = false, bool embed = false) => new()
+        bool attach = false, bool embed = false) => new MessageEntity
         {
             DiscordId = discordId,
             AuthorId = authorId,
@@ -152,7 +149,7 @@ public sealed class CommunityStatsTests(PostgresFixture fixture) : IClassFixture
             CreatedAtUtc = at,
         };
 
-    private static ReactionEventEntity Reaction(ulong user, string emote, ulong messageId, DateTime at) => new()
+    private static ReactionEventEntity Reaction(ulong user, string emote, ulong messageId, DateTime at) => new ReactionEventEntity
     {
         UserDiscordId = user,
         GuildDiscordId = GuildSf,
@@ -165,7 +162,7 @@ public sealed class CommunityStatsTests(PostgresFixture fixture) : IClassFixture
     };
 
     private static VoiceStateEventEntity Voice(
-        ulong user, ulong? before, ulong? after, VoiceEventType type, DateTime at) => new()
+        ulong user, ulong? before, ulong? after, VoiceEventType type, DateTime at) => new VoiceStateEventEntity
         {
             UserDiscordId = user,
             GuildDiscordId = GuildSf,

--- a/tests/DiscordEventService.Tests/EntitiesControllerTests.cs
+++ b/tests/DiscordEventService.Tests/EntitiesControllerTests.cs
@@ -1,7 +1,7 @@
 using System.Text.Json;
 using DiscordEventService.Controllers;
-using DiscordEventService.Data.Entities.Core;
 using DiscordEventService.Data;
+using DiscordEventService.Data.Entities.Core;
 using DiscordEventService.Dtos;
 using DiscordEventService.Infrastructure;
 using Microsoft.AspNetCore.Mvc;

--- a/tests/DiscordEventService.Tests/FailedEventResolveTests.cs
+++ b/tests/DiscordEventService.Tests/FailedEventResolveTests.cs
@@ -92,7 +92,7 @@ public sealed class FailedEventResolveTests(PostgresFixture fixture)
     }
 
     private FailedEventService NewService() =>
-        new(NewContext(), NullLogger<FailedEventService>.Instance, new FakeHostEnvironment());
+        new FailedEventService(NewContext(), NullLogger<FailedEventService>.Instance, new FakeHostEnvironment());
 
     private DiscordDbContext NewContext()
     {

--- a/tests/DiscordEventService.Tests/FkResolverTests.cs
+++ b/tests/DiscordEventService.Tests/FkResolverTests.cs
@@ -114,7 +114,7 @@ public sealed class FkResolverTests
     }
 
     private static EventContext NewContext(ILogger logger, List<Exception> recordedFailures) =>
-        new(
+        new EventContext(
             Db: null!,
             Services: null!,
             CorrelationId: Guid.NewGuid(),
@@ -141,7 +141,7 @@ public sealed class FkResolverTests
 
         private sealed class NullScope : IDisposable
         {
-            public static readonly NullScope Instance = new();
+            public static readonly NullScope Instance = new NullScope();
             public void Dispose() { }
         }
     }

--- a/tests/DiscordEventService.Tests/GuildControllerTests.cs
+++ b/tests/DiscordEventService.Tests/GuildControllerTests.cs
@@ -114,7 +114,7 @@ public sealed class GuildControllerTests(PostgresFixture fixture) : IClassFixtur
     }
 
     private static PresenceEventEntity Presence(
-        ulong user, DateTime at, int desktop = 0, int mobile = 0, int web = 0) => new()
+        ulong user, DateTime at, int desktop = 0, int mobile = 0, int web = 0) => new PresenceEventEntity
         {
             UserDiscordId = user,
             GuildDiscordId = GuildSf,

--- a/tests/DiscordEventService.Tests/HangfireSlidingInvisibilityTests.cs
+++ b/tests/DiscordEventService.Tests/HangfireSlidingInvisibilityTests.cs
@@ -7,12 +7,8 @@ using Xunit;
 
 namespace DiscordEventService.Tests;
 
-// Regression contract for the #219 benchmark incident: a job outliving the
-// fixed InvisibilityTimeout was presumed dead, re-fetched by another worker,
-// and a pay-per-run job restarted in a loop. UseSlidingInvisibilityTimeout
-// heartbeats fetchedat (every InvisibilityTimeout/5) while the worker is
-// alive, so a long job runs exactly once and the timeout only governs how
-// fast a genuinely dead worker's job is re-picked.
+// UseSlidingInvisibilityTimeout heartbeats fetchedat while the worker is alive, so a job
+// outliving InvisibilityTimeout runs exactly once instead of being re-fetched as dead.
 public sealed class HangfireSlidingInvisibilityTests(PostgresFixture fixture) : IClassFixture<PostgresFixture>
 {
     private static readonly TimeSpan InvisibilityTimeout = TimeSpan.FromSeconds(5);
@@ -86,9 +82,7 @@ public sealed class HangfireSlidingInvisibilityTests(PostgresFixture fixture) : 
     }
 }
 
-// Public so Hangfire's activator can resolve and invoke it from the persisted
-// job payload. Sleeps in slices so a test can release still-running
-// executions instead of stalling server shutdown.
+// Public so Hangfire's activator can invoke it from the persisted job payload.
 public static class SlowJobProbe
 {
     private static readonly ConcurrentDictionary<string, int> _executions = new();

--- a/tests/DiscordEventService.Tests/HealthCheckEventRatioTests.cs
+++ b/tests/DiscordEventService.Tests/HealthCheckEventRatioTests.cs
@@ -25,11 +25,6 @@ public sealed class HealthCheckEventRatioTests(PostgresFixture fixture)
 
     public Task DisposeAsync() => _db.DisposeAsync().AsTask();
 
-    /// <summary>
-    /// A type whose recent count collapses against its time-of-day baseline only alerts once the
-    /// drop has persisted for EventRatioConsecutiveRuns runs (debounce), and excluded voice types
-    /// never alert at all — even when their counts collapse identically.
-    /// </summary>
     [Fact]
     public async Task EventRatioDrop_DebouncesAcrossRuns_AndExcludesVoice()
     {
@@ -37,8 +32,11 @@ public sealed class HealthCheckEventRatioTests(PostgresFixture fixture)
 
         // Baseline: 20 events/day for each of the previous 7 days, ~1h before "now" so they land
         // inside the 6h time-of-day baseline window. One normal type and one excluded voice type.
-        foreach (var type in new[] { "MessageCreated", "VoiceStateUpdated" })
+        string[] eventTypes = ["MessageCreated", "VoiceStateUpdated"];
+        foreach (var type in eventTypes)
+        {
             for (var day = 1; day <= 7; day++)
+            {
                 for (var i = 0; i < 20; i++)
                     _db.RawEventLogs.Add(new RawEventLogEntity
                     {
@@ -47,6 +45,8 @@ public sealed class HealthCheckEventRatioTests(PostgresFixture fixture)
                         EventJson = "{}",
                         ReceivedAtUtc = now.AddDays(-day).AddHours(-1).AddSeconds(i),
                     });
+            }
+        }
         // Recent 6h window: nothing seeded for either type -> both read as a near-total drop.
         await _db.SaveChangesAsync();
 

--- a/tests/DiscordEventService.Tests/MemeIndexLiveAndSweepTests.cs
+++ b/tests/DiscordEventService.Tests/MemeIndexLiveAndSweepTests.cs
@@ -12,10 +12,6 @@ using Xunit;
 
 namespace DiscordEventService.Tests;
 
-// #222 acceptance contracts: the live single-message path (IndexMessageAsync),
-// the weekly healing sweep (ExecuteSweepAsync + MemeIndexSweepJob coordinator),
-// end-to-end against real Postgres with the same handler-level HTTP fakes as
-// MemeIndexingJobTests.
 public sealed class MemeIndexLiveAndSweepTests(PostgresFixture fixture) : IClassFixture<PostgresFixture>, IAsyncLifetime
 {
     private const ulong GuildDiscordId = 1UL;
@@ -316,8 +312,7 @@ public sealed class MemeIndexLiveAndSweepTests(PostgresFixture fixture) : IClass
     }
 }
 
-// Captures Hangfire enqueues without a storage backend; the coordinator's
-// contract is "which jobs got created", not their execution.
+// Captures enqueues without a storage backend.
 internal sealed class RecordingJobClient : IBackgroundJobClient
 {
     public List<Job> Created { get; } = [];

--- a/tests/DiscordEventService.Tests/MemeIndexSchemaTests.cs
+++ b/tests/DiscordEventService.Tests/MemeIndexSchemaTests.cs
@@ -6,9 +6,6 @@ using Xunit;
 
 namespace DiscordEventService.Tests;
 
-// #220 acceptance contracts for the meme_index schema: idempotency key,
-// status lifecycle CHECK, FTS + trigram search semantics on the stored
-// generated columns, and the soft-delete join shape /meme (§6) will use.
 public sealed class MemeIndexSchemaTests(PostgresFixture fixture) : IClassFixture<PostgresFixture>, IAsyncLifetime
 {
     private DiscordDbContext _db = null!;

--- a/tests/DiscordEventService.Tests/MemeIndexingJobTests.cs
+++ b/tests/DiscordEventService.Tests/MemeIndexingJobTests.cs
@@ -12,9 +12,6 @@ using Xunit;
 
 namespace DiscordEventService.Tests;
 
-// #221 acceptance contracts, end-to-end against real Postgres with the three
-// HTTP surfaces (refresh-urls, CDN, OpenRouter) faked at the handler level —
-// the job, executor, sampler, refresh service, and client all run for real.
 public sealed class MemeIndexingJobTests(PostgresFixture fixture) : IClassFixture<PostgresFixture>, IAsyncLifetime
 {
     private const ulong GuildDiscordId = 1UL;
@@ -312,12 +309,9 @@ public sealed class MemeIndexingJobTests(PostgresFixture fixture) : IClassFixtur
     }
 }
 
-// Routes the three HTTP surfaces the job touches. CDN bytes are keyed by
-// attachment id parsed from the URL path; refresh succeeds for everything
-// except DeadAttachments (absent from the refresh response, like Discord).
 internal sealed class FakeMemeHttpHandler : HttpMessageHandler
 {
-    private readonly Dictionary<ulong, byte[]> _imagesByAttachment = new Dictionary<ulong, byte[]>();
+    private readonly Dictionary<ulong, byte[]> _imagesByAttachment = [];
 
     public HashSet<ulong> DeadAttachments { get; } = [];
     public List<byte[]> RefusalFor { get; } = [];

--- a/tests/DiscordEventService.Tests/MemeSampleServiceTests.cs
+++ b/tests/DiscordEventService.Tests/MemeSampleServiceTests.cs
@@ -65,12 +65,11 @@ public sealed class MemeSampleServiceTests(PostgresFixture fixture) : IClassFixt
     {
         var nextDiscordId = 200UL;
         var nextAttachmentId = 2000UL;
-        foreach (var year in new[] { 2018, 2020, 2022, 2024 })
+        int[] years = [2018, 2020, 2022, 2024];
+        foreach (var year in years)
         {
             for (var i = 0; i < 5; i++)
-            {
                 AddMessage(_memeChannel, nextDiscordId++, Year(year), Attachment(nextAttachmentId++, $"m{year}-{i}.jpg"));
-            }
         }
         await _db.SaveChangesAsync();
 
@@ -78,7 +77,7 @@ public sealed class MemeSampleServiceTests(PostgresFixture fixture) : IClassFixt
 
         Assert.Equal(8, sample.Count);
         var perYear = sample.GroupBy(s => s.CreatedAtUtc.Year).ToDictionary(g => g.Key, g => g.Count());
-        Assert.Equal(new[] { 2018, 2020, 2022, 2024 }, perYear.Keys.Order());
+        Assert.Equal([2018, 2020, 2022, 2024], perYear.Keys.Order());
         Assert.All(perYear.Values, count => Assert.Equal(2, count));
     }
 
@@ -94,7 +93,7 @@ public sealed class MemeSampleServiceTests(PostgresFixture fixture) : IClassFixt
 
         Assert.Equal(2, sample.Count);
         Assert.All(sample, s => Assert.Equal(300UL, s.MessageDiscordId));
-        Assert.Equal(new[] { 3000UL, 3001UL }, sample.Select(s => s.AttachmentDiscordId).Order().ToArray());
+        Assert.Equal([3000UL, 3001UL], sample.Select(s => s.AttachmentDiscordId).Order().ToArray());
     }
 
     private MemeSampleService NewService() =>

--- a/tests/DiscordEventService.Tests/MemeSearchServiceTests.cs
+++ b/tests/DiscordEventService.Tests/MemeSearchServiceTests.cs
@@ -6,11 +6,6 @@ using Xunit;
 
 namespace DiscordEventService.Tests;
 
-// #224 acceptance contracts for the /meme search query (binding design on
-// #224, column semantics pinned by MemeIndexSchemaTests): hybrid FTS + trigram
-// gate, weighted rank blend, soft-delete exclusion, recency tiebreak. The
-// slash-command surface itself can't be integration-tested (bots can't invoke
-// other bots' commands) — that part is user-verified live on the dev guild.
 public sealed class MemeSearchServiceTests(PostgresFixture fixture) : IClassFixture<PostgresFixture>, IAsyncLifetime
 {
     private const ulong GuildDiscordId = 1UL;

--- a/tests/DiscordEventService.Tests/OpenRouterClientTests.cs
+++ b/tests/DiscordEventService.Tests/OpenRouterClientTests.cs
@@ -40,7 +40,7 @@ public sealed class OpenRouterClientTests
         Assert.Equal(MemeAnalysisOutcome.Success, result.Outcome);
         Assert.NotNull(result.Metadata);
         Assert.Equal("Opis po polsku", result.Metadata!.DescriptionPl);
-        Assert.Equal(new[] { "kot", "cat" }, result.Metadata.Tags);
+        Assert.Equal(["kot", "cat"], result.Metadata.Tags);
         Assert.Equal("reddit", result.Metadata.Source);
         Assert.Null(result.Metadata.Template);
         Assert.Equal(10, result.Usage!.PromptTokens);
@@ -120,9 +120,8 @@ public sealed class OpenRouterClientTests
         Assert.False(called);
     }
 
-    private static string CompletionBody(string? content, string finishReason, decimal? cost, string? refusal = null)
-    {
-        return JsonSerializer.Serialize(new
+    private static string CompletionBody(string? content, string finishReason, decimal? cost, string? refusal = null) =>
+        JsonSerializer.Serialize(new
         {
             choices = new[]
             {
@@ -134,7 +133,6 @@ public sealed class OpenRouterClientTests
             },
             usage = new { prompt_tokens = 10, completion_tokens = 20, cost }
         });
-    }
 
     private static OpenRouterClient NewClient(Func<HttpRequestMessage, HttpResponseMessage> respond, string apiKey = "test-key")
     {

--- a/tests/DiscordEventService.Tests/ProfileTests.cs
+++ b/tests/DiscordEventService.Tests/ProfileTests.cs
@@ -129,7 +129,7 @@ public sealed class ProfileTests(PostgresFixture fixture) : IClassFixture<Postgr
     }
 
     private static MessageEntity Message(
-        Guid authorId, Guid channelId, Guid guildId, ulong discordId, DateTime at, bool attach = false) => new()
+        Guid authorId, Guid channelId, Guid guildId, ulong discordId, DateTime at, bool attach = false) => new MessageEntity
         {
             DiscordId = discordId,
             AuthorId = authorId,
@@ -140,7 +140,7 @@ public sealed class ProfileTests(PostgresFixture fixture) : IClassFixture<Postgr
             CreatedAtUtc = at,
         };
 
-    private static ReactionEventEntity Reaction(ulong user, string emote, ulong messageId, DateTime at) => new()
+    private static ReactionEventEntity Reaction(ulong user, string emote, ulong messageId, DateTime at) => new ReactionEventEntity
     {
         UserDiscordId = user,
         GuildDiscordId = GuildSf,
@@ -153,7 +153,7 @@ public sealed class ProfileTests(PostgresFixture fixture) : IClassFixture<Postgr
     };
 
     private static VoiceStateEventEntity Voice(
-        ulong user, ulong? before, ulong? after, VoiceEventType type, DateTime at) => new()
+        ulong user, ulong? before, ulong? after, VoiceEventType type, DateTime at) => new VoiceStateEventEntity
         {
             UserDiscordId = user,
             GuildDiscordId = GuildSf,
@@ -164,7 +164,7 @@ public sealed class ProfileTests(PostgresFixture fixture) : IClassFixture<Postgr
             EventTimestampUtc = at,
         };
 
-    private static PresenceEventEntity Presence(ulong user, DateTime at, int desktop = 0) => new()
+    private static PresenceEventEntity Presence(ulong user, DateTime at, int desktop = 0) => new PresenceEventEntity
     {
         UserDiscordId = user,
         GuildDiscordId = GuildSf,

--- a/tests/DiscordEventService.Tests/RawEventSerializationTests.cs
+++ b/tests/DiscordEventService.Tests/RawEventSerializationTests.cs
@@ -23,7 +23,7 @@ public sealed class SerializeEventUnitTests
 {
     // dbContext/logger are unused by SerializeEvent, so no DB needed here.
     private static RawEventLogService NewService()
-        => new(null!, NullLogger<RawEventLogService>.Instance);
+        => new RawEventLogService(null!, NullLogger<RawEventLogService>.Instance);
 
     [Fact]
     public void SerializeEvent_WhenSuccessful_ReturnsJsonWithNoError()

--- a/tests/DiscordEventService.Tests/SpotifyStatsTests.cs
+++ b/tests/DiscordEventService.Tests/SpotifyStatsTests.cs
@@ -91,7 +91,7 @@ public sealed class SpotifyStatsTests(PostgresFixture fixture) : IClassFixture<P
 
     private static ActivityEntity Activity(
         Guid userId, Guid guildId, string track, string album, string art, string artistsJson,
-        bool isActive, DateTime lastSeen, DateTime? ended = null) => new()
+        bool isActive, DateTime lastSeen, DateTime? ended = null) => new ActivityEntity
         {
             UserId = userId,
             GuildId = guildId,

--- a/tests/DiscordEventService.Tests/StatsControllerTests.cs
+++ b/tests/DiscordEventService.Tests/StatsControllerTests.cs
@@ -190,7 +190,7 @@ public sealed class StatsControllerTests(PostgresFixture fixture) : IClassFixtur
         _db.ChangeTracker.Clear();
     }
 
-    private static MessageEntity Message(Guid authorId, Guid channelId, Guid guildId, ulong discordId) => new()
+    private static MessageEntity Message(Guid authorId, Guid channelId, Guid guildId, ulong discordId) => new MessageEntity
     {
         DiscordId = discordId,
         AuthorId = authorId,
@@ -201,7 +201,7 @@ public sealed class StatsControllerTests(PostgresFixture fixture) : IClassFixtur
     };
 
     private static VoiceStateEventEntity Voice(
-        ulong user, ulong guild, ulong? before, ulong? after, VoiceEventType type, DateTime at) => new()
+        ulong user, ulong guild, ulong? before, ulong? after, VoiceEventType type, DateTime at) => new VoiceStateEventEntity
         {
             UserDiscordId = user,
             GuildDiscordId = guild,
@@ -213,7 +213,7 @@ public sealed class StatsControllerTests(PostgresFixture fixture) : IClassFixtur
         };
 
     private static ReactionEventEntity Reaction(
-        ulong user, ulong guild, ulong channel, string emote, ulong? emoteId) => new()
+        ulong user, ulong guild, ulong channel, string emote, ulong? emoteId) => new ReactionEventEntity
         {
             UserDiscordId = user,
             GuildDiscordId = guild,
@@ -226,7 +226,7 @@ public sealed class StatsControllerTests(PostgresFixture fixture) : IClassFixtur
             EventTimestampUtc = DateTime.UtcNow,
         };
 
-    private static RawEventLogEntity Raw(string type, DateTime at) => new()
+    private static RawEventLogEntity Raw(string type, DateTime at) => new RawEventLogEntity
     {
         EventType = type,
         GuildDiscordId = 742554855180206203UL,

--- a/tests/DiscordEventService.Tests/TablesControllerTests.cs
+++ b/tests/DiscordEventService.Tests/TablesControllerTests.cs
@@ -139,7 +139,7 @@ public sealed class TablesControllerTests(PostgresFixture fixture) : IClassFixtu
         _db.ChangeTracker.Clear();
     }
 
-    private TablesController NewController() => new(_db, _catalog);
+    private TablesController NewController() => new TablesController(_db, _catalog);
 
     private static T Ok<T>(ActionResult<T> result)
     {

--- a/tests/DiscordEventService.Tests/VoiceDowntimeAndDailyTests.cs
+++ b/tests/DiscordEventService.Tests/VoiceDowntimeAndDailyTests.cs
@@ -7,12 +7,7 @@ using Xunit;
 
 namespace DiscordEventService.Tests;
 
-/// <summary>
-/// Guards the voice-minute bot-downtime adjustment (a join whose leave goes unobserved
-/// during an outage must not credit the blind gap) and the dense, zero-filled CET-day
-/// message series. Each test class owns its Postgres container (IClassFixture), so the
-/// seeded downtime interval here cannot leak into the other voice tests.
-/// </summary>
+// Per-class Postgres container (IClassFixture) so the seeded downtime interval can't leak into other voice tests.
 public sealed class VoiceDowntimeAndDailyTests(PostgresFixture fixture) : IClassFixture<PostgresFixture>, IAsyncLifetime
 {
     private const ulong GuildSf = 742554855180206203UL;
@@ -128,7 +123,7 @@ public sealed class VoiceDowntimeAndDailyTests(PostgresFixture fixture) : IClass
         _db.ChangeTracker.Clear();
     }
 
-    private static MessageEntity Message(Guid authorId, Guid channelId, Guid guildId, ulong discordId, DateTime at) => new()
+    private static MessageEntity Message(Guid authorId, Guid channelId, Guid guildId, ulong discordId, DateTime at) => new MessageEntity
     {
         DiscordId = discordId,
         AuthorId = authorId,
@@ -139,7 +134,7 @@ public sealed class VoiceDowntimeAndDailyTests(PostgresFixture fixture) : IClass
     };
 
     private static VoiceStateEventEntity Voice(
-        ulong user, ulong? before, ulong? after, VoiceEventType type, DateTime at) => new()
+        ulong user, ulong? before, ulong? after, VoiceEventType type, DateTime at) => new VoiceStateEventEntity
         {
             UserDiscordId = user,
             GuildDiscordId = GuildSf,


### PR DESCRIPTION
## What

Full-repo audit against the **updated** `dotnet-guidelines` skill, applying only the low-risk **mechanical** category ("Tier A") across 141 files. Net **−754 lines** (mostly XML-doc removal).

The audit found **523 verified findings** total (42 false positives filtered out via adversarial verification). This PR ships the safe mechanical slice; the rest is deferred to follow-ups.

### Applied (Tier A)
- Delete XML-doc / WHAT comments; keep genuine WHY notes as inline `//`
- Drop braces on single-statement bodies; expression-body trivial members
- Target-typed `new()` → `new TypeName()`
- `new List<>/Dictionary<>/HashSet<>` → `[]` (only where a target type exists; `var`-lhs cases correctly skipped)
- Explicit local types → `var`; using-directive ordering
- Trailing commas on multi-line initializers

### Deliberately excluded
- **`enum-implicit-values`** — reverted. Several event/status/`ChannelType` enums are **non-sequential** (`Media = 16`, status `0/2/4`, backfill kind `0/2/4/6/7`) and persisted as ints / mapped from Discord API. Stripping explicit values would silently renumber and corrupt data. This category is dropped, not deferred.
- **public → internal controllers** — default MVC discovery skips non-public controllers (no custom `ControllerFeatureProvider` here), so making the 8 controllers internal would break `/api/*` routing. Left public as an exemption per owner decision.

### Deferred to follow-up PRs
- **Tier B** — `internal`/`sealed` (non-controller, ~110), `pattern-matching`, `magic-number` constants, `member-order`, `async-suffix`, `ef-core`, `testing`, `[ProducesResponseType]`/`ActionResult<T>`, `CancellationToken` threading, co-location
- **Tier C** — logging: `$"…"` interpolation → structured prose templates (20), levels
- **Tier D** — `method-length` decomposition (27)

## Verification
- `dotnet build --no-incremental`: **0 warnings, 0 errors**
- `dotnet test`: **151/151 pass**
- Diff safety-scanned: no logic deletions (all `-` lines are paired transforms); single-agent guideline re-review of the diff: clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)