### PR TITLE
chore: dotnet-guidelines Tier B1 — internal/sealed visibility sweep

### DIFF
--- a/src/DiscordEventService/Configuration/DatabaseOptions.cs
+++ b/src/DiscordEventService/Configuration/DatabaseOptions.cs
@@ -1,6 +1,6 @@
 namespace DiscordEventService.Configuration;
 
-public class DatabaseOptions
+internal sealed class DatabaseOptions
 {
     public const string SectionName = "Database";
 

--- a/src/DiscordEventService/Configuration/DiscordOptions.cs
+++ b/src/DiscordEventService/Configuration/DiscordOptions.cs
@@ -2,7 +2,7 @@ using System.ComponentModel.DataAnnotations;
 
 namespace DiscordEventService.Configuration;
 
-public class DiscordOptions
+internal sealed class DiscordOptions
 {
     public const string SectionName = "Discord";
 

--- a/src/DiscordEventService/Configuration/HealthCheckOptions.cs
+++ b/src/DiscordEventService/Configuration/HealthCheckOptions.cs
@@ -1,6 +1,6 @@
 namespace DiscordEventService.Configuration;
 
-public class HealthCheckOptions
+internal sealed class HealthCheckOptions
 {
     public const string SectionName = "HealthCheck";
 

--- a/src/DiscordEventService/Configuration/MemeIndexOptions.cs
+++ b/src/DiscordEventService/Configuration/MemeIndexOptions.cs
@@ -1,6 +1,6 @@
 namespace DiscordEventService.Configuration;
 
-public sealed class MemeIndexOptions
+internal sealed class MemeIndexOptions
 {
     public const string SectionName = "MemeIndex";
 

--- a/src/DiscordEventService/Configuration/OpenRouterOptions.cs
+++ b/src/DiscordEventService/Configuration/OpenRouterOptions.cs
@@ -1,6 +1,6 @@
 namespace DiscordEventService.Configuration;
 
-public sealed class OpenRouterOptions
+internal sealed class OpenRouterOptions
 {
     public const string SectionName = "OpenRouter";
 

--- a/src/DiscordEventService/Data/DiscordDbContext.cs
+++ b/src/DiscordEventService/Data/DiscordDbContext.cs
@@ -5,7 +5,7 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 namespace DiscordEventService.Data;
 
-public class DiscordDbContext(DbContextOptions<DiscordDbContext> options) : DbContext(options)
+public sealed class DiscordDbContext(DbContextOptions<DiscordDbContext> options) : DbContext(options)
 {
     public DbSet<GuildEntity> Guilds => Set<GuildEntity>();
     public DbSet<ChannelEntity> Channels => Set<ChannelEntity>();
@@ -140,13 +140,13 @@ public class DiscordDbContext(DbContextOptions<DiscordDbContext> options) : DbCo
     }
 }
 
-public interface ITimestamped
+internal interface ITimestamped
 {
     DateTime FirstSeenUtc { get; set; }
     DateTime LastUpdatedUtc { get; set; }
 }
 
-public static class UuidV7Extensions
+internal static class UuidV7Extensions
 {
     public static void ConfigureUuidGeneration(this ModelBuilder modelBuilder)
     {

--- a/src/DiscordEventService/Endpoints/BackfillEndpoints.cs
+++ b/src/DiscordEventService/Endpoints/BackfillEndpoints.cs
@@ -6,7 +6,7 @@ using Microsoft.EntityFrameworkCore;
 
 namespace DiscordEventService.Endpoints;
 
-public static class BackfillEndpoints
+internal static class BackfillEndpoints
 {
     public static void MapBackfillEndpoints(this WebApplication app)
     {
@@ -118,7 +118,7 @@ public static class BackfillEndpoints
     }
 }
 
-public record BackfillRequest
+internal sealed record BackfillRequest
 {
     public bool IncludeMessages { get; init; } = true;
     public bool IncludeReactions { get; init; } = true;
@@ -130,20 +130,20 @@ public record BackfillRequest
     };
 }
 
-public record BackfillResponse
+internal sealed record BackfillResponse
 {
     public required string JobId { get; init; }
     public required ulong GuildId { get; init; }
 }
 
-public record BackfillStatusResponse
+internal sealed record BackfillStatusResponse
 {
     public required ulong GuildId { get; init; }
     public required string OverallStatus { get; init; }
     public required List<CheckpointDto> Checkpoints { get; init; }
 }
 
-public record CheckpointDto
+internal sealed record CheckpointDto
 {
     public required string Type { get; init; }
     public required string Status { get; init; }

--- a/src/DiscordEventService/Endpoints/MemeBenchmarkEndpoints.cs
+++ b/src/DiscordEventService/Endpoints/MemeBenchmarkEndpoints.cs
@@ -5,7 +5,7 @@ using Microsoft.Extensions.Options;
 
 namespace DiscordEventService.Endpoints;
 
-public static class MemeBenchmarkEndpoints
+internal static class MemeBenchmarkEndpoints
 {
     public static void MapMemeBenchmarkEndpoints(this WebApplication app)
     {
@@ -101,7 +101,7 @@ public static class MemeBenchmarkEndpoints
     }
 }
 
-public sealed record BenchmarkStartResponse
+internal sealed record BenchmarkStartResponse
 {
     public required string HangfireJobId { get; init; }
     public required int SampleSize { get; init; }

--- a/src/DiscordEventService/Endpoints/MemeIndexEndpoints.cs
+++ b/src/DiscordEventService/Endpoints/MemeIndexEndpoints.cs
@@ -8,7 +8,7 @@ using Microsoft.Extensions.Options;
 
 namespace DiscordEventService.Endpoints;
 
-public static class MemeIndexEndpoints
+internal static class MemeIndexEndpoints
 {
     public static void MapMemeIndexEndpoints(this WebApplication app)
     {
@@ -91,7 +91,7 @@ public static class MemeIndexEndpoints
     }
 }
 
-public sealed record MemeIndexStartResponse
+internal sealed record MemeIndexStartResponse
 {
     public required string HangfireJobId { get; init; }
     public required ulong GuildId { get; init; }
@@ -99,13 +99,13 @@ public sealed record MemeIndexStartResponse
     public required int MaxImagesPerRun { get; init; }
 }
 
-public sealed record MemeIndexStatusResponse
+internal sealed record MemeIndexStatusResponse
 {
     public required List<MemeIndexCheckpointDto> Checkpoints { get; init; }
     public required MemeIndexRowCounts Rows { get; init; }
 }
 
-public sealed record MemeIndexRowCounts
+internal sealed record MemeIndexRowCounts
 {
     public int Pending { get; init; }
     public int Indexed { get; init; }
@@ -114,7 +114,7 @@ public sealed record MemeIndexRowCounts
     public int Total => Pending + Indexed + Failed + Skipped;
 }
 
-public sealed record MemeIndexCheckpointDto
+internal sealed record MemeIndexCheckpointDto
 {
     public required ulong GuildId { get; init; }
     public required string Status { get; init; }

--- a/src/DiscordEventService/Endpoints/OpsEndpoints.cs
+++ b/src/DiscordEventService/Endpoints/OpsEndpoints.cs
@@ -3,7 +3,7 @@ using DiscordEventService.Services;
 
 namespace DiscordEventService.Endpoints;
 
-public static class OpsEndpoints
+internal static class OpsEndpoints
 {
     public static void MapOpsEndpoints(this WebApplication app)
     {
@@ -109,7 +109,7 @@ public static class OpsEndpoints
     }
 }
 
-public record DowntimeStartResponse
+internal sealed record DowntimeStartResponse
 {
     public required Guid Id { get; init; }
     public required string Type { get; init; }

--- a/src/DiscordEventService/Jobs/BackfillJobBase.cs
+++ b/src/DiscordEventService/Jobs/BackfillJobBase.cs
@@ -6,7 +6,7 @@ namespace DiscordEventService.Jobs;
 // Per-item progress helpers shared by every backfill job. The job lifecycle (scope, checkpoint
 // get-or-create, status transitions) lives in BackfillJobExecutor; only the mid-loop progress/error
 // book-keeping that runs inside a job's work delegate stays here.
-public abstract class BackfillJobBase
+internal abstract class BackfillJobBase
 {
     protected abstract BackfillType BackfillType { get; }
 

--- a/src/DiscordEventService/Jobs/BackfillJobExecutor.cs
+++ b/src/DiscordEventService/Jobs/BackfillJobExecutor.cs
@@ -6,7 +6,7 @@ namespace DiscordEventService.Jobs;
 
 // Jobs supply only per-item work as a delegate, keeping DiscordClient out of the executor so its
 // checkpoint transitions are unit-testable against a real DbContext with no gateway.
-public sealed class BackfillJobExecutor(
+internal sealed class BackfillJobExecutor(
     IServiceScopeFactory scopeFactory,
     ILogger<BackfillJobExecutor> logger)
 {
@@ -105,12 +105,12 @@ public sealed class BackfillJobExecutor(
     }
 }
 
-public sealed record BackfillContext(
+internal sealed record BackfillContext(
     DiscordDbContext Db,
     IServiceProvider Services,
     BackfillCheckpointEntity Checkpoint);
 
-public sealed record BackfillOutcome
+internal sealed record BackfillOutcome
 {
     public required bool IsShortCircuit { get; init; }
     public string? Reason { get; init; }

--- a/src/DiscordEventService/Jobs/ChannelsBackfillJob.cs
+++ b/src/DiscordEventService/Jobs/ChannelsBackfillJob.cs
@@ -5,7 +5,7 @@ using Microsoft.EntityFrameworkCore;
 
 namespace DiscordEventService.Jobs;
 
-public sealed class ChannelsBackfillJob(
+internal sealed class ChannelsBackfillJob(
     DiscordClient discordClient,
     BackfillJobExecutor executor) : BackfillJobBase, IBackfillJob
 {

--- a/src/DiscordEventService/Jobs/EmojisBackfillJob.cs
+++ b/src/DiscordEventService/Jobs/EmojisBackfillJob.cs
@@ -5,7 +5,7 @@ using Microsoft.EntityFrameworkCore;
 
 namespace DiscordEventService.Jobs;
 
-public sealed class EmojisBackfillJob(
+internal sealed class EmojisBackfillJob(
     DiscordClient discordClient,
     BackfillJobExecutor executor) : BackfillJobBase, IBackfillJob
 {

--- a/src/DiscordEventService/Jobs/GuildBackfillOrchestrator.cs
+++ b/src/DiscordEventService/Jobs/GuildBackfillOrchestrator.cs
@@ -2,7 +2,7 @@ using Hangfire;
 
 namespace DiscordEventService.Jobs;
 
-public class GuildBackfillOrchestrator(
+internal sealed class GuildBackfillOrchestrator(
     IBackgroundJobClient backgroundJobClient,
     ILogger<GuildBackfillOrchestrator> logger)
 {
@@ -58,7 +58,7 @@ public class GuildBackfillOrchestrator(
     }
 }
 
-public record BackfillOptions
+internal sealed record BackfillOptions
 {
     public bool IncludeMessages { get; init; } = true;
     public bool IncludeReactions { get; init; } = true;

--- a/src/DiscordEventService/Jobs/HealthCheckJob.cs
+++ b/src/DiscordEventService/Jobs/HealthCheckJob.cs
@@ -7,7 +7,7 @@ using Microsoft.Extensions.Options;
 
 namespace DiscordEventService.Jobs;
 
-public class HealthCheckJob(
+internal sealed class HealthCheckJob(
     IServiceScopeFactory scopeFactory,
     IHttpClientFactory httpClientFactory,
     IOptions<HealthCheckOptions> options,

--- a/src/DiscordEventService/Jobs/IBackfillJob.cs
+++ b/src/DiscordEventService/Jobs/IBackfillJob.cs
@@ -1,6 +1,6 @@
 namespace DiscordEventService.Jobs;
 
-public interface IBackfillJob
+internal interface IBackfillJob
 {
     Task ExecuteAsync(ulong guildId, CancellationToken cancellationToken);
 }

--- a/src/DiscordEventService/Jobs/MembersBackfillJob.cs
+++ b/src/DiscordEventService/Jobs/MembersBackfillJob.cs
@@ -6,7 +6,7 @@ using Microsoft.EntityFrameworkCore;
 
 namespace DiscordEventService.Jobs;
 
-public sealed class MembersBackfillJob(
+internal sealed class MembersBackfillJob(
     DiscordClient discordClient,
     BackfillJobExecutor executor,
     ILogger<MembersBackfillJob> logger) : BackfillJobBase, IBackfillJob

--- a/src/DiscordEventService/Jobs/MemeBenchmarkJob.cs
+++ b/src/DiscordEventService/Jobs/MemeBenchmarkJob.cs
@@ -6,7 +6,7 @@ using Microsoft.Extensions.Options;
 
 namespace DiscordEventService.Jobs;
 
-public sealed class MemeBenchmarkJob(
+internal sealed class MemeBenchmarkJob(
     MemeSampleService sampleService,
     AttachmentUrlRefreshService urlRefreshService,
     OpenRouterClient openRouterClient,

--- a/src/DiscordEventService/Jobs/MemeIndexSweepJob.cs
+++ b/src/DiscordEventService/Jobs/MemeIndexSweepJob.cs
@@ -11,7 +11,7 @@ namespace DiscordEventService.Jobs;
 // seconds; this catches what it misses — attachments posted during downtime,
 // live-path enqueue failures, and Failed rows still under the attempt cap.
 // Skips guilds whose meme indexing is already running.
-public sealed class MemeIndexSweepJob(
+internal sealed class MemeIndexSweepJob(
     IServiceScopeFactory scopeFactory,
     IBackgroundJobClient backgroundJobClient,
     ILogger<MemeIndexSweepJob> logger)

--- a/src/DiscordEventService/Jobs/MemeIndexingJob.cs
+++ b/src/DiscordEventService/Jobs/MemeIndexingJob.cs
@@ -7,7 +7,7 @@ using Microsoft.Extensions.Options;
 
 namespace DiscordEventService.Jobs;
 
-public sealed class MemeIndexingJob(
+internal sealed class MemeIndexingJob(
     BackfillJobExecutor executor,
     IServiceScopeFactory scopeFactory,
     ILogger<MemeIndexingJob> logger) : BackfillJobBase

--- a/src/DiscordEventService/Jobs/MessagesBackfillJob.cs
+++ b/src/DiscordEventService/Jobs/MessagesBackfillJob.cs
@@ -9,7 +9,7 @@ using Microsoft.EntityFrameworkCore;
 
 namespace DiscordEventService.Jobs;
 
-public sealed class MessagesBackfillJob(
+internal sealed class MessagesBackfillJob(
     DiscordClient discordClient,
     BackfillJobExecutor executor,
     ILogger<MessagesBackfillJob> logger) : BackfillJobBase, IBackfillJob

--- a/src/DiscordEventService/Jobs/PeriodicFullBackfillJob.cs
+++ b/src/DiscordEventService/Jobs/PeriodicFullBackfillJob.cs
@@ -7,7 +7,7 @@ namespace DiscordEventService.Jobs;
 // Reconnect-backfill is capped to 2 days, so anything older needs this periodic sweep;
 // skips guilds with an InProgress checkpoint to avoid stepping on the reconnect path or
 // the operator-triggered /api/backfill endpoint.
-public class PeriodicFullBackfillJob(
+internal sealed class PeriodicFullBackfillJob(
     IServiceScopeFactory scopeFactory,
     ILogger<PeriodicFullBackfillJob> logger)
 {

--- a/src/DiscordEventService/Jobs/ReactionsBackfillJob.cs
+++ b/src/DiscordEventService/Jobs/ReactionsBackfillJob.cs
@@ -8,7 +8,7 @@ using Microsoft.EntityFrameworkCore;
 
 namespace DiscordEventService.Jobs;
 
-public sealed class ReactionsBackfillJob(
+internal sealed class ReactionsBackfillJob(
     DiscordClient discordClient,
     BackfillJobExecutor executor,
     ILogger<ReactionsBackfillJob> logger) : BackfillJobBase, IBackfillJob

--- a/src/DiscordEventService/Jobs/RolesBackfillJob.cs
+++ b/src/DiscordEventService/Jobs/RolesBackfillJob.cs
@@ -5,7 +5,7 @@ using Microsoft.EntityFrameworkCore;
 
 namespace DiscordEventService.Jobs;
 
-public sealed class RolesBackfillJob(
+internal sealed class RolesBackfillJob(
     DiscordClient discordClient,
     BackfillJobExecutor executor) : BackfillJobBase, IBackfillJob
 {

--- a/src/DiscordEventService/Jobs/StickersBackfillJob.cs
+++ b/src/DiscordEventService/Jobs/StickersBackfillJob.cs
@@ -5,7 +5,7 @@ using Microsoft.EntityFrameworkCore;
 
 namespace DiscordEventService.Jobs;
 
-public sealed class StickersBackfillJob(
+internal sealed class StickersBackfillJob(
     DiscordClient discordClient,
     BackfillJobExecutor executor) : BackfillJobBase, IBackfillJob
 {

--- a/src/DiscordEventService/Services/BootQuickSyncService.cs
+++ b/src/DiscordEventService/Services/BootQuickSyncService.cs
@@ -8,7 +8,7 @@ using Microsoft.EntityFrameworkCore;
 
 namespace DiscordEventService.Services;
 
-public class BootQuickSyncService(
+internal sealed class BootQuickSyncService(
     IServiceScopeFactory scopeFactory,
     DiscordClient discordClient,
     ILogger<BootQuickSyncService> logger)

--- a/src/DiscordEventService/Services/ChannelUpsertService.cs
+++ b/src/DiscordEventService/Services/ChannelUpsertService.cs
@@ -5,7 +5,7 @@ using Microsoft.EntityFrameworkCore;
 
 namespace DiscordEventService.Services;
 
-public class ChannelUpsertService(DiscordDbContext db, ILogger<ChannelUpsertService> logger)
+internal sealed class ChannelUpsertService(DiscordDbContext db, ILogger<ChannelUpsertService> logger)
 {
     public async Task<UpsertResult<Guid>> UpsertChannelAsync(DiscordChannel channel, Guid guildId)
     {

--- a/src/DiscordEventService/Services/CoreServiceRegistration.cs
+++ b/src/DiscordEventService/Services/CoreServiceRegistration.cs
@@ -6,7 +6,7 @@ namespace DiscordEventService.Services;
 
 // Single source of truth for the scoped services both the root (ASP.NET Core) and the DSharpPlus
 // child DI container need — registration and StartupValidator both loop over CoreServiceTypes.
-public static class CoreServiceRegistration
+internal static class CoreServiceRegistration
 {
     public static readonly Type[] CoreServiceTypes =
     [

--- a/src/DiscordEventService/Services/DiscordHostedService.cs
+++ b/src/DiscordEventService/Services/DiscordHostedService.cs
@@ -4,7 +4,7 @@ using DSharpPlus.Exceptions;
 
 namespace DiscordEventService.Services;
 
-public class DiscordHostedService(
+internal sealed class DiscordHostedService(
     DiscordClient client,
     IServiceScopeFactory scopeFactory,
     ILogger<DiscordHostedService> logger) : IHostedService

--- a/src/DiscordEventService/Services/DowntimeTrackerService.cs
+++ b/src/DiscordEventService/Services/DowntimeTrackerService.cs
@@ -4,7 +4,7 @@ using Microsoft.EntityFrameworkCore;
 
 namespace DiscordEventService.Services;
 
-public class DowntimeTrackerService(DiscordDbContext db, ILogger<DowntimeTrackerService> logger)
+internal sealed class DowntimeTrackerService(DiscordDbContext db, ILogger<DowntimeTrackerService> logger)
 {
     private static readonly TimeSpan StartupGapThreshold = TimeSpan.FromSeconds(30);
 
@@ -147,7 +147,7 @@ public class DowntimeTrackerService(DiscordDbContext db, ILogger<DowntimeTracker
     }
 }
 
-public record LastAliveResult(DateTime? LastAliveUtc, DateTime? LastHeartbeatUtc, DateTime? MaxReceivedAtUtc);
+internal sealed record LastAliveResult(DateTime? LastAliveUtc, DateTime? LastHeartbeatUtc, DateTime? MaxReceivedAtUtc);
 
-public record OpenDowntimeResult(Guid Id, BotDowntimeType ActualType, bool Created);
+internal sealed record OpenDowntimeResult(Guid Id, BotDowntimeType ActualType, bool Created);
 

--- a/src/DiscordEventService/Services/EventHandlers/AuditLogEventHandler.cs
+++ b/src/DiscordEventService/Services/EventHandlers/AuditLogEventHandler.cs
@@ -5,7 +5,7 @@ using DSharpPlus.EventArgs;
 
 namespace DiscordEventService.Services.EventHandlers;
 
-public sealed class AuditLogEventHandler(EventPipeline pipeline) :
+internal sealed class AuditLogEventHandler(EventPipeline pipeline) :
     IEventHandler<GuildAuditLogCreatedEventArgs>
 {
     public async Task HandleEventAsync(DiscordClient sender, GuildAuditLogCreatedEventArgs e)

--- a/src/DiscordEventService/Services/EventHandlers/AutoModEventHandler.cs
+++ b/src/DiscordEventService/Services/EventHandlers/AutoModEventHandler.cs
@@ -5,7 +5,7 @@ using DSharpPlus.EventArgs;
 
 namespace DiscordEventService.Services.EventHandlers;
 
-public sealed class AutoModEventHandler(EventPipeline pipeline) :
+internal sealed class AutoModEventHandler(EventPipeline pipeline) :
     IEventHandler<AutoModerationRuleCreatedEventArgs>,
     IEventHandler<AutoModerationRuleUpdatedEventArgs>,
     IEventHandler<AutoModerationRuleDeletedEventArgs>,

--- a/src/DiscordEventService/Services/EventHandlers/AutoModRuleEventHandler.cs
+++ b/src/DiscordEventService/Services/EventHandlers/AutoModRuleEventHandler.cs
@@ -8,7 +8,7 @@ using Microsoft.EntityFrameworkCore;
 
 namespace DiscordEventService.Services.EventHandlers;
 
-public sealed class AutoModRuleEventHandler(EventPipeline pipeline) :
+internal sealed class AutoModRuleEventHandler(EventPipeline pipeline) :
     IEventHandler<AutoModerationRuleCreatedEventArgs>,
     IEventHandler<AutoModerationRuleUpdatedEventArgs>,
     IEventHandler<AutoModerationRuleDeletedEventArgs>

--- a/src/DiscordEventService/Services/EventHandlers/BanEventHandler.cs
+++ b/src/DiscordEventService/Services/EventHandlers/BanEventHandler.cs
@@ -7,7 +7,7 @@ using Microsoft.EntityFrameworkCore;
 
 namespace DiscordEventService.Services.EventHandlers;
 
-public sealed class BanEventHandler(EventPipeline pipeline) :
+internal sealed class BanEventHandler(EventPipeline pipeline) :
     IEventHandler<GuildBanAddedEventArgs>,
     IEventHandler<GuildBanRemovedEventArgs>
 {

--- a/src/DiscordEventService/Services/EventHandlers/ChannelEventHandler.cs
+++ b/src/DiscordEventService/Services/EventHandlers/ChannelEventHandler.cs
@@ -9,7 +9,7 @@ using Microsoft.EntityFrameworkCore;
 
 namespace DiscordEventService.Services.EventHandlers;
 
-public sealed class ChannelEventHandler(EventPipeline pipeline) :
+internal sealed class ChannelEventHandler(EventPipeline pipeline) :
     IEventHandler<ChannelCreatedEventArgs>,
     IEventHandler<ChannelUpdatedEventArgs>,
     IEventHandler<ChannelDeletedEventArgs>,

--- a/src/DiscordEventService/Services/EventHandlers/EmojiEventHandler.cs
+++ b/src/DiscordEventService/Services/EventHandlers/EmojiEventHandler.cs
@@ -8,7 +8,7 @@ using Microsoft.EntityFrameworkCore;
 
 namespace DiscordEventService.Services.EventHandlers;
 
-public sealed class EmojiEventHandler(EventPipeline pipeline) :
+internal sealed class EmojiEventHandler(EventPipeline pipeline) :
     IEventHandler<GuildEmojisUpdatedEventArgs>
 {
     public async Task HandleEventAsync(DiscordClient sender, GuildEmojisUpdatedEventArgs e)

--- a/src/DiscordEventService/Services/EventHandlers/GuildEventHandler.cs
+++ b/src/DiscordEventService/Services/EventHandlers/GuildEventHandler.cs
@@ -8,7 +8,7 @@ using Microsoft.EntityFrameworkCore;
 
 namespace DiscordEventService.Services.EventHandlers;
 
-public sealed class GuildEventHandler(EventPipeline pipeline) :
+internal sealed class GuildEventHandler(EventPipeline pipeline) :
     IEventHandler<GuildCreatedEventArgs>,
     IEventHandler<GuildAvailableEventArgs>,
     IEventHandler<GuildUpdatedEventArgs>,

--- a/src/DiscordEventService/Services/EventHandlers/GuildMembersChunkHandler.cs
+++ b/src/DiscordEventService/Services/EventHandlers/GuildMembersChunkHandler.cs
@@ -6,7 +6,7 @@ using DSharpPlus.EventArgs;
 
 namespace DiscordEventService.Services.EventHandlers;
 
-public sealed class GuildMembersChunkHandler(EventPipeline pipeline) :
+internal sealed class GuildMembersChunkHandler(EventPipeline pipeline) :
     IEventHandler<GuildMembersChunkedEventArgs>
 {
     private static readonly JsonSerializerOptions JsonOptions = new JsonSerializerOptions

--- a/src/DiscordEventService/Services/EventHandlers/GuildUpdateEventHandler.cs
+++ b/src/DiscordEventService/Services/EventHandlers/GuildUpdateEventHandler.cs
@@ -5,7 +5,7 @@ using DSharpPlus.EventArgs;
 
 namespace DiscordEventService.Services.EventHandlers;
 
-public sealed class GuildUpdateEventHandler(EventPipeline pipeline) :
+internal sealed class GuildUpdateEventHandler(EventPipeline pipeline) :
     IEventHandler<GuildUpdatedEventArgs>
 {
     public async Task HandleEventAsync(DiscordClient sender, GuildUpdatedEventArgs e)

--- a/src/DiscordEventService/Services/EventHandlers/IntegrationEventHandler.cs
+++ b/src/DiscordEventService/Services/EventHandlers/IntegrationEventHandler.cs
@@ -7,7 +7,7 @@ using Microsoft.EntityFrameworkCore;
 
 namespace DiscordEventService.Services.EventHandlers;
 
-public sealed class IntegrationEventHandler(EventPipeline pipeline) :
+internal sealed class IntegrationEventHandler(EventPipeline pipeline) :
     IEventHandler<IntegrationCreatedEventArgs>,
     IEventHandler<IntegrationUpdatedEventArgs>,
     IEventHandler<IntegrationDeletedEventArgs>

--- a/src/DiscordEventService/Services/EventHandlers/InviteEventHandler.cs
+++ b/src/DiscordEventService/Services/EventHandlers/InviteEventHandler.cs
@@ -7,7 +7,7 @@ using Microsoft.EntityFrameworkCore;
 
 namespace DiscordEventService.Services.EventHandlers;
 
-public sealed class InviteEventHandler(EventPipeline pipeline) :
+internal sealed class InviteEventHandler(EventPipeline pipeline) :
     IEventHandler<InviteCreatedEventArgs>,
     IEventHandler<InviteDeletedEventArgs>
 {

--- a/src/DiscordEventService/Services/EventHandlers/MemberEventHandler.cs
+++ b/src/DiscordEventService/Services/EventHandlers/MemberEventHandler.cs
@@ -9,7 +9,7 @@ using Microsoft.EntityFrameworkCore;
 
 namespace DiscordEventService.Services.EventHandlers;
 
-public sealed class MemberEventHandler(EventPipeline pipeline) :
+internal sealed class MemberEventHandler(EventPipeline pipeline) :
     IEventHandler<GuildMemberAddedEventArgs>,
     IEventHandler<GuildMemberRemovedEventArgs>,
     IEventHandler<GuildMemberUpdatedEventArgs>,

--- a/src/DiscordEventService/Services/EventHandlers/MessageEventHandler.cs
+++ b/src/DiscordEventService/Services/EventHandlers/MessageEventHandler.cs
@@ -16,7 +16,7 @@ using Microsoft.Extensions.Options;
 
 namespace DiscordEventService.Services.EventHandlers;
 
-public sealed class MessageEventHandler(EventPipeline pipeline) :
+internal sealed class MessageEventHandler(EventPipeline pipeline) :
     IEventHandler<MessageCreatedEventArgs>,
     IEventHandler<MessageUpdatedEventArgs>,
     IEventHandler<MessageDeletedEventArgs>,

--- a/src/DiscordEventService/Services/EventHandlers/PinEventHandler.cs
+++ b/src/DiscordEventService/Services/EventHandlers/PinEventHandler.cs
@@ -5,7 +5,7 @@ using DSharpPlus.EventArgs;
 
 namespace DiscordEventService.Services.EventHandlers;
 
-public sealed class PinEventHandler(EventPipeline pipeline) :
+internal sealed class PinEventHandler(EventPipeline pipeline) :
     IEventHandler<ChannelPinsUpdatedEventArgs>
 {
     public async Task HandleEventAsync(DiscordClient sender, ChannelPinsUpdatedEventArgs e)

--- a/src/DiscordEventService/Services/EventHandlers/PollEventHandler.cs
+++ b/src/DiscordEventService/Services/EventHandlers/PollEventHandler.cs
@@ -5,7 +5,7 @@ using DSharpPlus.EventArgs;
 
 namespace DiscordEventService.Services.EventHandlers;
 
-public sealed class PollEventHandler(EventPipeline pipeline) :
+internal sealed class PollEventHandler(EventPipeline pipeline) :
     IEventHandler<MessagePollVotedEventArgs>
 {
     public async Task HandleEventAsync(DiscordClient sender, MessagePollVotedEventArgs e)

--- a/src/DiscordEventService/Services/EventHandlers/PresenceEventHandler.cs
+++ b/src/DiscordEventService/Services/EventHandlers/PresenceEventHandler.cs
@@ -10,7 +10,7 @@ using Microsoft.EntityFrameworkCore;
 
 namespace DiscordEventService.Services.EventHandlers;
 
-public sealed class PresenceEventHandler(EventPipeline pipeline) :
+internal sealed class PresenceEventHandler(EventPipeline pipeline) :
     IEventHandler<PresenceUpdatedEventArgs>
 {
     private static readonly JsonSerializerOptions JsonOptions = new JsonSerializerOptions

--- a/src/DiscordEventService/Services/EventHandlers/ReactionEventHandler.cs
+++ b/src/DiscordEventService/Services/EventHandlers/ReactionEventHandler.cs
@@ -5,7 +5,7 @@ using DSharpPlus.EventArgs;
 
 namespace DiscordEventService.Services.EventHandlers;
 
-public sealed class ReactionEventHandler(EventPipeline pipeline) :
+internal sealed class ReactionEventHandler(EventPipeline pipeline) :
     IEventHandler<MessageReactionAddedEventArgs>,
     IEventHandler<MessageReactionRemovedEventArgs>,
     IEventHandler<MessageReactionsClearedEventArgs>,

--- a/src/DiscordEventService/Services/EventHandlers/RoleEventHandler.cs
+++ b/src/DiscordEventService/Services/EventHandlers/RoleEventHandler.cs
@@ -9,7 +9,7 @@ using Microsoft.EntityFrameworkCore;
 
 namespace DiscordEventService.Services.EventHandlers;
 
-public sealed class RoleEventHandler(EventPipeline pipeline) :
+internal sealed class RoleEventHandler(EventPipeline pipeline) :
     IEventHandler<GuildRoleCreatedEventArgs>,
     IEventHandler<GuildRoleUpdatedEventArgs>,
     IEventHandler<GuildRoleDeletedEventArgs>

--- a/src/DiscordEventService/Services/EventHandlers/ScheduledEventHandler.cs
+++ b/src/DiscordEventService/Services/EventHandlers/ScheduledEventHandler.cs
@@ -9,7 +9,7 @@ using Microsoft.EntityFrameworkCore;
 
 namespace DiscordEventService.Services.EventHandlers;
 
-public sealed class ScheduledEventHandler(EventPipeline pipeline) :
+internal sealed class ScheduledEventHandler(EventPipeline pipeline) :
     IEventHandler<ScheduledGuildEventCreatedEventArgs>,
     IEventHandler<ScheduledGuildEventUpdatedEventArgs>,
     IEventHandler<ScheduledGuildEventDeletedEventArgs>,

--- a/src/DiscordEventService/Services/EventHandlers/SocketLifecycleHandler.cs
+++ b/src/DiscordEventService/Services/EventHandlers/SocketLifecycleHandler.cs
@@ -7,7 +7,7 @@ using Microsoft.EntityFrameworkCore;
 
 namespace DiscordEventService.Services.EventHandlers;
 
-public sealed class SocketLifecycleHandler(
+internal sealed class SocketLifecycleHandler(
     DiscordDbContext db,
     DowntimeTrackerService tracker,
     GuildBackfillOrchestrator orchestrator,

--- a/src/DiscordEventService/Services/EventHandlers/StageInstanceEventHandler.cs
+++ b/src/DiscordEventService/Services/EventHandlers/StageInstanceEventHandler.cs
@@ -7,7 +7,7 @@ using Microsoft.EntityFrameworkCore;
 
 namespace DiscordEventService.Services.EventHandlers;
 
-public sealed class StageInstanceEventHandler(EventPipeline pipeline) :
+internal sealed class StageInstanceEventHandler(EventPipeline pipeline) :
     IEventHandler<StageInstanceCreatedEventArgs>,
     IEventHandler<StageInstanceUpdatedEventArgs>,
     IEventHandler<StageInstanceDeletedEventArgs>

--- a/src/DiscordEventService/Services/EventHandlers/StickerEventHandler.cs
+++ b/src/DiscordEventService/Services/EventHandlers/StickerEventHandler.cs
@@ -8,7 +8,7 @@ using Microsoft.EntityFrameworkCore;
 
 namespace DiscordEventService.Services.EventHandlers;
 
-public sealed class StickerEventHandler(EventPipeline pipeline) :
+internal sealed class StickerEventHandler(EventPipeline pipeline) :
     IEventHandler<GuildStickersUpdatedEventArgs>
 {
     public async Task HandleEventAsync(DiscordClient sender, GuildStickersUpdatedEventArgs e)

--- a/src/DiscordEventService/Services/EventHandlers/ThreadEventHandler.cs
+++ b/src/DiscordEventService/Services/EventHandlers/ThreadEventHandler.cs
@@ -7,7 +7,7 @@ using DSharpPlus.EventArgs;
 
 namespace DiscordEventService.Services.EventHandlers;
 
-public sealed class ThreadEventHandler(EventPipeline pipeline) :
+internal sealed class ThreadEventHandler(EventPipeline pipeline) :
     IEventHandler<ThreadCreatedEventArgs>,
     IEventHandler<ThreadUpdatedEventArgs>,
     IEventHandler<ThreadDeletedEventArgs>,

--- a/src/DiscordEventService/Services/EventHandlers/ThreadSyncHandler.cs
+++ b/src/DiscordEventService/Services/EventHandlers/ThreadSyncHandler.cs
@@ -6,7 +6,7 @@ using DSharpPlus.EventArgs;
 
 namespace DiscordEventService.Services.EventHandlers;
 
-public sealed class ThreadSyncHandler(EventPipeline pipeline) :
+internal sealed class ThreadSyncHandler(EventPipeline pipeline) :
     IEventHandler<ThreadListSyncedEventArgs>
 {
     private static readonly JsonSerializerOptions JsonOptions = new JsonSerializerOptions

--- a/src/DiscordEventService/Services/EventHandlers/TypingEventHandler.cs
+++ b/src/DiscordEventService/Services/EventHandlers/TypingEventHandler.cs
@@ -6,7 +6,7 @@ using Microsoft.Extensions.Caching.Memory;
 
 namespace DiscordEventService.Services.EventHandlers;
 
-public sealed class TypingEventHandler(EventPipeline pipeline, IMemoryCache cache) :
+internal sealed class TypingEventHandler(EventPipeline pipeline, IMemoryCache cache) :
     IEventHandler<TypingStartedEventArgs>
 {
     private static readonly TimeSpan ThrottleWindow = TimeSpan.FromSeconds(10);

--- a/src/DiscordEventService/Services/EventHandlers/VoiceEventHandler.cs
+++ b/src/DiscordEventService/Services/EventHandlers/VoiceEventHandler.cs
@@ -5,7 +5,7 @@ using DSharpPlus.EventArgs;
 
 namespace DiscordEventService.Services.EventHandlers;
 
-public sealed class VoiceEventHandler(EventPipeline pipeline) :
+internal sealed class VoiceEventHandler(EventPipeline pipeline) :
     IEventHandler<VoiceStateUpdatedEventArgs>
 {
     public async Task HandleEventAsync(DiscordClient sender, VoiceStateUpdatedEventArgs args)

--- a/src/DiscordEventService/Services/EventHandlers/VoiceServerEventHandler.cs
+++ b/src/DiscordEventService/Services/EventHandlers/VoiceServerEventHandler.cs
@@ -5,7 +5,7 @@ using DSharpPlus.EventArgs;
 
 namespace DiscordEventService.Services.EventHandlers;
 
-public sealed class VoiceServerEventHandler(EventPipeline pipeline) :
+internal sealed class VoiceServerEventHandler(EventPipeline pipeline) :
     IEventHandler<VoiceServerUpdatedEventArgs>
 {
     public async Task HandleEventAsync(DiscordClient sender, VoiceServerUpdatedEventArgs args)

--- a/src/DiscordEventService/Services/EventHandlers/WebhookEventHandler.cs
+++ b/src/DiscordEventService/Services/EventHandlers/WebhookEventHandler.cs
@@ -5,7 +5,7 @@ using DSharpPlus.EventArgs;
 
 namespace DiscordEventService.Services.EventHandlers;
 
-public sealed class WebhookEventHandler(EventPipeline pipeline) :
+internal sealed class WebhookEventHandler(EventPipeline pipeline) :
     IEventHandler<WebhooksUpdatedEventArgs>
 {
     public async Task HandleEventAsync(DiscordClient sender, WebhooksUpdatedEventArgs e)

--- a/src/DiscordEventService/Services/FailedEventService.cs
+++ b/src/DiscordEventService/Services/FailedEventService.cs
@@ -5,7 +5,7 @@ using Microsoft.EntityFrameworkCore;
 
 namespace DiscordEventService.Services;
 
-public class FailedEventService(DiscordDbContext db, ILogger<FailedEventService> logger, IHostEnvironment env)
+internal sealed class FailedEventService(DiscordDbContext db, ILogger<FailedEventService> logger, IHostEnvironment env)
 {
     private static readonly SemaphoreSlim _fallbackFileLock = new SemaphoreSlim(1, 1);
 

--- a/src/DiscordEventService/Services/GuildUpsertService.cs
+++ b/src/DiscordEventService/Services/GuildUpsertService.cs
@@ -4,7 +4,7 @@ using DSharpPlus.Entities;
 
 namespace DiscordEventService.Services;
 
-public class GuildUpsertService(DiscordDbContext db, ILogger<GuildUpsertService> logger)
+internal sealed class GuildUpsertService(DiscordDbContext db, ILogger<GuildUpsertService> logger)
 {
     public async Task<UpsertResult<Guid>> UpsertGuildAsync(DiscordGuild guild)
     {

--- a/src/DiscordEventService/Services/HeartbeatBackgroundService.cs
+++ b/src/DiscordEventService/Services/HeartbeatBackgroundService.cs
@@ -2,7 +2,7 @@ using DSharpPlus;
 
 namespace DiscordEventService.Services;
 
-public class HeartbeatBackgroundService(
+internal sealed class HeartbeatBackgroundService(
     IServiceScopeFactory scopeFactory,
     DiscordClient discordClient,
     ILogger<HeartbeatBackgroundService> logger) : BackgroundService

--- a/src/DiscordEventService/Services/IDiscordEventHandler.cs
+++ b/src/DiscordEventService/Services/IDiscordEventHandler.cs
@@ -2,7 +2,7 @@ using DSharpPlus;
 
 namespace DiscordEventService.Services;
 
-public interface IDiscordEventHandler
+internal interface IDiscordEventHandler
 {
     void RegisterHandlers(DiscordClient client);
 }

--- a/src/DiscordEventService/Services/MemberRoleSnapshotBackfillService.cs
+++ b/src/DiscordEventService/Services/MemberRoleSnapshotBackfillService.cs
@@ -8,12 +8,12 @@ using Microsoft.EntityFrameworkCore;
 
 namespace DiscordEventService.Services;
 
-public class MemberRoleSnapshotBackfillService(
+internal sealed class MemberRoleSnapshotBackfillService(
     DiscordDbContext db,
     DiscordClient discordClient,
     ILogger<MemberRoleSnapshotBackfillService> logger)
 {
-    public record Result(
+    public sealed record Result(
         int EventsProcessed,
         int SnapshotsCreated,
         int SnapshotsClosed,

--- a/src/DiscordEventService/Services/MemeIndexing/AttachmentUrlRefreshService.cs
+++ b/src/DiscordEventService/Services/MemeIndexing/AttachmentUrlRefreshService.cs
@@ -6,7 +6,7 @@ using Microsoft.Extensions.Options;
 
 namespace DiscordEventService.Services.MemeIndexing;
 
-public sealed class AttachmentUrlRefreshService(
+internal sealed class AttachmentUrlRefreshService(
     IHttpClientFactory httpClientFactory,
     IOptions<DiscordOptions> discordOptions,
     ILogger<AttachmentUrlRefreshService> logger)

--- a/src/DiscordEventService/Services/MemeIndexing/BenchmarkReportWriter.cs
+++ b/src/DiscordEventService/Services/MemeIndexing/BenchmarkReportWriter.cs
@@ -3,22 +3,22 @@ using System.Text;
 
 namespace DiscordEventService.Services.MemeIndexing;
 
-public sealed record BenchmarkCell(string Model, MemeAnalysisResult Result, double ElapsedSeconds);
+internal sealed record BenchmarkCell(string Model, MemeAnalysisResult Result, double ElapsedSeconds);
 
-public sealed record BenchmarkItem(
+internal sealed record BenchmarkItem(
     MemeSampleItem Sample,
     string? FreshUrl,
     string? SkipReason,
     List<BenchmarkCell> Cells);
 
-public sealed record BenchmarkRun(
+internal sealed record BenchmarkRun(
     DateTime StartedUtc,
     DateTime FinishedUtc,
     int RequestedSampleSize,
     string[] Models,
     List<BenchmarkItem> Items);
 
-public static class BenchmarkReportWriter
+internal static class BenchmarkReportWriter
 {
     public static string Render(BenchmarkRun run)
     {

--- a/src/DiscordEventService/Services/MemeIndexing/ImageMagic.cs
+++ b/src/DiscordEventService/Services/MemeIndexing/ImageMagic.cs
@@ -1,6 +1,6 @@
 namespace DiscordEventService.Services.MemeIndexing;
 
-public static class ImageMagic
+internal static class ImageMagic
 {
     private static readonly string[] ImageExtensions = ["jpg", "jpeg", "png", "webp", "gif"];
 

--- a/src/DiscordEventService/Services/MemeIndexing/MemeAttachmentIndexer.cs
+++ b/src/DiscordEventService/Services/MemeIndexing/MemeAttachmentIndexer.cs
@@ -8,7 +8,7 @@ using Microsoft.Extensions.Options;
 
 namespace DiscordEventService.Services.MemeIndexing;
 
-public sealed class MemeIndexRunCounters
+internal sealed class MemeIndexRunCounters
 {
     public int Indexed { get; set; }
     public int Deduped { get; set; }
@@ -21,7 +21,7 @@ public sealed class MemeIndexRunCounters
 }
 
 // The DbContext stays a parameter — callers own the unit of work and decide when to flush.
-public sealed class MemeAttachmentIndexer(
+internal sealed class MemeAttachmentIndexer(
     OpenRouterClient openRouterClient,
     IHttpClientFactory httpClientFactory,
     IOptions<MemeIndexOptions> memeIndexOptions,

--- a/src/DiscordEventService/Services/MemeIndexing/MemeMetadata.cs
+++ b/src/DiscordEventService/Services/MemeIndexing/MemeMetadata.cs
@@ -2,7 +2,7 @@ using System.Text.Json.Serialization;
 
 namespace DiscordEventService.Services.MemeIndexing;
 
-public sealed record MemeMetadata
+internal sealed record MemeMetadata
 {
     [JsonPropertyName("description_pl")]
     public required string DescriptionPl { get; init; }
@@ -26,7 +26,7 @@ public sealed record MemeMetadata
     public string? Template { get; init; }
 }
 
-public enum MemeAnalysisOutcome
+internal enum MemeAnalysisOutcome
 {
     Success,
 
@@ -38,9 +38,9 @@ public enum MemeAnalysisOutcome
     Error,
 }
 
-public sealed record MemeAnalysisUsage(int PromptTokens, int CompletionTokens, decimal? CostUsd);
+internal sealed record MemeAnalysisUsage(int PromptTokens, int CompletionTokens, decimal? CostUsd);
 
-public sealed record MemeAnalysisResult
+internal sealed record MemeAnalysisResult
 {
     public required MemeAnalysisOutcome Outcome { get; init; }
     public MemeMetadata? Metadata { get; init; }

--- a/src/DiscordEventService/Services/MemeIndexing/MemeSampleService.cs
+++ b/src/DiscordEventService/Services/MemeIndexing/MemeSampleService.cs
@@ -7,7 +7,7 @@ using Microsoft.Extensions.Options;
 namespace DiscordEventService.Services.MemeIndexing;
 
 // Trailing defaults keep pre-#221 benchmark links files deserializable — old exports lack MessageId/FileSizeBytes.
-public sealed record MemeSampleItem(
+internal sealed record MemeSampleItem(
     ulong GuildDiscordId,
     ulong ChannelDiscordId,
     ulong MessageDiscordId,
@@ -18,7 +18,7 @@ public sealed record MemeSampleItem(
     Guid MessageId = default,
     long FileSizeBytes = 0);
 
-public sealed class MemeSampleService(
+internal sealed class MemeSampleService(
     DiscordDbContext db,
     IOptions<MemeIndexOptions> options,
     ILogger<MemeSampleService> logger)

--- a/src/DiscordEventService/Services/MemeIndexing/OpenRouterClient.cs
+++ b/src/DiscordEventService/Services/MemeIndexing/OpenRouterClient.cs
@@ -8,7 +8,7 @@ using Microsoft.Extensions.Options;
 
 namespace DiscordEventService.Services.MemeIndexing;
 
-public sealed class OpenRouterClient(
+internal sealed class OpenRouterClient(
     IHttpClientFactory httpClientFactory,
     IOptions<OpenRouterOptions> options,
     ILogger<OpenRouterClient> logger)

--- a/src/DiscordEventService/Services/MessageMentionsBackfillService.cs
+++ b/src/DiscordEventService/Services/MessageMentionsBackfillService.cs
@@ -5,11 +5,11 @@ using Microsoft.EntityFrameworkCore;
 
 namespace DiscordEventService.Services;
 
-public partial class MessageMentionsBackfillService(
+internal sealed partial class MessageMentionsBackfillService(
     DiscordDbContext db,
     ILogger<MessageMentionsBackfillService> logger)
 {
-    public record Result(
+    public sealed record Result(
         int MessagesScanned,
         int MessagesSkipped,
         int MessagesProcessed,

--- a/src/DiscordEventService/Services/OrphanReplayService.cs
+++ b/src/DiscordEventService/Services/OrphanReplayService.cs
@@ -4,9 +4,9 @@ using Microsoft.EntityFrameworkCore;
 
 namespace DiscordEventService.Services;
 
-public record OrphanReplayResult(int Scanned, int Inserted, int Skipped);
+internal sealed record OrphanReplayResult(int Scanned, int Inserted, int Skipped);
 
-public class OrphanReplayService(DiscordDbContext db, ILogger<OrphanReplayService> logger)
+internal sealed class OrphanReplayService(DiscordDbContext db, ILogger<OrphanReplayService> logger)
 {
     // Scan-only: JSON reconstruction is deferred until a real non-stub orphan is sampled in prod.
     public async Task<OrphanReplayResult> ReplayMemberUpdateOrphansAsync(CancellationToken ct)

--- a/src/DiscordEventService/Services/Pipeline/EventContext.cs
+++ b/src/DiscordEventService/Services/Pipeline/EventContext.cs
@@ -2,7 +2,7 @@ using DiscordEventService.Data;
 
 namespace DiscordEventService.Services.Pipeline;
 
-public record EventContext(
+internal sealed record EventContext(
     DiscordDbContext Db,
     IServiceProvider Services,
     Guid CorrelationId,

--- a/src/DiscordEventService/Services/Pipeline/EventPipeline.cs
+++ b/src/DiscordEventService/Services/Pipeline/EventPipeline.cs
@@ -2,7 +2,7 @@ using DiscordEventService.Data;
 
 namespace DiscordEventService.Services.Pipeline;
 
-public sealed class EventPipeline(IServiceScopeFactory scopeFactory, ILoggerFactory loggerFactory)
+internal sealed class EventPipeline(IServiceScopeFactory scopeFactory, ILoggerFactory loggerFactory)
 {
     public async Task Execute<TEventArgs>(
         TEventArgs e,

--- a/src/DiscordEventService/Services/Pipeline/FkResolver.cs
+++ b/src/DiscordEventService/Services/Pipeline/FkResolver.cs
@@ -2,7 +2,7 @@ using DSharpPlus.Entities;
 
 namespace DiscordEventService.Services.Pipeline;
 
-public sealed class FkResolver(
+internal sealed class FkResolver(
     GuildUpsertService guildUpsert,
     ChannelUpsertService channelUpsert,
     UserService userService)

--- a/src/DiscordEventService/Services/Pipeline/ResolvedFks.cs
+++ b/src/DiscordEventService/Services/Pipeline/ResolvedFks.cs
@@ -1,6 +1,6 @@
 namespace DiscordEventService.Services.Pipeline;
 
-public sealed record ResolvedFks(bool Success, Guid GuildId, Guid ChannelId, Guid UserId)
+internal sealed record ResolvedFks(bool Success, Guid GuildId, Guid ChannelId, Guid UserId)
 {
     public static ResolvedFks Resolved(Guid guildId, Guid channelId, Guid userId) =>
         new ResolvedFks(true, guildId, channelId, userId);
@@ -8,7 +8,7 @@ public sealed record ResolvedFks(bool Success, Guid GuildId, Guid ChannelId, Gui
     public static readonly ResolvedFks Failed = new ResolvedFks(false, default, default, default);
 }
 
-public sealed record ResolvedUserFks(bool Success, Guid GuildId, Guid UserId)
+internal sealed record ResolvedUserFks(bool Success, Guid GuildId, Guid UserId)
 {
     public static ResolvedUserFks Resolved(Guid guildId, Guid userId) => new ResolvedUserFks(true, guildId, userId);
 

--- a/src/DiscordEventService/Services/RawEventLogService.cs
+++ b/src/DiscordEventService/Services/RawEventLogService.cs
@@ -7,12 +7,12 @@ using Newtonsoft.Json.Serialization;
 namespace DiscordEventService.Services;
 
 // Error is non-null when serialization failed; Json is then a diagnostic stub, not the real payload.
-public sealed record EventSerializationResult(string Json, Exception? Error)
+internal sealed record EventSerializationResult(string Json, Exception? Error)
 {
     public bool Failed => Error is not null;
 }
 
-public class RawEventLogService(DiscordDbContext dbContext, ILogger<RawEventLogService> logger)
+internal sealed class RawEventLogService(DiscordDbContext dbContext, ILogger<RawEventLogService> logger)
 {
     // Marker in the error field of a serialization-failure stub — kept constant so detectors don't hard-code the literal.
     public const string SerializationFailedMarker = "Serialization failed";

--- a/src/DiscordEventService/Services/StartupValidator.cs
+++ b/src/DiscordEventService/Services/StartupValidator.cs
@@ -7,7 +7,7 @@ namespace DiscordEventService.Services;
 
 // Missing child-container registrations otherwise surface only at runtime when a handler
 // fires — sometimes hours after deploy, often only logged at Error inside a catch block.
-public static class StartupValidator
+internal static class StartupValidator
 {
     // Services event handlers resolve via scopeFactory.CreateScope().
     // Constructor-injected transitive dependencies are also validated by trying

--- a/src/DiscordEventService/Services/ThreadChannelBackfillService.cs
+++ b/src/DiscordEventService/Services/ThreadChannelBackfillService.cs
@@ -6,13 +6,13 @@ using Microsoft.EntityFrameworkCore;
 
 namespace DiscordEventService.Services;
 
-public class ThreadChannelBackfillService(
+internal sealed class ThreadChannelBackfillService(
     DiscordDbContext db,
     DiscordClient client,
     ChannelUpsertService channelUpsert,
     ILogger<ThreadChannelBackfillService> logger)
 {
-    public record Result(int ThreadsRepaired);
+    public sealed record Result(int ThreadsRepaired);
 
     public async Task<Result> BackfillAsync(CancellationToken ct)
     {

--- a/src/DiscordEventService/Services/UpsertResult.cs
+++ b/src/DiscordEventService/Services/UpsertResult.cs
@@ -1,7 +1,7 @@
 namespace DiscordEventService.Services;
 
 // Replaces the prior Guid.Empty-as-error sentinel so callers branch on IsSuccess, not a magic value.
-public sealed record UpsertResult<T>(bool IsSuccess, T? Value, string? FailureReason)
+internal sealed record UpsertResult<T>(bool IsSuccess, T? Value, string? FailureReason)
 {
     public static UpsertResult<T> Success(T value) => new(true, value, null);
 

--- a/src/DiscordEventService/Services/UserService.cs
+++ b/src/DiscordEventService/Services/UserService.cs
@@ -5,7 +5,7 @@ using Microsoft.EntityFrameworkCore;
 
 namespace DiscordEventService.Services;
 
-public class UserService(DiscordDbContext db, ILogger<UserService> logger)
+internal sealed class UserService(DiscordDbContext db, ILogger<UserService> logger)
 {
     public async Task<UpsertResult<Guid>> UpsertUserAsync(DiscordUser user)
     {


### PR DESCRIPTION
## Summary
- Applies the 118 `internal`/`sealed` findings from the dotnet-guidelines repo audit (Tier B1 of the deferred backlog; Tier A #232 and Tier C #233 already merged).
- Top-level types consumed only in-assembly drop from `public` to `internal`; non-abstract classes/records gain `sealed`. 82 files, declaration lines only — no logic changes.
- Includes reviewer follow-ups: three nested `Result` records sealed, `BackfillJobBase`/`IBackfillJob` to internal.

## Deliberate deviations (owner-approved exemptions)
- **Controllers stay `public sealed`** — default MVC discovery skips non-public controllers (exemption recorded 2026-06-12). Untouched here.
- **`Dtos/*` records and `SchemaCatalog` types stay public** — they appear in public controller ctor/action signatures, so `internal` would be CS0050/51. All already `sealed`.
- **`DiscordDbContext` stays public** (injected into public controllers) but is now `sealed`; `ITimestamped` and `UuidV7Extensions` went internal.
- **No persisted-enum values touched** (guard comments respected); diff scan confirms zero `= N` strips.

## Verification
- `dotnet build --no-incremental`: 0 warnings / 0 errors
- `dotnet test`: 151/151
- Live dev-bot run: gateway connect, MessageCreated / MessageUpdated / MessageReactionAdded all persisted through the now-internal handlers and pipeline; Hangfire boot backfill instantiated internal job classes (runtime reflection paths confirmed).
- `InternalsVisibleTo("DiscordEventService.Tests")` already present; test access intact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)