### PR TITLE
chore: dotnet-guidelines Tier C — logging conformance + enum renumbering guards

### DIFF
--- a/src/DiscordEventService/Data/Entities/Core/BackfillCheckpointEntity.cs
+++ b/src/DiscordEventService/Data/Entities/Core/BackfillCheckpointEntity.cs
@@ -24,6 +24,7 @@ public class BackfillCheckpointEntity : ITimestamped
     public DateTime LastUpdatedUtc { get; set; }
 }
 
+// Persisted as int in the DB — values are a data contract; never renumber or strip explicit values.
 public enum BackfillType
 {
     Roles = 0,
@@ -39,6 +40,7 @@ public enum BackfillType
     MemeIndex = 7
 }
 
+// Persisted as int in the DB — values are a data contract; never renumber or strip explicit values.
 public enum BackfillStatus
 {
     Pending = 0,

--- a/src/DiscordEventService/Data/Entities/Core/BotDowntimeIntervalEntity.cs
+++ b/src/DiscordEventService/Data/Entities/Core/BotDowntimeIntervalEntity.cs
@@ -14,6 +14,7 @@ public class BotDowntimeIntervalEntity : ITimestamped
     public DateTime LastUpdatedUtc { get; set; }
 }
 
+// Persisted as int in the DB — values are a data contract; never renumber or strip explicit values.
 public enum BotDowntimeType
 {
     GracefulShutdown = 0,
@@ -24,6 +25,7 @@ public enum BotDowntimeType
     Inferred = 5
 }
 
+// Persisted as int in the DB — values are a data contract; never renumber or strip explicit values.
 public enum BotDowntimeDetectionMethod
 {
     GracefulStop = 0,

--- a/src/DiscordEventService/Data/Entities/Core/ChannelEntity.cs
+++ b/src/DiscordEventService/Data/Entities/Core/ChannelEntity.cs
@@ -25,6 +25,8 @@ public class ChannelEntity : ITimestamped
     public GuildEntity Guild { get; set; } = null!;
 }
 
+// Values mirror Discord's API channel-type ints and are persisted as int in the DB —
+// a data contract on both sides; never renumber or strip explicit values (they are non-sequential).
 public enum ChannelType
 {
     // Sentinel for Discord-side types we don't yet model. Direct casts

--- a/src/DiscordEventService/Data/Entities/Core/MemeIndexEntity.cs
+++ b/src/DiscordEventService/Data/Entities/Core/MemeIndexEntity.cs
@@ -2,6 +2,7 @@ using NpgsqlTypes;
 
 namespace DiscordEventService.Data.Entities.Core;
 
+// Persisted as int in the DB — values are a data contract; never renumber or strip explicit values.
 public enum MemeIndexStatus
 {
     Pending = 0,

--- a/src/DiscordEventService/Data/Entities/Core/MessageMentionEntity.cs
+++ b/src/DiscordEventService/Data/Entities/Core/MessageMentionEntity.cs
@@ -1,5 +1,6 @@
 namespace DiscordEventService.Data.Entities.Core;
 
+// Persisted as int in the DB — values are a data contract; never renumber or strip explicit values.
 public enum MessageMentionType
 {
     User = 0,

--- a/src/DiscordEventService/Data/Entities/Events/AutoModEventEntity.cs
+++ b/src/DiscordEventService/Data/Entities/Events/AutoModEventEntity.cs
@@ -1,5 +1,6 @@
 namespace DiscordEventService.Data.Entities.Events;
 
+// Persisted as int in the DB — values are a data contract; never renumber or strip explicit values.
 public enum AutoModEventType
 {
     RuleCreated = 0,

--- a/src/DiscordEventService/Data/Entities/Events/AutoModRuleEventEntity.cs
+++ b/src/DiscordEventService/Data/Entities/Events/AutoModRuleEventEntity.cs
@@ -1,5 +1,6 @@
 namespace DiscordEventService.Data.Entities.Events;
 
+// Persisted as int in the DB — values are a data contract; never renumber or strip explicit values.
 public enum AutoModRuleEventType
 {
     Created = 0,

--- a/src/DiscordEventService/Data/Entities/Events/BanEventEntity.cs
+++ b/src/DiscordEventService/Data/Entities/Events/BanEventEntity.cs
@@ -1,5 +1,6 @@
 namespace DiscordEventService.Data.Entities.Events;
 
+// Persisted as int in the DB — values are a data contract; never renumber or strip explicit values.
 public enum BanEventType
 {
     Added = 0,

--- a/src/DiscordEventService/Data/Entities/Events/ChannelEventEntity.cs
+++ b/src/DiscordEventService/Data/Entities/Events/ChannelEventEntity.cs
@@ -1,5 +1,6 @@
 namespace DiscordEventService.Data.Entities.Events;
 
+// Persisted as int in the DB — values are a data contract; never renumber or strip explicit values.
 public enum ChannelEventType
 {
     Created = 0,

--- a/src/DiscordEventService/Data/Entities/Events/GuildEventEntity.cs
+++ b/src/DiscordEventService/Data/Entities/Events/GuildEventEntity.cs
@@ -1,5 +1,6 @@
 namespace DiscordEventService.Data.Entities.Events;
 
+// Persisted as int in the DB — values are a data contract; never renumber or strip explicit values.
 public enum GuildEventType
 {
     Updated = 0,

--- a/src/DiscordEventService/Data/Entities/Events/IntegrationEventEntity.cs
+++ b/src/DiscordEventService/Data/Entities/Events/IntegrationEventEntity.cs
@@ -1,5 +1,6 @@
 namespace DiscordEventService.Data.Entities.Events;
 
+// Persisted as int in the DB — values are a data contract; never renumber or strip explicit values.
 public enum IntegrationEventType
 {
     Created = 0,

--- a/src/DiscordEventService/Data/Entities/Events/InviteEventEntity.cs
+++ b/src/DiscordEventService/Data/Entities/Events/InviteEventEntity.cs
@@ -1,5 +1,6 @@
 namespace DiscordEventService.Data.Entities.Events;
 
+// Persisted as int in the DB — values are a data contract; never renumber or strip explicit values.
 public enum InviteEventType
 {
     Created = 0,

--- a/src/DiscordEventService/Data/Entities/Events/MemberEventEntity.cs
+++ b/src/DiscordEventService/Data/Entities/Events/MemberEventEntity.cs
@@ -1,5 +1,6 @@
 namespace DiscordEventService.Data.Entities.Events;
 
+// Persisted as int in the DB — values are a data contract; never renumber or strip explicit values.
 public enum MemberEventType
 {
     Joined = 0,

--- a/src/DiscordEventService/Data/Entities/Events/MessageEventEntity.cs
+++ b/src/DiscordEventService/Data/Entities/Events/MessageEventEntity.cs
@@ -1,5 +1,6 @@
 namespace DiscordEventService.Data.Entities.Events;
 
+// Persisted as int in the DB — values are a data contract; never renumber or strip explicit values.
 public enum MessageEventType
 {
     Created = 0,

--- a/src/DiscordEventService/Data/Entities/Events/PollEventEntity.cs
+++ b/src/DiscordEventService/Data/Entities/Events/PollEventEntity.cs
@@ -1,5 +1,6 @@
 namespace DiscordEventService.Data.Entities.Events;
 
+// Persisted as int in the DB — values are a data contract; never renumber or strip explicit values.
 public enum PollEventType
 {
     VoteAdded = 0,

--- a/src/DiscordEventService/Data/Entities/Events/PresenceEventEntity.cs
+++ b/src/DiscordEventService/Data/Entities/Events/PresenceEventEntity.cs
@@ -1,5 +1,6 @@
 namespace DiscordEventService.Data.Entities.Events;
 
+// Persisted as int in the DB — values are a data contract; never renumber or strip explicit values.
 public enum PresenceEventType
 {
     Updated = 0,

--- a/src/DiscordEventService/Data/Entities/Events/ReactionEventEntity.cs
+++ b/src/DiscordEventService/Data/Entities/Events/ReactionEventEntity.cs
@@ -1,5 +1,6 @@
 namespace DiscordEventService.Data.Entities.Events;
 
+// Persisted as int in the DB — values are a data contract; never renumber or strip explicit values.
 public enum ReactionEventType
 {
     Added = 0,

--- a/src/DiscordEventService/Data/Entities/Events/RoleEventEntity.cs
+++ b/src/DiscordEventService/Data/Entities/Events/RoleEventEntity.cs
@@ -1,5 +1,6 @@
 namespace DiscordEventService.Data.Entities.Events;
 
+// Persisted as int in the DB — values are a data contract; never renumber or strip explicit values.
 public enum RoleEventType
 {
     Created = 0,

--- a/src/DiscordEventService/Data/Entities/Events/ScheduledEventEntity.cs
+++ b/src/DiscordEventService/Data/Entities/Events/ScheduledEventEntity.cs
@@ -1,5 +1,6 @@
 namespace DiscordEventService.Data.Entities.Events;
 
+// Persisted as int in the DB — values are a data contract; never renumber or strip explicit values.
 public enum ScheduledEventEventType
 {
     Created = 0,

--- a/src/DiscordEventService/Data/Entities/Events/StageInstanceEventEntity.cs
+++ b/src/DiscordEventService/Data/Entities/Events/StageInstanceEventEntity.cs
@@ -1,5 +1,6 @@
 namespace DiscordEventService.Data.Entities.Events;
 
+// Persisted as int in the DB — values are a data contract; never renumber or strip explicit values.
 public enum StageInstanceEventType
 {
     Created = 0,

--- a/src/DiscordEventService/Data/Entities/Events/ThreadEventEntity.cs
+++ b/src/DiscordEventService/Data/Entities/Events/ThreadEventEntity.cs
@@ -1,5 +1,6 @@
 namespace DiscordEventService.Data.Entities.Events;
 
+// Persisted as int in the DB — values are a data contract; never renumber or strip explicit values.
 public enum ThreadEventType
 {
     Created = 0,

--- a/src/DiscordEventService/Data/Entities/Events/VoiceStateEventEntity.cs
+++ b/src/DiscordEventService/Data/Entities/Events/VoiceStateEventEntity.cs
@@ -1,5 +1,6 @@
 namespace DiscordEventService.Data.Entities.Events;
 
+// Persisted as int in the DB — values are a data contract; never renumber or strip explicit values.
 public enum VoiceEventType
 {
     Joined = 0,

--- a/src/DiscordEventService/Jobs/BackfillJobBase.cs
+++ b/src/DiscordEventService/Jobs/BackfillJobBase.cs
@@ -54,7 +54,7 @@ public abstract class BackfillJobBase
             }
             else
             {
-                logger.LogWarning("Backfill resume cursor {ResumeId} not found in {Count} items, restarting from beginning",
+                logger.LogWarning("Backfill resume cursor {ResumeId} not found in {ItemCount} items, restarting from beginning",
                     resumeId, items.Count);
                 checkpoint.CurrentChannelId = null;
                 checkpoint.LastProcessedId = null;

--- a/src/DiscordEventService/Jobs/BackfillJobExecutor.cs
+++ b/src/DiscordEventService/Jobs/BackfillJobExecutor.cs
@@ -47,7 +47,7 @@ public sealed class BackfillJobExecutor(
             }
 
             await MarkCompletedAsync(db, checkpoint);
-            logger.LogInformation("{BackfillType} backfill completed for guild {GuildId}: {Count} processed",
+            logger.LogInformation("{BackfillType} backfill completed for guild {GuildId}: {ProcessedCount} processed",
                 type, guildId, checkpoint.ProcessedCount);
         }
         catch (OperationCanceledException ex)

--- a/src/DiscordEventService/Jobs/GuildBackfillOrchestrator.cs
+++ b/src/DiscordEventService/Jobs/GuildBackfillOrchestrator.cs
@@ -17,7 +17,7 @@ public class GuildBackfillOrchestrator(
     private string EnqueueChain(ulong guildId, BackfillOptions options, DateTime? afterTimestampUtc)
     {
         logger.LogInformation(
-            "Starting backfill orchestration for guild {GuildId} with options: {@Options} afterTimestampUtc={AfterTimestamp:O}",
+            "Starting backfill orchestration for guild {GuildId} with options {@Options}, backfilling after {AfterTimestampUtc:O}",
             guildId, options, afterTimestampUtc);
 
         var rolesJobId = backgroundJobClient.Enqueue<RolesBackfillJob>(

--- a/src/DiscordEventService/Jobs/MessagesBackfillJob.cs
+++ b/src/DiscordEventService/Jobs/MessagesBackfillJob.cs
@@ -48,8 +48,8 @@ public sealed class MessagesBackfillJob(
             await IterateWithCheckpointAsync(ctx.Db, ctx.Checkpoint, textChannels, c => c.Id,
                 async channel =>
                 {
-                    logger.LogInformation("Backfilling messages for channel {ChannelName} ({ChannelId}) in guild {GuildId}",
-                        channel.Name, channel.Id, guildId);
+                    logger.LogInformation("Backfilling messages for channel {ChannelName} ({ChannelId}) in guild {GuildId} from cursor {ResumeCursor}",
+                        channel.Name, channel.Id, guildId, ctx.Checkpoint.LastProcessedId?.ToString() ?? "start");
                     await BackfillChannelMessagesAsync(ctx.Db, userService, guildEntity, channel, ctx.Checkpoint, afterTimestampUtc, cancellationToken);
                 },
                 logger, cancellationToken);
@@ -76,12 +76,6 @@ public sealed class MessagesBackfillJob(
         var batchNum = 0;
         var totalInserted = 0;
         var exitReason = "unknown";
-
-        // #124 diagnostic: trace exactly why per-channel loops terminated at ~one batch
-        // in auto-startup runs but went deep when manually triggered.
-        logger.LogInformation(
-            "[bf-diag] Channel {ChannelName} ({ChannelId}) starting; initial beforeId={BeforeId}",
-            channel.Name, channel.Id, beforeId);
 
         while (hasMore)
         {
@@ -116,16 +110,18 @@ public sealed class MessagesBackfillJob(
 
             if (messages.Count == 0)
             {
-                logger.LogInformation(
-                    "[bf-diag] Channel {ChannelName} batch {BatchNum}: API returned 0 messages with beforeId={BeforeId} — terminating loop",
+                logger.LogDebug(
+                    "Channel {ChannelName} batch {BatchNum} returned no messages before cursor {BeforeId}; stopping",
                     channel.Name, batchNum, beforeId);
                 hasMore = false;
                 exitReason = "API returned 0";
                 break;
             }
 
-            logger.LogInformation(
-                "[bf-diag] Channel {ChannelName} batch {BatchNum}: got {Count} messages, newest={NewestId} ({NewestTs:O}), oldest={OldestId} ({OldestTs:O})",
+            // #124 diagnostic: per-batch trace of why per-channel loops terminated at ~one
+            // batch in auto-startup runs but went deep when manually triggered.
+            logger.LogDebug(
+                "Channel {ChannelName} batch {BatchNum} fetched {MessageCount} messages, newest {NewestMessageId} ({NewestTimestampUtc:O}), oldest {OldestMessageId} ({OldestTimestampUtc:O})",
                 channel.Name, batchNum, messages.Count,
                 messages.First().Id, messages.First().Timestamp.UtcDateTime,
                 messages.Last().Id, messages.Last().Timestamp.UtcDateTime);
@@ -154,7 +150,7 @@ public sealed class MessagesBackfillJob(
                         if (channelEntity is null || authorEntity is null)
                         {
                             logger.LogWarning(
-                                "Skipping backfill insert for message {MessageId}: channelEntity={ChannelPresent} authorEntity={AuthorPresent}",
+                                "Skipping backfill insert for message {MessageId}: channel resolved {ChannelPresent}, author resolved {AuthorPresent}",
                                 message.Id, channelEntity is not null, authorEntity is not null);
                             continue;
                         }
@@ -235,7 +231,7 @@ public sealed class MessagesBackfillJob(
         }
 
         logger.LogInformation(
-            "[bf-diag] Channel {ChannelName} ({ChannelId}) done: batches={BatchCount}, inserted={Inserted}, exit_reason={ExitReason}, final_beforeId={BeforeId}",
+            "Channel {ChannelName} ({ChannelId}) done after {BatchCount} batches: inserted {InsertedCount} messages, stopped because {ExitReason}, cursor at {BeforeId}",
             channel.Name, channel.Id, batchNum, totalInserted, exitReason, beforeId);
     }
 }

--- a/src/DiscordEventService/Jobs/PeriodicFullBackfillJob.cs
+++ b/src/DiscordEventService/Jobs/PeriodicFullBackfillJob.cs
@@ -42,7 +42,7 @@ public class PeriodicFullBackfillJob(
                 continue;
             }
 
-            logger.LogInformation("Periodic backfill enqueued for guild {GuildId} (window={Window}d, after={After:O})",
+            logger.LogInformation("Periodic backfill enqueued for guild {GuildId} covering the last {WindowDays} days, after {AfterTimestampUtc:O}",
                 guildId, BackfillWindow.TotalDays, afterTimestamp);
             orchestrator.EnqueueBackfillFrom(guildId, afterTimestamp);
         }

--- a/src/DiscordEventService/Services/BootQuickSyncService.cs
+++ b/src/DiscordEventService/Services/BootQuickSyncService.cs
@@ -28,7 +28,7 @@ public class BootQuickSyncService(
         var (presenceSnapshots, activitiesInserted) = await SyncPresencesAsync(guild);
 
         logger.LogInformation(
-            "Boot quick-sync completed for guild {GuildId}: {Messages} messages, {Presences} presence snapshots, {Activities} new activities",
+            "Boot quick-sync completed for guild {GuildId}: {MessageCount} messages, {PresenceSnapshotCount} presence snapshots, {NewActivityCount} new activities",
             guildId, messagesInserted, presenceSnapshots, activitiesInserted);
     }
 
@@ -138,11 +138,11 @@ public class BootQuickSyncService(
             }
             catch (DSharpPlus.Exceptions.UnauthorizedException)
             {
-                logger.LogDebug("Quick-sync: no permission to read channel {ChannelId}, skipping", channel.Id);
+                logger.LogWarning("Quick-sync: no permission to read channel {ChannelId}, skipping", channel.Id);
             }
             catch (DSharpPlus.Exceptions.NotFoundException)
             {
-                logger.LogDebug("Quick-sync: channel {ChannelId} not found, skipping", channel.Id);
+                logger.LogWarning("Quick-sync: channel {ChannelId} not found, skipping", channel.Id);
             }
             catch (Exception ex)
             {

--- a/src/DiscordEventService/Services/ChannelUpsertService.cs
+++ b/src/DiscordEventService/Services/ChannelUpsertService.cs
@@ -40,7 +40,7 @@ public class ChannelUpsertService(DiscordDbContext db, ILogger<ChannelUpsertServ
 
         if (id == Guid.Empty)
         {
-            logger.LogError("ChannelUpsert lost the row for DiscordId={DiscordId} after upsert", channel.Id);
+            logger.LogError("Channel upsert lost the row for channel {ChannelId} after upsert", channel.Id);
             return UpsertResult<Guid>.Failure($"Channel upsert lost the row for DiscordId={channel.Id}");
         }
 
@@ -50,7 +50,7 @@ public class ChannelUpsertService(DiscordDbContext db, ILogger<ChannelUpsertServ
     public async Task<Guid> InsertPlaceholderAsync(ulong channelDiscordId, Guid guildId, DateTime firstOrphanSeenUtc)
     {
         logger.LogWarning(
-            "Inserting placeholder channel row for unresolvable thread DiscordId={DiscordId}; first orphan message seen at {FirstSeen}",
+            "Inserting placeholder channel row for unresolvable thread {ChannelId}; first orphan message seen at {FirstOrphanSeenUtc}",
             channelDiscordId, firstOrphanSeenUtc);
 
         // Insert-or-get: a concurrent writer (or a real ChannelCreate) may have inserted the row

--- a/src/DiscordEventService/Services/DowntimeTrackerService.cs
+++ b/src/DiscordEventService/Services/DowntimeTrackerService.cs
@@ -22,7 +22,7 @@ public class DowntimeTrackerService(DiscordDbContext db, ILogger<DowntimeTracker
         if (existingOpen is not null)
         {
             logger.LogWarning(
-                "OpenDowntimeAsync({Type}/{Method}) skipped: open row Id={Id} Type={ExistingType} already exists",
+                "Skipped opening downtime row of type {DowntimeType} via {DetectionMethod}: open row {DowntimeId} with type {ExistingType} already exists",
                 type, method, existingOpen.Id, existingOpen.Type);
             return new OpenDowntimeResult(existingOpen.Id, existingOpen.Type, Created: false);
         }
@@ -39,7 +39,7 @@ public class DowntimeTrackerService(DiscordDbContext db, ILogger<DowntimeTracker
         db.BotDowntimeIntervals.Add(row);
         await db.SaveChangesAsync();
         logger.LogInformation(
-            "Opened downtime row Id={Id} Type={Type} Method={Method}",
+            "Opened downtime row {DowntimeId} with type {DowntimeType} via {DetectionMethod}",
             row.Id, type, method);
         return new OpenDowntimeResult(row.Id, type, Created: true);
     }
@@ -62,9 +62,9 @@ public class DowntimeTrackerService(DiscordDbContext db, ILogger<DowntimeTracker
             .SetProperty(x => x.LastUpdatedUtc, endedAtUtc));
 
         if (affected > 1)
-            logger.LogWarning("Closed {Count} open downtime rows (expected at most 1)", affected);
+            logger.LogWarning("Closed {RowCount} open downtime rows (expected at most 1)", affected);
         else if (affected == 1)
-            logger.LogInformation("Closed open downtime row at {EndedAt:O} (filter={Filter})", endedAtUtc, onlyType?.ToString() ?? "any");
+            logger.LogInformation("Closed open downtime row at {EndedAtUtc:O} with type filter {TypeFilter}", endedAtUtc, onlyType?.ToString() ?? "any");
         return affected;
     }
 
@@ -134,7 +134,7 @@ public class DowntimeTrackerService(DiscordDbContext db, ILogger<DowntimeTracker
         db.BotDowntimeIntervals.Add(row);
         await db.SaveChangesAsync();
         logger.LogInformation(
-            "Inferred startup gap of {Gap:F0}s, row Id={Id}",
+            "Inferred startup gap of {GapSeconds:F0}s, opened downtime row {DowntimeId}",
             gap.TotalSeconds, row.Id);
         return row.Id;
     }

--- a/src/DiscordEventService/Services/EventHandlers/GuildEventHandler.cs
+++ b/src/DiscordEventService/Services/EventHandlers/GuildEventHandler.cs
@@ -19,7 +19,7 @@ public sealed class GuildEventHandler(EventPipeline pipeline) :
         await pipeline.Execute(e, "GuildCreated", nameof(GuildEventHandler),
             e.Guild.Id, null, null, async ctx =>
             {
-                ctx.Logger.LogInformation("GuildCreated event received for GuildId={GuildId} Name={GuildName}", e.Guild.Id, e.Guild.Name);
+                ctx.Logger.LogInformation("GuildCreated received for guild {GuildId} ({GuildName})", e.Guild.Id, e.Guild.Name);
 
                 // Upsert the guild (for its Guid) then every channel/role, all in one transaction
                 // so a partial failure rolls back atomically. Each upsert handles its own 23505
@@ -195,7 +195,7 @@ public sealed class GuildEventHandler(EventPipeline pipeline) :
         if (mapped == ChannelType.Unknown)
         {
             logger.LogWarning(
-                "Unknown DiscordChannelType={DiscordType} (int={Int}); mapping to ChannelType.Unknown",
+                "Unknown Discord channel type {DiscordChannelType} (value {ChannelTypeValue}); mapping to ChannelType.Unknown",
                 discordType, (int)discordType);
         }
 

--- a/src/DiscordEventService/Services/EventHandlers/MemberEventHandler.cs
+++ b/src/DiscordEventService/Services/EventHandlers/MemberEventHandler.cs
@@ -169,7 +169,7 @@ public sealed class MemberEventHandler(EventPipeline pipeline) :
 
         if (member is null)
         {
-            logger.LogWarning("Cannot maintain role snapshots: member not found for User={UserDiscordId} Guild={GuildDiscordId}",
+            logger.LogWarning("Cannot maintain role snapshots: member not found for user {UserDiscordId} in guild {GuildDiscordId}",
                 userDiscordId, guildDiscordId);
             return;
         }
@@ -198,7 +198,7 @@ public sealed class MemberEventHandler(EventPipeline pipeline) :
 
             if (closed == 0)
             {
-                logger.LogDebug("No open role snapshot to close: Member={MemberId} Role={RoleDiscordId}",
+                logger.LogDebug("No open role snapshot to close for member {MemberGuid} and role {RoleDiscordId}",
                     member.Id, roleId);
             }
         }

--- a/src/DiscordEventService/Services/EventHandlers/SocketLifecycleHandler.cs
+++ b/src/DiscordEventService/Services/EventHandlers/SocketLifecycleHandler.cs
@@ -38,7 +38,7 @@ public sealed class SocketLifecycleHandler(
             }
             catch (Exception ex)
             {
-                logger.LogError(ex, "Failed to open downtime row on SocketClosed (code={CloseCode})", e.CloseCode);
+                logger.LogError(ex, "Failed to open downtime row on SocketClosed with close code {CloseCode}", e.CloseCode);
             }
         }
     }
@@ -110,7 +110,7 @@ public sealed class SocketLifecycleHandler(
                 if (gap < ReconnectGapThreshold)
                 {
                     logger.LogInformation(
-                        "GuildDownloadCompleted: gap {Gap:c} below threshold, running quick-sync only",
+                        "GuildDownloadCompleted: gap {GapDuration:c} below threshold, running quick-sync only",
                         gap);
                     foreach (var guildId in e.Guilds.Keys)
                         await quickSyncService.SyncAsync(guildId);
@@ -122,7 +122,7 @@ public sealed class SocketLifecycleHandler(
                 if (afterTimestamp < earliestAllowed)
                 {
                     logger.LogInformation(
-                        "Reconnect backfill window capped to {Window} (gap was {Gap:c}, capped from {Original:O} to {Capped:O})",
+                        "Reconnect backfill window capped to {Window} (gap was {GapDuration:c}, capped from {Original:O} to {Capped:O})",
                         MaxReconnectBackfillWindow, gap, afterTimestamp, earliestAllowed);
                     afterTimestamp = earliestAllowed;
                 }
@@ -145,7 +145,7 @@ public sealed class SocketLifecycleHandler(
                     }
 
                     logger.LogInformation(
-                        "Reconnect backfill enqueued for guild {GuildId} after gap {Gap:c} (afterTimestampUtc={After:O})",
+                        "Reconnect backfill enqueued for guild {GuildId} after gap {GapDuration:c}, backfilling from {AfterTimestampUtc:O}",
                         guildId, gap, afterTimestamp);
                     orchestrator.EnqueueBackfillFrom(guildId, afterTimestamp);
                 }

--- a/src/DiscordEventService/Services/FailedEventService.cs
+++ b/src/DiscordEventService/Services/FailedEventService.cs
@@ -42,14 +42,14 @@ public class FailedEventService(DiscordDbContext db, ILogger<FailedEventService>
             await db.SaveChangesAsync();
 
             logger.LogWarning(
-                "Recorded failed event: {EventType} in {HandlerName} - {ExceptionType}: {Message}",
+                "Recorded failed event: {EventType} in {HandlerName} - {ExceptionType}: {ExceptionMessage}",
                 eventType, handlerName, failedEvent.ExceptionType, exception.Message);
         }
         catch (Exception ex)
         {
             // Last resort - if we can't even record the failure, just log it
             logger.LogCritical(ex,
-                "CRITICAL: Failed to record event failure. Original error: {EventType} in {HandlerName} - {OriginalException}",
+                "CRITICAL: Failed to record event failure. Original error: {EventType} in {HandlerName} - {OriginalExceptionMessage}",
                 eventType, handlerName, exception.Message);
 
             try

--- a/src/DiscordEventService/Services/GuildUpsertService.cs
+++ b/src/DiscordEventService/Services/GuildUpsertService.cs
@@ -26,7 +26,7 @@ public class GuildUpsertService(DiscordDbContext db, ILogger<GuildUpsertService>
 
         if (id == Guid.Empty)
         {
-            logger.LogError("GuildUpsert lost the row for DiscordId={DiscordId} after upsert", guild.Id);
+            logger.LogError("Guild upsert lost the row for guild {GuildId} after upsert", guild.Id);
             return UpsertResult<Guid>.Failure($"Guild upsert lost the row for DiscordId={guild.Id}");
         }
 

--- a/src/DiscordEventService/Services/MemberRoleSnapshotBackfillService.cs
+++ b/src/DiscordEventService/Services/MemberRoleSnapshotBackfillService.cs
@@ -48,7 +48,7 @@ public class MemberRoleSnapshotBackfillService(
             })
             .ToListAsync(ct);
 
-        logger.LogInformation("Backfilling role snapshots from {Count} member events with role changes", events.Count);
+        logger.LogInformation("Backfilling role snapshots from {EventCount} member events with role changes", events.Count);
 
         foreach (var evt in events)
         {
@@ -56,7 +56,7 @@ public class MemberRoleSnapshotBackfillService(
 
             if (!memberLookup.TryGetValue((evt.UserDiscordId, evt.GuildDiscordId), out var memberId))
             {
-                logger.LogDebug("Skipping event {EventId}: member not found for User={User} Guild={Guild}",
+                logger.LogDebug("Skipping event {EventId}: member not found for user {UserId} in guild {GuildId}",
                     evt.Id, evt.UserDiscordId, evt.GuildDiscordId);
                 continue;
             }
@@ -105,7 +105,7 @@ public class MemberRoleSnapshotBackfillService(
             eventsProcessed++;
         }
 
-        logger.LogInformation("Event replay done: {Events} events, {Created} snapshots created, {Closed} closed",
+        logger.LogInformation("Event replay done: {EventCount} events, {CreatedCount} snapshots created, {ClosedCount} closed",
             eventsProcessed, created, closed);
 
         var seeded = await SeedCurrentRolesAsync(memberLookup, ct);
@@ -131,7 +131,7 @@ public class MemberRoleSnapshotBackfillService(
             }
             catch (Exception ex) when (ex is NotFoundException or UnauthorizedException)
             {
-                logger.LogWarning(ex, "Cannot fetch guild {Guild} for role seeding — skipping", guildDiscordId);
+                logger.LogWarning(ex, "Cannot fetch guild {GuildId} for role seeding — skipping", guildDiscordId);
                 continue;
             }
 
@@ -139,7 +139,7 @@ public class MemberRoleSnapshotBackfillService(
             await foreach (var member in guild.GetAllMembersAsync())
                 members.Add(member);
 
-            logger.LogInformation("Seeding current roles for {Count} members in guild {Guild}",
+            logger.LogInformation("Seeding current roles for {MemberCount} members in guild {GuildId}",
                 members.Count, guildDiscordId);
 
             foreach (var member in members)
@@ -176,7 +176,7 @@ public class MemberRoleSnapshotBackfillService(
             }
         }
 
-        logger.LogInformation("Current role seeding done: {Seeded} new snapshots", seeded);
+        logger.LogInformation("Current role seeding done: {SeededCount} new snapshots", seeded);
         return seeded;
     }
 }

--- a/src/DiscordEventService/Services/MemeIndexing/AttachmentUrlRefreshService.cs
+++ b/src/DiscordEventService/Services/MemeIndexing/AttachmentUrlRefreshService.cs
@@ -35,14 +35,14 @@ public sealed class AttachmentUrlRefreshService(
             catch (Exception ex) when (ex is HttpRequestException or TaskCanceledException && !cancellationToken.IsCancellationRequested)
             {
                 // Lose this batch only; its URLs surface downstream as skips.
-                logger.LogWarning(ex, "Attachment URL refresh batch failed ({Count} urls)", batch.Count);
+                logger.LogWarning(ex, "Attachment URL refresh batch failed for {UrlCount} urls", batch.Count);
             }
 
             if (offset + BatchSize < distinct.Count)
                 await Task.Delay(DelayBetweenBatches, cancellationToken);
         }
 
-        logger.LogInformation("Refreshed {Refreshed}/{Requested} attachment URLs", result.Count, distinct.Count);
+        logger.LogInformation("Refreshed {RefreshedCount} of {RequestedCount} attachment URLs", result.Count, distinct.Count);
         return result;
     }
 

--- a/src/DiscordEventService/Services/MemeIndexing/MemeAttachmentIndexer.cs
+++ b/src/DiscordEventService/Services/MemeIndexing/MemeAttachmentIndexer.cs
@@ -175,7 +175,7 @@ public sealed class MemeAttachmentIndexer(
         row.Status = MemeIndexStatus.Skipped;
         row.Error = reason;
         counters.Skipped++;
-        logger.LogInformation("Meme attachment {AttachmentId} skipped: {Reason}", row.AttachmentDiscordId, reason);
+        logger.LogWarning("Meme attachment {AttachmentId} skipped: {Reason}", row.AttachmentDiscordId, reason);
     }
 
     private void Fail(MemeIndexEntity row, MemeIndexRunCounters counters, string error)

--- a/src/DiscordEventService/Services/MessageMentionsBackfillService.cs
+++ b/src/DiscordEventService/Services/MessageMentionsBackfillService.cs
@@ -36,7 +36,7 @@ public partial class MessageMentionsBackfillService(
             .Select(m => new { m.Id, m.Content })
             .ToListAsync(ct);
 
-        logger.LogInformation("Mention backfill: {Total} messages with content, {Skipped} already have mentions",
+        logger.LogInformation("Mention backfill starting: {MessageCount} messages with content, {SkippedCount} already have mentions",
             messages.Count, alreadyProcessed.Count);
 
         var scanned = messages.Count;
@@ -65,7 +65,7 @@ public partial class MessageMentionsBackfillService(
             mentionsCreated += mentions.Count;
         }
 
-        logger.LogInformation("Mention backfill done: {Processed} messages processed, {Created} mentions created",
+        logger.LogInformation("Mention backfill done: {ProcessedCount} messages processed, {MentionCount} mentions created",
             processed, mentionsCreated);
 
         return new Result(scanned, skipped, processed, mentionsCreated);

--- a/src/DiscordEventService/Services/OrphanReplayService.cs
+++ b/src/DiscordEventService/Services/OrphanReplayService.cs
@@ -33,7 +33,7 @@ public class OrphanReplayService(DiscordDbContext db, ILogger<OrphanReplayServic
 
             // Reconstruction not yet implemented — log so we can find the sample.
             logger.LogWarning(
-                "Non-stub GuildMemberUpdated orphan found: raw_event_log_id={Id} user={User} received={ReceivedAt}. JSON reconstruction not yet implemented.",
+                "Non-stub GuildMemberUpdated orphan {RawEventLogId} for user {UserId} received at {ReceivedAtUtc}; JSON reconstruction not yet implemented",
                 o.Id, o.UserDiscordId, o.ReceivedAtUtc);
             skipped++;
         }

--- a/src/DiscordEventService/Services/Pipeline/FkResolver.cs
+++ b/src/DiscordEventService/Services/Pipeline/FkResolver.cs
@@ -34,7 +34,7 @@ public sealed class FkResolver(
             return ResolvedFks.Resolved(guild.Value, channel.Value, user.Value);
 
         ctx.Logger.LogError(
-            "Could not resolve required FKs ({LogContext}): guildResolved={GuildResolved} channelResolved={ChannelResolved} userResolved={UserResolved}; skipping insert",
+            "Could not resolve required FKs for {LogContext}: guild resolved {GuildResolved}, channel resolved {ChannelResolved}, user resolved {UserResolved}; skipping insert",
             logContext ?? "no context", guild.IsSuccess, channel.IsSuccess, user.IsSuccess);
         await ctx.RecordFailureAsync(new InvalidOperationException(
             $"Required FK not resolved ({logContext ?? "no context"}): guildResolved={guild.IsSuccess} channelResolved={channel.IsSuccess} userResolved={user.IsSuccess}"));
@@ -63,7 +63,7 @@ public sealed class FkResolver(
             return ResolvedUserFks.Resolved(guild.Value, user.Value);
 
         ctx.Logger.LogError(
-            "Could not resolve required FKs ({LogContext}): guildResolved={GuildResolved} userResolved={UserResolved}; skipping insert",
+            "Could not resolve required FKs for {LogContext}: guild resolved {GuildResolved}, user resolved {UserResolved}; skipping insert",
             logContext ?? "no context", guild.IsSuccess, user.IsSuccess);
         await ctx.RecordFailureAsync(new InvalidOperationException(
             $"Required FK not resolved ({logContext ?? "no context"}): guildResolved={guild.IsSuccess} userResolved={user.IsSuccess}"));

--- a/src/DiscordEventService/Services/ThreadChannelBackfillService.cs
+++ b/src/DiscordEventService/Services/ThreadChannelBackfillService.cs
@@ -39,16 +39,16 @@ public class ThreadChannelBackfillService(
                 await channelUpsert.UpsertChannelAsync(live, thread.GuildId);
                 repaired++;
                 logger.LogInformation(
-                    "Repaired thread channel {DiscordId} via Discord API as {Type} (parent={ParentId})",
+                    "Repaired thread channel {ChannelId} via Discord API as {ChannelType} under parent {ParentChannelId}",
                     thread.DiscordId, live.Type, live.ParentId);
             }
             catch (NotFoundException)
             {
-                logger.LogDebug("Thread {DiscordId} 404 from Discord; leaving as-is", thread.DiscordId);
+                logger.LogDebug("Thread {ChannelId} 404 from Discord; leaving as-is", thread.DiscordId);
             }
             catch (UnauthorizedException)
             {
-                logger.LogDebug("Thread {DiscordId} 403 from Discord; leaving as-is", thread.DiscordId);
+                logger.LogDebug("Thread {ChannelId} 403 from Discord; leaving as-is", thread.DiscordId);
             }
         }
 

--- a/src/DiscordEventService/Services/UserService.cs
+++ b/src/DiscordEventService/Services/UserService.cs
@@ -30,7 +30,7 @@ public class UserService(DiscordDbContext db, ILogger<UserService> logger)
             var entity = await db.Users.FirstOrDefaultAsync(u => u.DiscordId == user.Id);
             if (entity is null)
             {
-                logger.LogError("UserUpsert lost the row for DiscordId={DiscordId} after detecting a name change", user.Id);
+                logger.LogError("User upsert lost the row for user {UserId} after detecting a name change", user.Id);
                 return UpsertResult<Guid>.Failure($"User upsert lost the row for DiscordId={user.Id}");
             }
 
@@ -52,7 +52,7 @@ public class UserService(DiscordDbContext db, ILogger<UserService> logger)
             await db.SaveChangesAsync();
 
             logger.LogInformation(
-                "User name changed for {DiscordId}: username {OldUser} → {NewUser}, globalName {OldGlobal} → {NewGlobal}",
+                "User name changed for {UserId}: username {OldUsername} → {NewUsername}, global name {OldGlobalName} → {NewGlobalName}",
                 user.Id,
                 usernameChanged ? existing.Username : "(unchanged)",
                 usernameChanged ? user.Username : "(unchanged)",
@@ -85,7 +85,7 @@ public class UserService(DiscordDbContext db, ILogger<UserService> logger)
 
         if (id == Guid.Empty)
         {
-            logger.LogError("UserUpsert lost the row for DiscordId={DiscordId} after upsert", user.Id);
+            logger.LogError("User upsert lost the row for user {UserId} after upsert", user.Id);
             return UpsertResult<Guid>.Failure($"User upsert lost the row for DiscordId={user.Id}");
         }
 
@@ -104,8 +104,8 @@ public class UserService(DiscordDbContext db, ILogger<UserService> logger)
 
         if (!userResult.IsSuccess || guildId == Guid.Empty)
         {
-            logger.LogWarning("Cannot upsert member: User={UserResolved} Guild={GuildResolved} for MemberId={MemberId} GuildId={GuildId}",
-                userResult.IsSuccess, guildId != Guid.Empty, member.Id, member.Guild.Id);
+            logger.LogError("Cannot upsert member {MemberId} in guild {GuildId}: user resolved {UserResolved}, guild resolved {GuildResolved}",
+                member.Id, member.Guild.Id, userResult.IsSuccess, guildId != Guid.Empty);
             return;
         }
 


### PR DESCRIPTION
## Summary

Tier C of the dotnet-guidelines audit backlog (follow-up to #232 / Tier A): the 25 confirmed logging findings, plus guard comments on persisted enums.

### Logging (25 audit findings)
- **log-template (20)** — Key=Value dump templates rewritten as prose sentences; placeholders renamed to semantic PascalCase per the naming table: `{Thing}Count` for counts, `{EntityType}Id` for Discord ids, `{MemberGuid}` where the value is an internal Guid, `{GapDuration}` for durations. A few same-file occurrences of the identical pattern were renamed alongside the flagged lines so no file is left half-converted.
- **log-level (4)** — quick-sync channel skips Debug→Warning (BootQuickSyncService); member-upsert abort Warning→Error (UserService, data loss); per-batch `[bf-diag]` diagnostics Info→Debug (MessagesBackfillJob); meme attachment skips Info→Warning (MemeAttachmentIndexer).
- **log-duplicate (1)** — duplicate channel-start log removed in MessagesBackfillJob; the resume cursor folded into the surviving start log (renders `start` when there is no cursor).

**Deliberate deviation:** the per-channel *done* summary in MessagesBackfillJob stays at Information (reworded to prose) instead of dropping to Debug — it mirrors the kept channel-start Information log and carries the `ExitReason` that diagnosed #124.

**Worth a glance:** `MemeAttachmentIndexer.Skip()` at Warning means the #223 full backfill will emit a burst of warnings for routine filtering (oversized/non-image attachments). Skips are terminal DB rows so steady-state volume is low; flagging in case you'd rather keep it at Information until after the backfill.

### Enum guards (second commit)
All 24 entity enums persist as raw ints (default EF mapping, no converters) and several are non-sequential (`ChannelType.Media=16`, statuses `0/2/4`). Each declaration now carries a WHY comment forbidding renumbering/stripping explicit values, so the `enum-implicit-values` style rule can't silently corrupt data again (last audit pass an editor agent stripped 22 of them before the safety scan caught it).

## Verification
- `dotnet build --no-incremental`: 0 warnings, 0 errors
- `dotnet test`: 151/151 passed (Testcontainers)
- Focused dotnet-guidelines review over the diff: arg order/count verified on every rewritten template, no behavior change outside log calls

🤖 Generated with [Claude Code](https://claude.com/claude-code)