### PR TITLE
chore: dotnet-guidelines Tier D1 — decompose long methods (handlers + services)

### DIFF
--- a/src/DiscordEventService/Services/BootQuickSyncService.cs
+++ b/src/DiscordEventService/Services/BootQuickSyncService.cs
@@ -48,96 +48,7 @@ internal sealed class BootQuickSyncService(
         {
             try
             {
-                List<DiscordMessage> messages = [];
-                await foreach (var msg in channel.GetMessagesAsync(RecentMessagesPerChannel))
-                    messages.Add(msg);
-
-                if (messages.Count == 0) continue;
-
-                using var scope = scopeFactory.CreateScope();
-                var db = scope.ServiceProvider.GetRequiredService<DiscordDbContext>();
-                var userService = scope.ServiceProvider.GetRequiredService<UserService>();
-                var guildUpsert = scope.ServiceProvider.GetRequiredService<GuildUpsertService>();
-                var channelUpsert = scope.ServiceProvider.GetRequiredService<ChannelUpsertService>();
-
-                var guildId = (await guildUpsert.UpsertGuildAsync(guild)).Value;
-                var channelId = (await channelUpsert.UpsertChannelAsync(channel, guildId)).Value;
-
-                var existingDiscordIds = await db.Messages
-                    .Where(m => messages.Select(msg => msg.Id).Contains(m.DiscordId))
-                    .Select(m => m.DiscordId)
-                    .ToListAsync();
-                var existingSet = existingDiscordIds.ToHashSet();
-
-                var newMessages = messages.Where(m => !existingSet.Contains(m.Id) && m.Author is not null).ToList();
-                if (newMessages.Count == 0) continue;
-
-                var uniqueAuthors = newMessages.Select(m => m.Author!).DistinctBy(a => a.Id).ToList();
-                foreach (var author in uniqueAuthors)
-                    await userService.UpsertUserAsync(author);
-
-                var authorDiscordIds = newMessages.Select(m => m.Author!.Id).Distinct().ToList();
-                var authorLookup = await db.Users
-                    .Where(u => authorDiscordIds.Contains(u.DiscordId))
-                    .ToDictionaryAsync(u => u.DiscordId, u => u.Id);
-
-                foreach (var message in newMessages)
-                {
-                    if (!authorLookup.TryGetValue(message.Author!.Id, out var authorId))
-                        continue;
-
-                    var attachmentsJson = message.Attachments.Count > 0
-                        ? JsonSerializer.Serialize(message.Attachments.Select(a => new { a.Id, a.Url, a.FileName, a.FileSize }))
-                        : null;
-                    var embedsJson = message.Embeds.Count > 0
-                        ? JsonSerializer.Serialize(message.Embeds)
-                        : null;
-
-                    // Insert-or-ignore per message: the existingSet pre-check filters known rows;
-                    // this guards the race where a live MessageCreated inserts the same message
-                    // during boot. On conflict we skip the backfilled event (the live path logs
-                    // its own Created event) and don't count it.
-                    var (_, inserted) = await db.Messages.GetOrInsertAsync(
-                        m => m.DiscordId == message.Id,
-                        () => new MessageEntity
-                        {
-                            DiscordId = message.Id,
-                            ChannelId = channelId,
-                            GuildId = guildId,
-                            AuthorId = authorId,
-                            Content = string.IsNullOrEmpty(message.Content) ? null : message.Content,
-                            ReplyToDiscordId = message.ReferencedMessage?.Id,
-                            HasAttachments = message.Attachments.Count > 0,
-                            HasEmbeds = message.Embeds.Count > 0,
-                            AttachmentsJson = attachmentsJson,
-                            EmbedsJson = embedsJson,
-                            Flags = (int)(message.Flags ?? 0),
-                            CreatedAtUtc = message.Timestamp.UtcDateTime,
-                            EditedAtUtc = message.EditedTimestamp?.UtcDateTime
-                        });
-
-                    if (!inserted) continue;
-
-                    db.MessageEvents.Add(new MessageEventEntity
-                    {
-                        MessageDiscordId = message.Id,
-                        ChannelDiscordId = channel.Id,
-                        AuthorDiscordId = message.Author.Id,
-                        GuildDiscordId = guild.Id,
-                        EventType = MessageEventType.Backfilled,
-                        Content = string.IsNullOrEmpty(message.Content) ? null : message.Content,
-                        HasAttachments = message.Attachments.Count > 0,
-                        HasEmbeds = message.Embeds.Count > 0,
-                        ReplyToMessageDiscordId = message.ReferencedMessage?.Id,
-                        AttachmentsJson = attachmentsJson,
-                        EmbedsJson = embedsJson,
-                        EventTimestampUtc = message.Timestamp.UtcDateTime,
-                        ReceivedAtUtc = DateTime.UtcNow
-                    });
-                    await db.SaveChangesAsync();
-
-                    totalInserted++;
-                }
+                totalInserted += await SyncChannelMessagesAsync(guild, channel);
             }
             catch (DSharpPlus.Exceptions.UnauthorizedException)
             {
@@ -154,6 +65,116 @@ internal sealed class BootQuickSyncService(
         }
 
         return totalInserted;
+    }
+
+    private async Task<int> SyncChannelMessagesAsync(DiscordGuild guild, DiscordChannel channel)
+    {
+        List<DiscordMessage> messages = [];
+        await foreach (var msg in channel.GetMessagesAsync(RecentMessagesPerChannel))
+            messages.Add(msg);
+
+        if (messages.Count == 0) return 0;
+
+        using var scope = scopeFactory.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<DiscordDbContext>();
+        var userService = scope.ServiceProvider.GetRequiredService<UserService>();
+        var guildUpsert = scope.ServiceProvider.GetRequiredService<GuildUpsertService>();
+        var channelUpsert = scope.ServiceProvider.GetRequiredService<ChannelUpsertService>();
+
+        var guildId = (await guildUpsert.UpsertGuildAsync(guild)).Value;
+        var channelId = (await channelUpsert.UpsertChannelAsync(channel, guildId)).Value;
+
+        var existingDiscordIds = await db.Messages
+            .Where(m => messages.Select(msg => msg.Id).Contains(m.DiscordId))
+            .Select(m => m.DiscordId)
+            .ToListAsync();
+        var existingSet = existingDiscordIds.ToHashSet();
+
+        var newMessages = messages.Where(m => !existingSet.Contains(m.Id) && m.Author is not null).ToList();
+        if (newMessages.Count == 0) return 0;
+
+        var uniqueAuthors = newMessages.Select(m => m.Author!).DistinctBy(a => a.Id).ToList();
+        foreach (var author in uniqueAuthors)
+            await userService.UpsertUserAsync(author);
+
+        var authorDiscordIds = newMessages.Select(m => m.Author!.Id).Distinct().ToList();
+        var authorLookup = await db.Users
+            .Where(u => authorDiscordIds.Contains(u.DiscordId))
+            .ToDictionaryAsync(u => u.DiscordId, u => u.Id);
+
+        var inserted = 0;
+        foreach (var message in newMessages)
+        {
+            if (!authorLookup.TryGetValue(message.Author!.Id, out var authorId))
+                continue;
+
+            if (await InsertBackfilledMessageAsync(db, guild, channel, message, guildId, channelId, authorId))
+                inserted++;
+        }
+
+        return inserted;
+    }
+
+    // Insert-or-ignore per message: the caller's existingSet pre-check filters known rows;
+    // this guards the race where a live MessageCreated inserts the same message during boot.
+    // On conflict we skip the backfilled event (the live path logs its own Created event)
+    // and don't count it.
+    private static async Task<bool> InsertBackfilledMessageAsync(
+        DiscordDbContext db,
+        DiscordGuild guild,
+        DiscordChannel channel,
+        DiscordMessage message,
+        Guid guildId,
+        Guid channelId,
+        Guid authorId)
+    {
+        var attachmentsJson = message.Attachments.Count > 0
+            ? JsonSerializer.Serialize(message.Attachments.Select(a => new { a.Id, a.Url, a.FileName, a.FileSize }))
+            : null;
+        var embedsJson = message.Embeds.Count > 0
+            ? JsonSerializer.Serialize(message.Embeds)
+            : null;
+
+        var (_, inserted) = await db.Messages.GetOrInsertAsync(
+            m => m.DiscordId == message.Id,
+            () => new MessageEntity
+            {
+                DiscordId = message.Id,
+                ChannelId = channelId,
+                GuildId = guildId,
+                AuthorId = authorId,
+                Content = string.IsNullOrEmpty(message.Content) ? null : message.Content,
+                ReplyToDiscordId = message.ReferencedMessage?.Id,
+                HasAttachments = message.Attachments.Count > 0,
+                HasEmbeds = message.Embeds.Count > 0,
+                AttachmentsJson = attachmentsJson,
+                EmbedsJson = embedsJson,
+                Flags = (int)(message.Flags ?? 0),
+                CreatedAtUtc = message.Timestamp.UtcDateTime,
+                EditedAtUtc = message.EditedTimestamp?.UtcDateTime
+            });
+
+        if (!inserted) return false;
+
+        db.MessageEvents.Add(new MessageEventEntity
+        {
+            MessageDiscordId = message.Id,
+            ChannelDiscordId = channel.Id,
+            AuthorDiscordId = message.Author!.Id,
+            GuildDiscordId = guild.Id,
+            EventType = MessageEventType.Backfilled,
+            Content = string.IsNullOrEmpty(message.Content) ? null : message.Content,
+            HasAttachments = message.Attachments.Count > 0,
+            HasEmbeds = message.Embeds.Count > 0,
+            ReplyToMessageDiscordId = message.ReferencedMessage?.Id,
+            AttachmentsJson = attachmentsJson,
+            EmbedsJson = embedsJson,
+            EventTimestampUtc = message.Timestamp.UtcDateTime,
+            ReceivedAtUtc = DateTime.UtcNow
+        });
+        await db.SaveChangesAsync();
+
+        return true;
     }
 
     private async Task<(int presenceSnapshots, int activitiesInserted)> SyncPresencesAsync(DiscordGuild guild)
@@ -181,59 +202,11 @@ internal sealed class BootQuickSyncService(
         {
             try
             {
-                var presence = member.Presence;
-                if (presence is null) continue;
+                var newActivities = await SnapshotMemberPresenceAsync(db, userService, guild, member, guildGuid.Value, now);
+                if (newActivities is null) continue;
 
-                var userResult = await userService.UpsertUserAsync(member);
-                if (!userResult.IsSuccess) continue;
-                var userGuid = userResult.Value;
-
-                var activitiesJson = SerializeActivities(presence.Activities);
-
-                db.PresenceEvents.Add(new PresenceEventEntity
-                {
-                    UserDiscordId = member.Id,
-                    GuildDiscordId = guild.Id,
-                    EventType = PresenceEventType.BootSnapshot,
-                    DesktopStatusBefore = (int)DiscordUserStatus.Offline,
-                    MobileStatusBefore = (int)DiscordUserStatus.Offline,
-                    WebStatusBefore = (int)DiscordUserStatus.Offline,
-                    DesktopStatusAfter = GetStatusValue(presence.ClientStatus?.Desktop),
-                    MobileStatusAfter = GetStatusValue(presence.ClientStatus?.Mobile),
-                    WebStatusAfter = GetStatusValue(presence.ClientStatus?.Web),
-                    ActivitiesAfterJson = activitiesJson,
-                    EventTimestampUtc = now,
-                    ReceivedAtUtc = now
-                });
                 presenceSnapshots++;
-
-                if (presence.Activities is { Count: > 0 })
-                {
-                    foreach (var activity in presence.Activities)
-                    {
-                        var hasActive = await db.Activities
-                            .AnyAsync(a => a.UserId == userGuid && a.IsActive
-                                && a.Name == activity.Name && a.ActivityType == (int)activity.ActivityType);
-
-                        if (!hasActive)
-                        {
-                            db.Activities.Add(new ActivityEntity
-                            {
-                                UserId = userGuid,
-                                GuildId = guildGuid.Value,
-                                ActivityType = (int)activity.ActivityType,
-                                Name = activity.Name,
-                                StreamUrl = activity.StreamUrl,
-                                IsActive = true,
-                                FirstSeenAtUtc = now,
-                                LastSeenAtUtc = now
-                            });
-                            activitiesInserted++;
-                        }
-                    }
-                }
-
-                await db.SaveChangesAsync();
+                activitiesInserted += newActivities.Value;
             }
             catch (Exception ex)
             {
@@ -242,6 +215,81 @@ internal sealed class BootQuickSyncService(
         }
 
         return (presenceSnapshots, activitiesInserted);
+    }
+
+    // Returns the number of newly-started activities, or null when the member has no
+    // presence (or their user row couldn't be upserted) and no snapshot was taken.
+    private static async Task<int?> SnapshotMemberPresenceAsync(
+        DiscordDbContext db,
+        UserService userService,
+        DiscordGuild guild,
+        DiscordMember member,
+        Guid guildGuid,
+        DateTime now)
+    {
+        var presence = member.Presence;
+        if (presence is null) return null;
+
+        var userResult = await userService.UpsertUserAsync(member);
+        if (!userResult.IsSuccess) return null;
+        var userGuid = userResult.Value;
+
+        db.PresenceEvents.Add(new PresenceEventEntity
+        {
+            UserDiscordId = member.Id,
+            GuildDiscordId = guild.Id,
+            EventType = PresenceEventType.BootSnapshot,
+            DesktopStatusBefore = (int)DiscordUserStatus.Offline,
+            MobileStatusBefore = (int)DiscordUserStatus.Offline,
+            WebStatusBefore = (int)DiscordUserStatus.Offline,
+            DesktopStatusAfter = GetStatusValue(presence.ClientStatus?.Desktop),
+            MobileStatusAfter = GetStatusValue(presence.ClientStatus?.Mobile),
+            WebStatusAfter = GetStatusValue(presence.ClientStatus?.Web),
+            ActivitiesAfterJson = SerializeActivities(presence.Activities),
+            EventTimestampUtc = now,
+            ReceivedAtUtc = now
+        });
+
+        var activitiesInserted = await StartMissingActivitiesAsync(db, presence.Activities, userGuid, guildGuid, now);
+
+        await db.SaveChangesAsync();
+        return activitiesInserted;
+    }
+
+    private static async Task<int> StartMissingActivitiesAsync(
+        DiscordDbContext db,
+        IReadOnlyList<DiscordActivity>? activities,
+        Guid userGuid,
+        Guid guildGuid,
+        DateTime now)
+    {
+        if (activities is not { Count: > 0 }) return 0;
+
+        var inserted = 0;
+        foreach (var activity in activities)
+        {
+            var hasActive = await db.Activities
+                .AnyAsync(a => a.UserId == userGuid && a.IsActive
+                    && a.Name == activity.Name && a.ActivityType == (int)activity.ActivityType);
+
+            if (!hasActive)
+            {
+                db.Activities.Add(new ActivityEntity
+                {
+                    UserId = userGuid,
+                    GuildId = guildGuid,
+                    ActivityType = (int)activity.ActivityType,
+                    Name = activity.Name,
+                    StreamUrl = activity.StreamUrl,
+                    IsActive = true,
+                    FirstSeenAtUtc = now,
+                    LastSeenAtUtc = now
+                });
+                inserted++;
+            }
+        }
+
+        return inserted;
     }
 
     private static int GetStatusValue(Optional<DiscordUserStatus>? status)

--- a/src/DiscordEventService/Services/EventHandlers/ChannelEventHandler.cs
+++ b/src/DiscordEventService/Services/EventHandlers/ChannelEventHandler.cs
@@ -34,50 +34,9 @@ internal sealed class ChannelEventHandler(EventPipeline pipeline) :
                     ctx.Db.ChangeTracker.Clear();
                     await using var tx = await ctx.Db.Database.BeginTransactionAsync();
 
-                    await ctx.Db.Channels.UpsertAsync(
-                        c => c.DiscordId == e.Channel.Id,
-                        s => s
-                            .SetProperty(c => c.Name, e.Channel.Name)
-                            .SetProperty(c => c.Type, (ChannelType)e.Channel.Type)
-                            .SetProperty(c => c.Topic, e.Channel.Topic)
-                            .SetProperty(c => c.Position, e.Channel.Position)
-                            .SetProperty(c => c.ParentDiscordId, e.Channel.ParentId)
-                            .SetProperty(c => c.Bitrate, e.Channel.Bitrate)
-                            .SetProperty(c => c.UserLimit, e.Channel.UserLimit)
-                            .SetProperty(c => c.RateLimitPerUser, e.Channel.PerUserRateLimit)
-                            .SetProperty(c => c.IsNsfw, e.Channel.IsNSFW)
-                            .SetProperty(c => c.IsDeleted, false)
-                            .SetProperty(c => c.DeletedAtUtc, (DateTime?)null),
-                        () => new ChannelEntity
-                        {
-                            DiscordId = e.Channel.Id,
-                            GuildId = guildGuid,
-                            Name = e.Channel.Name,
-                            Type = (ChannelType)e.Channel.Type,
-                            Topic = e.Channel.Topic,
-                            Position = e.Channel.Position,
-                            ParentDiscordId = e.Channel.ParentId,
-                            Bitrate = e.Channel.Bitrate,
-                            UserLimit = e.Channel.UserLimit,
-                            RateLimitPerUser = e.Channel.PerUserRateLimit,
-                            IsNsfw = e.Channel.IsNSFW,
-                            IsDeleted = false,
-                        },
-                        c => c.Id);
+                    await UpsertCreatedChannelAsync(ctx, e.Channel, guildGuid);
 
-                    ctx.Db.ChannelEvents.Add(new ChannelEventEntity
-                    {
-                        ChannelDiscordId = e.Channel.Id,
-                        GuildDiscordId = e.Guild.Id,
-                        ChannelType = (int)e.Channel.Type,
-                        EventType = ChannelEventType.Created,
-                        NameAfter = e.Channel.Name,
-                        TopicAfter = e.Channel.Topic,
-                        PositionAfter = e.Channel.Position,
-                        EventTimestampUtc = ctx.ReceivedAtUtc,
-                        ReceivedAtUtc = ctx.ReceivedAtUtc,
-                        RawEventJson = ctx.RawJson,
-                    });
+                    ctx.Db.ChannelEvents.Add(BuildChannelCreatedEvent(e, ctx));
                     await ctx.Db.SaveChangesAsync();
                     await tx.CommitAsync();
                 });
@@ -195,4 +154,53 @@ internal sealed class ChannelEventHandler(EventPipeline pipeline) :
         entity.IsDeleted = false;
         entity.DeletedAtUtc = null;
     }
+
+    private static async Task UpsertCreatedChannelAsync(EventContext ctx, DiscordChannel channel, Guid guildGuid)
+    {
+        await ctx.Db.Channels.UpsertAsync(
+            c => c.DiscordId == channel.Id,
+            s => s
+                .SetProperty(c => c.Name, channel.Name)
+                .SetProperty(c => c.Type, (ChannelType)channel.Type)
+                .SetProperty(c => c.Topic, channel.Topic)
+                .SetProperty(c => c.Position, channel.Position)
+                .SetProperty(c => c.ParentDiscordId, channel.ParentId)
+                .SetProperty(c => c.Bitrate, channel.Bitrate)
+                .SetProperty(c => c.UserLimit, channel.UserLimit)
+                .SetProperty(c => c.RateLimitPerUser, channel.PerUserRateLimit)
+                .SetProperty(c => c.IsNsfw, channel.IsNSFW)
+                .SetProperty(c => c.IsDeleted, false)
+                .SetProperty(c => c.DeletedAtUtc, (DateTime?)null),
+            () => new ChannelEntity
+            {
+                DiscordId = channel.Id,
+                GuildId = guildGuid,
+                Name = channel.Name,
+                Type = (ChannelType)channel.Type,
+                Topic = channel.Topic,
+                Position = channel.Position,
+                ParentDiscordId = channel.ParentId,
+                Bitrate = channel.Bitrate,
+                UserLimit = channel.UserLimit,
+                RateLimitPerUser = channel.PerUserRateLimit,
+                IsNsfw = channel.IsNSFW,
+                IsDeleted = false,
+            },
+            c => c.Id);
+    }
+
+    private static ChannelEventEntity BuildChannelCreatedEvent(ChannelCreatedEventArgs e, EventContext ctx) => new ChannelEventEntity
+    {
+        ChannelDiscordId = e.Channel.Id,
+        GuildDiscordId = e.Guild.Id,
+        ChannelType = (int)e.Channel.Type,
+        EventType = ChannelEventType.Created,
+        NameAfter = e.Channel.Name,
+        TopicAfter = e.Channel.Topic,
+        PositionAfter = e.Channel.Position,
+        EventTimestampUtc = ctx.ReceivedAtUtc,
+        ReceivedAtUtc = ctx.ReceivedAtUtc,
+        RawEventJson = ctx.RawJson,
+    };
+
 }

--- a/src/DiscordEventService/Services/EventHandlers/ChannelEventHandler.cs
+++ b/src/DiscordEventService/Services/EventHandlers/ChannelEventHandler.cs
@@ -202,5 +202,4 @@ internal sealed class ChannelEventHandler(EventPipeline pipeline) :
         ReceivedAtUtc = ctx.ReceivedAtUtc,
         RawEventJson = ctx.RawJson,
     };
-
 }

--- a/src/DiscordEventService/Services/EventHandlers/EmojiEventHandler.cs
+++ b/src/DiscordEventService/Services/EventHandlers/EmojiEventHandler.cs
@@ -95,19 +95,19 @@ internal sealed class EmojiEventHandler(EventPipeline pipeline) :
         List<ulong> addedIds,
         List<ulong> removedIds,
         List<ulong> updatedIds) => new EmojiEventEntity
-    {
-        GuildDiscordId = e.Guild.Id,
-        EmojisAddedJson = addedIds.Count > 0
+        {
+            GuildDiscordId = e.Guild.Id,
+            EmojisAddedJson = addedIds.Count > 0
             ? JsonSerializer.Serialize(addedIds.Select(id => new { Id = id, e.EmojisAfter[id].Name }))
             : null,
-        EmojisRemovedJson = removedIds.Count > 0
+            EmojisRemovedJson = removedIds.Count > 0
             ? JsonSerializer.Serialize(removedIds.Select(id => new { Id = id, e.EmojisBefore[id].Name }))
             : null,
-        EmojisUpdatedJson = updatedIds.Count > 0
+            EmojisUpdatedJson = updatedIds.Count > 0
             ? JsonSerializer.Serialize(updatedIds.Select(id => new { Id = id, NameBefore = e.EmojisBefore[id].Name, NameAfter = e.EmojisAfter[id].Name }))
             : null,
-        EventTimestampUtc = ctx.ReceivedAtUtc,
-        ReceivedAtUtc = ctx.ReceivedAtUtc,
-        RawEventJson = ctx.RawJson,
-    };
+            EventTimestampUtc = ctx.ReceivedAtUtc,
+            ReceivedAtUtc = ctx.ReceivedAtUtc,
+            RawEventJson = ctx.RawJson,
+        };
 }

--- a/src/DiscordEventService/Services/EventHandlers/EmojiEventHandler.cs
+++ b/src/DiscordEventService/Services/EventHandlers/EmojiEventHandler.cs
@@ -29,68 +29,85 @@ internal sealed class EmojiEventHandler(EventPipeline pipeline) :
                     .Where(id => e.EmojisBefore[id].Name != e.EmojisAfter[id].Name)
                     .ToList();
 
-                foreach (var emoji in e.EmojisAfter.Values)
-                {
-                    var existing = await ctx.Db.Emotes
-                        .Where(em => em.DiscordId == emoji.Id)
-                        .FirstOrDefaultAsync();
-                    if (existing is null)
-                    {
-                        ctx.Db.Emotes.Add(new EmoteEntity
-                        {
-                            DiscordId = emoji.Id,
-                            GuildId = guildGuid,
-                            Name = emoji.Name,
-                            IsAnimated = emoji.IsAnimated,
-                            IsAvailable = emoji.IsAvailable,
-                        });
-                    }
-                    else
-                    {
-                        existing.Name = emoji.Name;
-                        existing.IsAnimated = emoji.IsAnimated;
-                        existing.IsAvailable = emoji.IsAvailable;
-                        existing.IsDeleted = false;
-                        existing.DeletedAtUtc = null;
-                    }
-                }
+                await UpsertEmotesAsync(ctx, e, guildGuid);
+                await SoftDeleteStaleEmotesAsync(ctx, guildGuid, afterIds, removedIds);
 
-                // Soft-delete stale rows. EmojiEventHandler is now the single canonical writer of
-                // Emotes for GuildEmojisUpdated (GuildEventHandler no longer touches the table), so
-                // reconcile the full stored set: any of this guild's active emotes absent from
-                // EmojisAfter is stale. This is broader than the before/after diff — it also reaps
-                // rows the event's "before" snapshot omitted — and preserves the first deletion time.
-                // When the guild FK didn't resolve, fall back to the before/after diff (by DiscordId)
-                // so a transient guild-upsert miss still records the removals it can see.
-                var staleQuery = ctx.Db.Emotes.Where(em => !em.IsDeleted);
-                staleQuery = guildGuid is { } gid
-                    ? staleQuery.Where(em => em.GuildId == gid && !afterIds.Contains(em.DiscordId))
-                    : staleQuery.Where(em => removedIds.Contains(em.DiscordId));
-
-                foreach (var stale in await staleQuery.ToListAsync())
-                {
-                    stale.IsDeleted = true;
-                    stale.DeletedAtUtc ??= ctx.ReceivedAtUtc;
-                }
-
-                ctx.Db.EmojiEvents.Add(new EmojiEventEntity
-                {
-                    GuildDiscordId = e.Guild.Id,
-                    EmojisAddedJson = addedIds.Count > 0
-                        ? JsonSerializer.Serialize(addedIds.Select(id => new { Id = id, e.EmojisAfter[id].Name }))
-                        : null,
-                    EmojisRemovedJson = removedIds.Count > 0
-                        ? JsonSerializer.Serialize(removedIds.Select(id => new { Id = id, e.EmojisBefore[id].Name }))
-                        : null,
-                    EmojisUpdatedJson = updatedIds.Count > 0
-                        ? JsonSerializer.Serialize(updatedIds.Select(id => new { Id = id, NameBefore = e.EmojisBefore[id].Name, NameAfter = e.EmojisAfter[id].Name }))
-                        : null,
-                    EventTimestampUtc = ctx.ReceivedAtUtc,
-                    ReceivedAtUtc = ctx.ReceivedAtUtc,
-                    RawEventJson = ctx.RawJson,
-                });
+                ctx.Db.EmojiEvents.Add(BuildEmojiEvent(e, ctx, addedIds, removedIds, updatedIds));
 
                 await ctx.Db.SaveChangesAsync();
             });
     }
+
+    private static async Task UpsertEmotesAsync(EventContext ctx, GuildEmojisUpdatedEventArgs e, Guid? guildGuid)
+    {
+        foreach (var emoji in e.EmojisAfter.Values)
+        {
+            var existing = await ctx.Db.Emotes
+                .Where(em => em.DiscordId == emoji.Id)
+                .FirstOrDefaultAsync();
+            if (existing is null)
+            {
+                ctx.Db.Emotes.Add(new EmoteEntity
+                {
+                    DiscordId = emoji.Id,
+                    GuildId = guildGuid,
+                    Name = emoji.Name,
+                    IsAnimated = emoji.IsAnimated,
+                    IsAvailable = emoji.IsAvailable,
+                });
+            }
+            else
+            {
+                existing.Name = emoji.Name;
+                existing.IsAnimated = emoji.IsAnimated;
+                existing.IsAvailable = emoji.IsAvailable;
+                existing.IsDeleted = false;
+                existing.DeletedAtUtc = null;
+            }
+        }
+    }
+
+    // Soft-delete stale rows. EmojiEventHandler is now the single canonical writer of
+    // Emotes for GuildEmojisUpdated (GuildEventHandler no longer touches the table), so
+    // reconcile the full stored set: any of this guild's active emotes absent from
+    // EmojisAfter is stale. This is broader than the before/after diff — it also reaps
+    // rows the event's "before" snapshot omitted — and preserves the first deletion time.
+    // When the guild FK didn't resolve, fall back to the before/after diff (by DiscordId)
+    // so a transient guild-upsert miss still records the removals it can see.
+    private static async Task SoftDeleteStaleEmotesAsync(
+        EventContext ctx, Guid? guildGuid, HashSet<ulong> afterIds, List<ulong> removedIds)
+    {
+        var staleQuery = ctx.Db.Emotes.Where(em => !em.IsDeleted);
+        staleQuery = guildGuid is { } gid
+            ? staleQuery.Where(em => em.GuildId == gid && !afterIds.Contains(em.DiscordId))
+            : staleQuery.Where(em => removedIds.Contains(em.DiscordId));
+
+        foreach (var stale in await staleQuery.ToListAsync())
+        {
+            stale.IsDeleted = true;
+            stale.DeletedAtUtc ??= ctx.ReceivedAtUtc;
+        }
+    }
+
+    private static EmojiEventEntity BuildEmojiEvent(
+        GuildEmojisUpdatedEventArgs e,
+        EventContext ctx,
+        List<ulong> addedIds,
+        List<ulong> removedIds,
+        List<ulong> updatedIds) => new EmojiEventEntity
+    {
+        GuildDiscordId = e.Guild.Id,
+        EmojisAddedJson = addedIds.Count > 0
+            ? JsonSerializer.Serialize(addedIds.Select(id => new { Id = id, e.EmojisAfter[id].Name }))
+            : null,
+        EmojisRemovedJson = removedIds.Count > 0
+            ? JsonSerializer.Serialize(removedIds.Select(id => new { Id = id, e.EmojisBefore[id].Name }))
+            : null,
+        EmojisUpdatedJson = updatedIds.Count > 0
+            ? JsonSerializer.Serialize(updatedIds.Select(id => new { Id = id, NameBefore = e.EmojisBefore[id].Name, NameAfter = e.EmojisAfter[id].Name }))
+            : null,
+        EventTimestampUtc = ctx.ReceivedAtUtc,
+        ReceivedAtUtc = ctx.ReceivedAtUtc,
+        RawEventJson = ctx.RawJson,
+    };
 }

--- a/src/DiscordEventService/Services/EventHandlers/GuildEventHandler.cs
+++ b/src/DiscordEventService/Services/EventHandlers/GuildEventHandler.cs
@@ -99,6 +99,12 @@ internal sealed class GuildEventHandler(EventPipeline pipeline) :
 
     private static async Task UpsertChannelsAndRolesAsync(DiscordDbContext db, ILogger logger, DiscordGuild guild, Guid guildGuid)
     {
+        await UpsertGuildChannelsAsync(db, logger, guild, guildGuid);
+        await UpsertGuildRolesAsync(db, guild, guildGuid);
+    }
+
+    private static async Task UpsertGuildChannelsAsync(DiscordDbContext db, ILogger logger, DiscordGuild guild, Guid guildGuid)
+    {
         // Per-entity upsert: each channel/role goes through the shared primitive, which absorbs
         // the 23505 race a concurrent GuildCreate could otherwise cause in a batched insert.
         foreach (var channel in guild.Channels.Values)
@@ -135,7 +141,10 @@ internal sealed class GuildEventHandler(EventPipeline pipeline) :
                 },
                 c => c.Id);
         }
+    }
 
+    private static async Task UpsertGuildRolesAsync(DiscordDbContext db, DiscordGuild guild, Guid guildGuid)
+    {
         foreach (var role in guild.Roles.Values)
         {
             var permissions = long.TryParse(role.Permissions.ToString(), out var p) ? p : 0;

--- a/src/DiscordEventService/Services/EventHandlers/GuildEventHandler.cs
+++ b/src/DiscordEventService/Services/EventHandlers/GuildEventHandler.cs
@@ -97,6 +97,8 @@ internal sealed class GuildEventHandler(EventPipeline pipeline) :
             });
     }
 
+    // Per-entity upsert: each channel/role goes through the shared primitive, which absorbs
+    // the 23505 race a concurrent GuildCreate could otherwise cause in a batched insert.
     private static async Task UpsertChannelsAndRolesAsync(DiscordDbContext db, ILogger logger, DiscordGuild guild, Guid guildGuid)
     {
         await UpsertGuildChannelsAsync(db, logger, guild, guildGuid);
@@ -105,8 +107,6 @@ internal sealed class GuildEventHandler(EventPipeline pipeline) :
 
     private static async Task UpsertGuildChannelsAsync(DiscordDbContext db, ILogger logger, DiscordGuild guild, Guid guildGuid)
     {
-        // Per-entity upsert: each channel/role goes through the shared primitive, which absorbs
-        // the 23505 race a concurrent GuildCreate could otherwise cause in a batched insert.
         foreach (var channel in guild.Channels.Values)
         {
             var mappedType = MapChannelType(channel.Type, logger);

--- a/src/DiscordEventService/Services/EventHandlers/MemberEventHandler.cs
+++ b/src/DiscordEventService/Services/EventHandlers/MemberEventHandler.cs
@@ -113,7 +113,8 @@ internal sealed class MemberEventHandler(EventPipeline pipeline) :
                         await using var tx = await ctx.Db.Database.BeginTransactionAsync();
 
                         var memberEvent = BuildMemberUpdatedEvent(
-                            e, ctx, rolesAdded, rolesRemoved, premiumBefore, mutedBefore, deafenedBefore);
+                            e, ctx, rolesAdded, rolesRemoved,
+                            premiumBefore, premiumAfter, mutedBefore, mutedAfter, deafenedBefore, deafenedAfter);
 
                         ctx.Db.MemberEvents.Add(memberEvent);
                         await ctx.Db.SaveChangesAsync();
@@ -228,8 +229,11 @@ internal sealed class MemberEventHandler(EventPipeline pipeline) :
         List<ulong> rolesAdded,
         List<ulong> rolesRemoved,
         DateTimeOffset? premiumBefore,
+        DateTimeOffset? premiumAfter,
         bool? mutedBefore,
-        bool? deafenedBefore) => new MemberEventEntity
+        bool mutedAfter,
+        bool? deafenedBefore,
+        bool deafenedAfter) => new MemberEventEntity
     {
         UserDiscordId = e.Member.Id,
         GuildDiscordId = e.Guild.Id,
@@ -244,18 +248,17 @@ internal sealed class MemberEventHandler(EventPipeline pipeline) :
             : null,
         TimeoutUntilUtc = e.CommunicationDisabledUntilAfter?.UtcDateTime,
         PremiumSinceBeforeUtc = premiumBefore?.UtcDateTime,
-        PremiumSinceAfterUtc = e.Member.PremiumSince?.UtcDateTime,
+        PremiumSinceAfterUtc = premiumAfter?.UtcDateTime,
         GuildAvatarHashBefore = e.GuildAvatarHashBefore,
         GuildAvatarHashAfter = e.GuildAvatarHashAfter,
         IsPendingBefore = e.PendingBefore,
         IsPendingAfter = e.PendingAfter,
         IsMutedBefore = mutedBefore,
-        IsMutedAfter = e.Member.IsMuted,
+        IsMutedAfter = mutedAfter,
         IsDeafenedBefore = deafenedBefore,
-        IsDeafenedAfter = e.Member.IsDeafened,
+        IsDeafenedAfter = deafenedAfter,
         EventTimestampUtc = ctx.ReceivedAtUtc,
         ReceivedAtUtc = ctx.ReceivedAtUtc,
         RawEventJson = ctx.RawJson,
     };
-
 }

--- a/src/DiscordEventService/Services/EventHandlers/MemberEventHandler.cs
+++ b/src/DiscordEventService/Services/EventHandlers/MemberEventHandler.cs
@@ -234,31 +234,31 @@ internal sealed class MemberEventHandler(EventPipeline pipeline) :
         bool mutedAfter,
         bool? deafenedBefore,
         bool deafenedAfter) => new MemberEventEntity
-    {
-        UserDiscordId = e.Member.Id,
-        GuildDiscordId = e.Guild.Id,
-        EventType = MemberEventType.Updated,
-        NicknameBefore = e.NicknameBefore,
-        NicknameAfter = e.NicknameAfter,
-        RolesAddedJson = rolesAdded.Any()
+        {
+            UserDiscordId = e.Member.Id,
+            GuildDiscordId = e.Guild.Id,
+            EventType = MemberEventType.Updated,
+            NicknameBefore = e.NicknameBefore,
+            NicknameAfter = e.NicknameAfter,
+            RolesAddedJson = rolesAdded.Any()
             ? JsonSerializer.Serialize(rolesAdded)
             : null,
-        RolesRemovedJson = rolesRemoved.Any()
+            RolesRemovedJson = rolesRemoved.Any()
             ? JsonSerializer.Serialize(rolesRemoved)
             : null,
-        TimeoutUntilUtc = e.CommunicationDisabledUntilAfter?.UtcDateTime,
-        PremiumSinceBeforeUtc = premiumBefore?.UtcDateTime,
-        PremiumSinceAfterUtc = premiumAfter?.UtcDateTime,
-        GuildAvatarHashBefore = e.GuildAvatarHashBefore,
-        GuildAvatarHashAfter = e.GuildAvatarHashAfter,
-        IsPendingBefore = e.PendingBefore,
-        IsPendingAfter = e.PendingAfter,
-        IsMutedBefore = mutedBefore,
-        IsMutedAfter = mutedAfter,
-        IsDeafenedBefore = deafenedBefore,
-        IsDeafenedAfter = deafenedAfter,
-        EventTimestampUtc = ctx.ReceivedAtUtc,
-        ReceivedAtUtc = ctx.ReceivedAtUtc,
-        RawEventJson = ctx.RawJson,
-    };
+            TimeoutUntilUtc = e.CommunicationDisabledUntilAfter?.UtcDateTime,
+            PremiumSinceBeforeUtc = premiumBefore?.UtcDateTime,
+            PremiumSinceAfterUtc = premiumAfter?.UtcDateTime,
+            GuildAvatarHashBefore = e.GuildAvatarHashBefore,
+            GuildAvatarHashAfter = e.GuildAvatarHashAfter,
+            IsPendingBefore = e.PendingBefore,
+            IsPendingAfter = e.PendingAfter,
+            IsMutedBefore = mutedBefore,
+            IsMutedAfter = mutedAfter,
+            IsDeafenedBefore = deafenedBefore,
+            IsDeafenedAfter = deafenedAfter,
+            EventTimestampUtc = ctx.ReceivedAtUtc,
+            ReceivedAtUtc = ctx.ReceivedAtUtc,
+            RawEventJson = ctx.RawJson,
+        };
 }

--- a/src/DiscordEventService/Services/EventHandlers/MemberEventHandler.cs
+++ b/src/DiscordEventService/Services/EventHandlers/MemberEventHandler.cs
@@ -112,34 +112,8 @@ internal sealed class MemberEventHandler(EventPipeline pipeline) :
                         ctx.Db.ChangeTracker.Clear();
                         await using var tx = await ctx.Db.Database.BeginTransactionAsync();
 
-                        var memberEvent = new MemberEventEntity
-                        {
-                            UserDiscordId = e.Member.Id,
-                            GuildDiscordId = e.Guild.Id,
-                            EventType = MemberEventType.Updated,
-                            NicknameBefore = e.NicknameBefore,
-                            NicknameAfter = e.NicknameAfter,
-                            RolesAddedJson = rolesAdded.Any()
-                                ? JsonSerializer.Serialize(rolesAdded)
-                                : null,
-                            RolesRemovedJson = rolesRemoved.Any()
-                                ? JsonSerializer.Serialize(rolesRemoved)
-                                : null,
-                            TimeoutUntilUtc = e.CommunicationDisabledUntilAfter?.UtcDateTime,
-                            PremiumSinceBeforeUtc = premiumBefore?.UtcDateTime,
-                            PremiumSinceAfterUtc = premiumAfter?.UtcDateTime,
-                            GuildAvatarHashBefore = e.GuildAvatarHashBefore,
-                            GuildAvatarHashAfter = e.GuildAvatarHashAfter,
-                            IsPendingBefore = e.PendingBefore,
-                            IsPendingAfter = e.PendingAfter,
-                            IsMutedBefore = mutedBefore,
-                            IsMutedAfter = mutedAfter,
-                            IsDeafenedBefore = deafenedBefore,
-                            IsDeafenedAfter = deafenedAfter,
-                            EventTimestampUtc = ctx.ReceivedAtUtc,
-                            ReceivedAtUtc = ctx.ReceivedAtUtc,
-                            RawEventJson = ctx.RawJson,
-                        };
+                        var memberEvent = BuildMemberUpdatedEvent(
+                            e, ctx, rolesAdded, rolesRemoved, premiumBefore, mutedBefore, deafenedBefore);
 
                         ctx.Db.MemberEvents.Add(memberEvent);
                         await ctx.Db.SaveChangesAsync();
@@ -247,4 +221,41 @@ internal sealed class MemberEventHandler(EventPipeline pipeline) :
             }
         }
     }
+
+    private static MemberEventEntity BuildMemberUpdatedEvent(
+        GuildMemberUpdatedEventArgs e,
+        EventContext ctx,
+        List<ulong> rolesAdded,
+        List<ulong> rolesRemoved,
+        DateTimeOffset? premiumBefore,
+        bool? mutedBefore,
+        bool? deafenedBefore) => new MemberEventEntity
+    {
+        UserDiscordId = e.Member.Id,
+        GuildDiscordId = e.Guild.Id,
+        EventType = MemberEventType.Updated,
+        NicknameBefore = e.NicknameBefore,
+        NicknameAfter = e.NicknameAfter,
+        RolesAddedJson = rolesAdded.Any()
+            ? JsonSerializer.Serialize(rolesAdded)
+            : null,
+        RolesRemovedJson = rolesRemoved.Any()
+            ? JsonSerializer.Serialize(rolesRemoved)
+            : null,
+        TimeoutUntilUtc = e.CommunicationDisabledUntilAfter?.UtcDateTime,
+        PremiumSinceBeforeUtc = premiumBefore?.UtcDateTime,
+        PremiumSinceAfterUtc = e.Member.PremiumSince?.UtcDateTime,
+        GuildAvatarHashBefore = e.GuildAvatarHashBefore,
+        GuildAvatarHashAfter = e.GuildAvatarHashAfter,
+        IsPendingBefore = e.PendingBefore,
+        IsPendingAfter = e.PendingAfter,
+        IsMutedBefore = mutedBefore,
+        IsMutedAfter = e.Member.IsMuted,
+        IsDeafenedBefore = deafenedBefore,
+        IsDeafenedAfter = e.Member.IsDeafened,
+        EventTimestampUtc = ctx.ReceivedAtUtc,
+        ReceivedAtUtc = ctx.ReceivedAtUtc,
+        RawEventJson = ctx.RawJson,
+    };
+
 }

--- a/src/DiscordEventService/Services/EventHandlers/MessageEventHandler.cs
+++ b/src/DiscordEventService/Services/EventHandlers/MessageEventHandler.cs
@@ -334,60 +334,60 @@ internal sealed class MessageEventHandler(EventPipeline pipeline) :
     private static MessageEntity BuildMessage(
         MessageCreatedEventArgs e, Guid guildId, Guid channelId, Guid authorId,
         string? attachmentsJson, string? embedsJson) => new MessageEntity
-    {
-        DiscordId = e.Message.Id,
-        ChannelId = channelId,
-        GuildId = guildId,
-        AuthorId = authorId,
-        Content = NormalizeContent(e.Message.Content),
-        ReplyToDiscordId = e.Message.ReferencedMessage?.Id,
-        HasAttachments = e.Message.Attachments.Count > 0,
-        HasEmbeds = e.Message.Embeds.Count > 0,
-        AttachmentsJson = attachmentsJson,
-        EmbedsJson = embedsJson,
-        Flags = (int)(e.Message.Flags ?? 0),
-        CreatedAtUtc = e.Message.Timestamp.UtcDateTime,
-    };
+        {
+            DiscordId = e.Message.Id,
+            ChannelId = channelId,
+            GuildId = guildId,
+            AuthorId = authorId,
+            Content = NormalizeContent(e.Message.Content),
+            ReplyToDiscordId = e.Message.ReferencedMessage?.Id,
+            HasAttachments = e.Message.Attachments.Count > 0,
+            HasEmbeds = e.Message.Embeds.Count > 0,
+            AttachmentsJson = attachmentsJson,
+            EmbedsJson = embedsJson,
+            Flags = (int)(e.Message.Flags ?? 0),
+            CreatedAtUtc = e.Message.Timestamp.UtcDateTime,
+        };
 
     private static MessageEventEntity BuildMessageCreatedEvent(
         MessageCreatedEventArgs e, EventContext ctx, string? attachmentsJson, string? embedsJson) => new MessageEventEntity
-    {
-        MessageDiscordId = e.Message.Id,
-        ChannelDiscordId = e.Channel.Id,
-        AuthorDiscordId = e.Author.Id,
-        GuildDiscordId = e.Guild.Id,
-        EventType = MessageEventType.Created,
-        Content = NormalizeContent(e.Message.Content),
-        HasAttachments = e.Message.Attachments.Count > 0,
-        HasEmbeds = e.Message.Embeds.Count > 0,
-        ReplyToMessageDiscordId = e.Message.ReferencedMessage?.Id,
-        AttachmentsJson = attachmentsJson,
-        EmbedsJson = embedsJson,
-        EventTimestampUtc = e.Message.Timestamp.UtcDateTime,
-        ReceivedAtUtc = ctx.ReceivedAtUtc,
-        RawEventJson = ctx.RawJson,
-    };
+        {
+            MessageDiscordId = e.Message.Id,
+            ChannelDiscordId = e.Channel.Id,
+            AuthorDiscordId = e.Author.Id,
+            GuildDiscordId = e.Guild.Id,
+            EventType = MessageEventType.Created,
+            Content = NormalizeContent(e.Message.Content),
+            HasAttachments = e.Message.Attachments.Count > 0,
+            HasEmbeds = e.Message.Embeds.Count > 0,
+            ReplyToMessageDiscordId = e.Message.ReferencedMessage?.Id,
+            AttachmentsJson = attachmentsJson,
+            EmbedsJson = embedsJson,
+            EventTimestampUtc = e.Message.Timestamp.UtcDateTime,
+            ReceivedAtUtc = ctx.ReceivedAtUtc,
+            RawEventJson = ctx.RawJson,
+        };
 
     private static MessageEventEntity BuildMessageUpdatedEvent(
         MessageUpdatedEventArgs e, EventContext ctx, string? normalizedContent, string? contentBefore,
         string? attachmentsJson, string? embedsJson, DateTime editedAt) => new MessageEventEntity
-    {
-        MessageDiscordId = e.Message.Id,
-        ChannelDiscordId = e.Channel.Id,
-        AuthorDiscordId = e.Author?.Id,
-        GuildDiscordId = e.Guild.Id,
-        EventType = MessageEventType.Updated,
-        Content = normalizedContent,
-        ContentBefore = contentBefore,
-        HasAttachments = e.Message.Attachments.Count > 0,
-        HasEmbeds = e.Message.Embeds.Count > 0,
-        ReplyToMessageDiscordId = e.Message.ReferencedMessage?.Id,
-        AttachmentsJson = attachmentsJson,
-        EmbedsJson = embedsJson,
-        EventTimestampUtc = editedAt,
-        ReceivedAtUtc = ctx.ReceivedAtUtc,
-        RawEventJson = ctx.RawJson,
-    };
+        {
+            MessageDiscordId = e.Message.Id,
+            ChannelDiscordId = e.Channel.Id,
+            AuthorDiscordId = e.Author?.Id,
+            GuildDiscordId = e.Guild.Id,
+            EventType = MessageEventType.Updated,
+            Content = normalizedContent,
+            ContentBefore = contentBefore,
+            HasAttachments = e.Message.Attachments.Count > 0,
+            HasEmbeds = e.Message.Embeds.Count > 0,
+            ReplyToMessageDiscordId = e.Message.ReferencedMessage?.Id,
+            AttachmentsJson = attachmentsJson,
+            EmbedsJson = embedsJson,
+            EventTimestampUtc = editedAt,
+            ReceivedAtUtc = ctx.ReceivedAtUtc,
+            RawEventJson = ctx.RawJson,
+        };
 
     private static void AddEditHistoryIfChanged(
         EventContext ctx,

--- a/src/DiscordEventService/Services/EventHandlers/MessageEventHandler.cs
+++ b/src/DiscordEventService/Services/EventHandlers/MessageEventHandler.cs
@@ -428,5 +428,4 @@ internal sealed class MessageEventHandler(EventPipeline pipeline) :
             });
         }
     }
-
 }

--- a/src/DiscordEventService/Services/EventHandlers/MessageEventHandler.cs
+++ b/src/DiscordEventService/Services/EventHandlers/MessageEventHandler.cs
@@ -62,40 +62,10 @@ internal sealed class MessageEventHandler(EventPipeline pipeline) :
                     // change-tracker clear on a conflict can't drop a pending event Add.
                     var (messageEntity, _) = await ctx.Db.Messages.GetOrInsertAsync(
                         m => m.DiscordId == e.Message.Id,
-                        () => new MessageEntity
-                        {
-                            DiscordId = e.Message.Id,
-                            ChannelId = channelId,
-                            GuildId = guildId,
-                            AuthorId = authorId,
-                            Content = NormalizeContent(e.Message.Content),
-                            ReplyToDiscordId = e.Message.ReferencedMessage?.Id,
-                            HasAttachments = e.Message.Attachments.Count > 0,
-                            HasEmbeds = e.Message.Embeds.Count > 0,
-                            AttachmentsJson = attachmentsJson,
-                            EmbedsJson = embedsJson,
-                            Flags = (int)(e.Message.Flags ?? 0),
-                            CreatedAtUtc = e.Message.Timestamp.UtcDateTime,
-                        });
+                        () => BuildMessage(e, guildId, channelId, authorId, attachmentsJson, embedsJson));
 
                     var messageId = messageEntity!.Id;
-                    ctx.Db.MessageEvents.Add(new MessageEventEntity
-                    {
-                        MessageDiscordId = e.Message.Id,
-                        ChannelDiscordId = e.Channel.Id,
-                        AuthorDiscordId = e.Author.Id,
-                        GuildDiscordId = e.Guild.Id,
-                        EventType = MessageEventType.Created,
-                        Content = NormalizeContent(e.Message.Content),
-                        HasAttachments = e.Message.Attachments.Count > 0,
-                        HasEmbeds = e.Message.Embeds.Count > 0,
-                        ReplyToMessageDiscordId = e.Message.ReferencedMessage?.Id,
-                        AttachmentsJson = attachmentsJson,
-                        EmbedsJson = embedsJson,
-                        EventTimestampUtc = e.Message.Timestamp.UtcDateTime,
-                        ReceivedAtUtc = ctx.ReceivedAtUtc,
-                        RawEventJson = ctx.RawJson,
-                    });
+                    ctx.Db.MessageEvents.Add(BuildMessageCreatedEvent(e, ctx, attachmentsJson, embedsJson));
                     await ctx.Db.SaveChangesAsync();
 
                     await ExtractAndSaveMentionsAsync(ctx.Db, messageId, e.Message);
@@ -127,22 +97,7 @@ internal sealed class MessageEventHandler(EventPipeline pipeline) :
                 var message = await ctx.Db.Messages.FirstOrDefaultAsync(m => m.DiscordId == e.Message.Id);
                 var messageGuid = message?.Id;
 
-                var contentBefore = NormalizeContent(e.MessageBefore is { } beforeForContent
-                    ? beforeForContent.Content
-                    : message?.Content);
-                var attachmentsBeforeJson = e.MessageBefore is { } beforeForAttachments
-                    ? (beforeForAttachments.Attachments.Count > 0
-                        ? JsonSerializer.Serialize(beforeForAttachments.Attachments.Select(a => new { a.Id, a.Url, a.FileName, a.FileSize }))
-                        : null)
-                    : message?.AttachmentsJson;
-                var embedsBeforeJson = e.MessageBefore is { } beforeForEmbeds
-                    ? (beforeForEmbeds.Embeds.Count > 0
-                        ? JsonSerializer.Serialize(beforeForEmbeds.Embeds)
-                        : null)
-                    : message?.EmbedsJson;
-                var flagsBefore = e.MessageBefore is { } before
-                    ? (int)(before.Flags ?? 0)
-                    : message?.Flags;
+                var before = ResolveBeforeState(e, message);
 
                 // Wrap the ExecuteUpdate (auto-commits without a tx) and the event-log inserts
                 // in one transaction so a failure between them rolls back atomically.
@@ -164,52 +119,11 @@ internal sealed class MessageEventHandler(EventPipeline pipeline) :
                             .SetProperty(m => m.Flags, flagsAfter)
                             .SetProperty(m => m.EditedAtUtc, editedAt));
 
-                    ctx.Db.MessageEvents.Add(new MessageEventEntity
-                    {
-                        MessageDiscordId = e.Message.Id,
-                        ChannelDiscordId = e.Channel.Id,
-                        AuthorDiscordId = e.Author?.Id,
-                        GuildDiscordId = e.Guild.Id,
-                        EventType = MessageEventType.Updated,
-                        Content = normalizedContent,
-                        ContentBefore = contentBefore,
-                        HasAttachments = e.Message.Attachments.Count > 0,
-                        HasEmbeds = e.Message.Embeds.Count > 0,
-                        ReplyToMessageDiscordId = e.Message.ReferencedMessage?.Id,
-                        AttachmentsJson = attachmentsJson,
-                        EmbedsJson = embedsJson,
-                        EventTimestampUtc = editedAt,
-                        ReceivedAtUtc = ctx.ReceivedAtUtc,
-                        RawEventJson = ctx.RawJson,
-                    });
+                    ctx.Db.MessageEvents.Add(BuildMessageUpdatedEvent(
+                        e, ctx, normalizedContent, before.ContentBefore, attachmentsJson, embedsJson, editedAt));
 
-                    var contentChanged = contentBefore != normalizedContent;
-                    // jsonb columns get PG-normalized on storage; freshly-serialized strings
-                    // (from e.Message or e.MessageBefore) won't byte-match the DB-loaded value
-                    // even when the underlying data is identical. Structural compare.
-                    var attachmentsChanged = !JsonEquals(attachmentsBeforeJson, attachmentsJson);
-                    var embedsChanged = !JsonEquals(embedsBeforeJson, embedsJson);
-                    var flagsChanged = flagsBefore != flagsAfter;
-
-                    if (messageGuid is Guid mid &&
-                        (contentChanged || attachmentsChanged || embedsChanged || flagsChanged))
-                    {
-                        ctx.Db.MessageEditHistory.Add(new MessageEditHistoryEntity
-                        {
-                            MessageId = mid,
-                            MessageDiscordId = e.Message.Id,
-                            ContentBefore = contentBefore,
-                            ContentAfter = normalizedContent,
-                            AttachmentsBeforeJson = attachmentsBeforeJson,
-                            AttachmentsAfterJson = attachmentsJson,
-                            EmbedsBeforeJson = embedsBeforeJson,
-                            EmbedsAfterJson = embedsJson,
-                            FlagsBefore = flagsBefore,
-                            FlagsAfter = flagsAfter,
-                            EditedAtUtc = editedAt,
-                            RecordedAtUtc = ctx.ReceivedAtUtc,
-                        });
-                    }
+                    AddEditHistoryIfChanged(
+                        ctx, e, messageGuid, before, normalizedContent, attachmentsJson, embedsJson, flagsAfter, editedAt);
 
                     await ctx.Db.SaveChangesAsync();
 
@@ -316,6 +230,17 @@ internal sealed class MessageEventHandler(EventPipeline pipeline) :
             .Where(m => m.MessageId == messageId)
             .ExecuteDeleteAsync();
 
+        var mentions = CollectMentions(messageId, message);
+
+        if (mentions.Count > 0)
+        {
+            db.MessageMentions.AddRange(mentions);
+            await db.SaveChangesAsync();
+        }
+    }
+
+    private static List<MessageMentionEntity> CollectMentions(Guid messageId, DiscordMessage message)
+    {
         List<MessageMentionEntity> mentions = [];
 
         if (message.MentionedUsers is { Count: > 0 })
@@ -366,11 +291,7 @@ internal sealed class MessageEventHandler(EventPipeline pipeline) :
                 mentions.Add(new MessageMentionEntity { MessageId = messageId, MentionType = MessageMentionType.Here });
         }
 
-        if (mentions.Count > 0)
-        {
-            db.MessageMentions.AddRange(mentions);
-            await db.SaveChangesAsync();
-        }
+        return mentions;
     }
 
     private static string? NormalizeContent(string? content) =>
@@ -382,4 +303,130 @@ internal sealed class MessageEventHandler(EventPipeline pipeline) :
         if (string.IsNullOrEmpty(a) || string.IsNullOrEmpty(b)) return false;
         return JsonNode.DeepEquals(JsonNode.Parse(a), JsonNode.Parse(b));
     }
+
+    // Before-state for an edit: prefer the cached e.MessageBefore; fall back to the stored row
+    // when DSharpPlus didn't deliver it (uncached message edit).
+    private sealed record MessageBeforeState(
+        string? ContentBefore, string? AttachmentsBeforeJson, string? EmbedsBeforeJson, int? FlagsBefore);
+
+    private static MessageBeforeState ResolveBeforeState(MessageUpdatedEventArgs e, MessageEntity? message)
+    {
+        var contentBefore = NormalizeContent(e.MessageBefore is { } beforeForContent
+            ? beforeForContent.Content
+            : message?.Content);
+        var attachmentsBeforeJson = e.MessageBefore is { } beforeForAttachments
+            ? (beforeForAttachments.Attachments.Count > 0
+                ? JsonSerializer.Serialize(beforeForAttachments.Attachments.Select(a => new { a.Id, a.Url, a.FileName, a.FileSize }))
+                : null)
+            : message?.AttachmentsJson;
+        var embedsBeforeJson = e.MessageBefore is { } beforeForEmbeds
+            ? (beforeForEmbeds.Embeds.Count > 0
+                ? JsonSerializer.Serialize(beforeForEmbeds.Embeds)
+                : null)
+            : message?.EmbedsJson;
+        var flagsBefore = e.MessageBefore is { } before
+            ? (int)(before.Flags ?? 0)
+            : message?.Flags;
+
+        return new MessageBeforeState(contentBefore, attachmentsBeforeJson, embedsBeforeJson, flagsBefore);
+    }
+
+    private static MessageEntity BuildMessage(
+        MessageCreatedEventArgs e, Guid guildId, Guid channelId, Guid authorId,
+        string? attachmentsJson, string? embedsJson) => new MessageEntity
+    {
+        DiscordId = e.Message.Id,
+        ChannelId = channelId,
+        GuildId = guildId,
+        AuthorId = authorId,
+        Content = NormalizeContent(e.Message.Content),
+        ReplyToDiscordId = e.Message.ReferencedMessage?.Id,
+        HasAttachments = e.Message.Attachments.Count > 0,
+        HasEmbeds = e.Message.Embeds.Count > 0,
+        AttachmentsJson = attachmentsJson,
+        EmbedsJson = embedsJson,
+        Flags = (int)(e.Message.Flags ?? 0),
+        CreatedAtUtc = e.Message.Timestamp.UtcDateTime,
+    };
+
+    private static MessageEventEntity BuildMessageCreatedEvent(
+        MessageCreatedEventArgs e, EventContext ctx, string? attachmentsJson, string? embedsJson) => new MessageEventEntity
+    {
+        MessageDiscordId = e.Message.Id,
+        ChannelDiscordId = e.Channel.Id,
+        AuthorDiscordId = e.Author.Id,
+        GuildDiscordId = e.Guild.Id,
+        EventType = MessageEventType.Created,
+        Content = NormalizeContent(e.Message.Content),
+        HasAttachments = e.Message.Attachments.Count > 0,
+        HasEmbeds = e.Message.Embeds.Count > 0,
+        ReplyToMessageDiscordId = e.Message.ReferencedMessage?.Id,
+        AttachmentsJson = attachmentsJson,
+        EmbedsJson = embedsJson,
+        EventTimestampUtc = e.Message.Timestamp.UtcDateTime,
+        ReceivedAtUtc = ctx.ReceivedAtUtc,
+        RawEventJson = ctx.RawJson,
+    };
+
+    private static MessageEventEntity BuildMessageUpdatedEvent(
+        MessageUpdatedEventArgs e, EventContext ctx, string? normalizedContent, string? contentBefore,
+        string? attachmentsJson, string? embedsJson, DateTime editedAt) => new MessageEventEntity
+    {
+        MessageDiscordId = e.Message.Id,
+        ChannelDiscordId = e.Channel.Id,
+        AuthorDiscordId = e.Author?.Id,
+        GuildDiscordId = e.Guild.Id,
+        EventType = MessageEventType.Updated,
+        Content = normalizedContent,
+        ContentBefore = contentBefore,
+        HasAttachments = e.Message.Attachments.Count > 0,
+        HasEmbeds = e.Message.Embeds.Count > 0,
+        ReplyToMessageDiscordId = e.Message.ReferencedMessage?.Id,
+        AttachmentsJson = attachmentsJson,
+        EmbedsJson = embedsJson,
+        EventTimestampUtc = editedAt,
+        ReceivedAtUtc = ctx.ReceivedAtUtc,
+        RawEventJson = ctx.RawJson,
+    };
+
+    private static void AddEditHistoryIfChanged(
+        EventContext ctx,
+        MessageUpdatedEventArgs e,
+        Guid? messageGuid,
+        MessageBeforeState before,
+        string? normalizedContent,
+        string? attachmentsJson,
+        string? embedsJson,
+        int flagsAfter,
+        DateTime editedAt)
+    {
+        var contentChanged = before.ContentBefore != normalizedContent;
+        // jsonb columns get PG-normalized on storage; freshly-serialized strings
+        // (from e.Message or e.MessageBefore) won't byte-match the DB-loaded value
+        // even when the underlying data is identical. Structural compare.
+        var attachmentsChanged = !JsonEquals(before.AttachmentsBeforeJson, attachmentsJson);
+        var embedsChanged = !JsonEquals(before.EmbedsBeforeJson, embedsJson);
+        var flagsChanged = before.FlagsBefore != flagsAfter;
+
+        if (messageGuid is Guid mid &&
+            (contentChanged || attachmentsChanged || embedsChanged || flagsChanged))
+        {
+            ctx.Db.MessageEditHistory.Add(new MessageEditHistoryEntity
+            {
+                MessageId = mid,
+                MessageDiscordId = e.Message.Id,
+                ContentBefore = before.ContentBefore,
+                ContentAfter = normalizedContent,
+                AttachmentsBeforeJson = before.AttachmentsBeforeJson,
+                AttachmentsAfterJson = attachmentsJson,
+                EmbedsBeforeJson = before.EmbedsBeforeJson,
+                EmbedsAfterJson = embedsJson,
+                FlagsBefore = before.FlagsBefore,
+                FlagsAfter = flagsAfter,
+                EditedAtUtc = editedAt,
+                RecordedAtUtc = ctx.ReceivedAtUtc,
+            });
+        }
+    }
+
 }

--- a/src/DiscordEventService/Services/EventHandlers/PresenceEventHandler.cs
+++ b/src/DiscordEventService/Services/EventHandlers/PresenceEventHandler.cs
@@ -168,25 +168,25 @@ internal sealed class PresenceEventHandler(EventPipeline pipeline) :
 
     private static PresenceEventEntity BuildPresenceEvent(
         PresenceUpdatedEventArgs args, ulong guildId, EventContext ctx) => new PresenceEventEntity
-    {
-        UserDiscordId = args.User.Id,
-        GuildDiscordId = guildId,
+        {
+            UserDiscordId = args.User.Id,
+            GuildDiscordId = guildId,
 
-        DesktopStatusBefore = GetStatusValue(args.PresenceBefore?.ClientStatus?.Desktop),
-        MobileStatusBefore = GetStatusValue(args.PresenceBefore?.ClientStatus?.Mobile),
-        WebStatusBefore = GetStatusValue(args.PresenceBefore?.ClientStatus?.Web),
+            DesktopStatusBefore = GetStatusValue(args.PresenceBefore?.ClientStatus?.Desktop),
+            MobileStatusBefore = GetStatusValue(args.PresenceBefore?.ClientStatus?.Mobile),
+            WebStatusBefore = GetStatusValue(args.PresenceBefore?.ClientStatus?.Web),
 
-        DesktopStatusAfter = GetStatusValue(args.PresenceAfter?.ClientStatus?.Desktop),
-        MobileStatusAfter = GetStatusValue(args.PresenceAfter?.ClientStatus?.Mobile),
-        WebStatusAfter = GetStatusValue(args.PresenceAfter?.ClientStatus?.Web),
+            DesktopStatusAfter = GetStatusValue(args.PresenceAfter?.ClientStatus?.Desktop),
+            MobileStatusAfter = GetStatusValue(args.PresenceAfter?.ClientStatus?.Mobile),
+            WebStatusAfter = GetStatusValue(args.PresenceAfter?.ClientStatus?.Web),
 
-        ActivitiesBeforeJson = SerializeActivities(args.PresenceBefore?.Activities),
-        ActivitiesAfterJson = SerializeActivities(args.PresenceAfter?.Activities),
+            ActivitiesBeforeJson = SerializeActivities(args.PresenceBefore?.Activities),
+            ActivitiesAfterJson = SerializeActivities(args.PresenceAfter?.Activities),
 
-        EventTimestampUtc = ctx.ReceivedAtUtc,
-        ReceivedAtUtc = ctx.ReceivedAtUtc,
-        RawEventJson = ctx.RawJson
-    };
+            EventTimestampUtc = ctx.ReceivedAtUtc,
+            ReceivedAtUtc = ctx.ReceivedAtUtc,
+            RawEventJson = ctx.RawJson
+        };
 
     private static bool IsSameActivity(DiscordActivity a, DiscordActivity b) =>
         a.Name == b.Name && a.ActivityType == b.ActivityType;

--- a/src/DiscordEventService/Services/EventHandlers/PresenceEventHandler.cs
+++ b/src/DiscordEventService/Services/EventHandlers/PresenceEventHandler.cs
@@ -23,30 +23,7 @@ internal sealed class PresenceEventHandler(EventPipeline pipeline) :
     {
         var guildId = args.PresenceAfter?.Guild?.Id ?? args.PresenceBefore?.Guild?.Id ?? 0;
 
-        // Serialize a DTO rather than the raw event args — DSharpPlus internals don't serialize
-        // cleanly, and the full presence payload is noisy. The pipeline serializes whatever we
-        // pass as the event object, so this DTO becomes the raw_event_logs row.
-        var eventDto = new
-        {
-            UserId = args.User.Id,
-            GuildId = guildId,
-            Before = args.PresenceBefore is null ? null : new
-            {
-                Desktop = GetStatusValue(args.PresenceBefore.ClientStatus?.Desktop),
-                Mobile = GetStatusValue(args.PresenceBefore.ClientStatus?.Mobile),
-                Web = GetStatusValue(args.PresenceBefore.ClientStatus?.Web),
-                Activities = args.PresenceBefore.Activities?.Select(a => new { a.Name, Type = (int)a.ActivityType, a.StreamUrl })
-            },
-            After = args.PresenceAfter is null ? null : new
-            {
-                Desktop = GetStatusValue(args.PresenceAfter.ClientStatus?.Desktop),
-                Mobile = GetStatusValue(args.PresenceAfter.ClientStatus?.Mobile),
-                Web = GetStatusValue(args.PresenceAfter.ClientStatus?.Web),
-                Activities = args.PresenceAfter.Activities?.Select(a => new { a.Name, Type = (int)a.ActivityType, a.StreamUrl })
-            }
-        };
-
-        await pipeline.ExecuteAsync(eventDto, "PresenceUpdated", nameof(PresenceEventHandler),
+        await pipeline.ExecuteAsync(BuildRawEventDto(args, guildId), "PresenceUpdated", nameof(PresenceEventHandler),
             guildId, null, args.User.Id, async ctx =>
             {
                 // Presence row, the user upsert, and activity tracking are one logical event:
@@ -62,26 +39,7 @@ internal sealed class PresenceEventHandler(EventPipeline pipeline) :
                     ctx.Db.ChangeTracker.Clear();
                     await using var tx = await ctx.Db.Database.BeginTransactionAsync();
 
-                    ctx.Db.PresenceEvents.Add(new PresenceEventEntity
-                    {
-                        UserDiscordId = args.User.Id,
-                        GuildDiscordId = guildId,
-
-                        DesktopStatusBefore = GetStatusValue(args.PresenceBefore?.ClientStatus?.Desktop),
-                        MobileStatusBefore = GetStatusValue(args.PresenceBefore?.ClientStatus?.Mobile),
-                        WebStatusBefore = GetStatusValue(args.PresenceBefore?.ClientStatus?.Web),
-
-                        DesktopStatusAfter = GetStatusValue(args.PresenceAfter?.ClientStatus?.Desktop),
-                        MobileStatusAfter = GetStatusValue(args.PresenceAfter?.ClientStatus?.Mobile),
-                        WebStatusAfter = GetStatusValue(args.PresenceAfter?.ClientStatus?.Web),
-
-                        ActivitiesBeforeJson = SerializeActivities(args.PresenceBefore?.Activities),
-                        ActivitiesAfterJson = SerializeActivities(args.PresenceAfter?.Activities),
-
-                        EventTimestampUtc = ctx.ReceivedAtUtc,
-                        ReceivedAtUtc = ctx.ReceivedAtUtc,
-                        RawEventJson = ctx.RawJson
-                    });
+                    ctx.Db.PresenceEvents.Add(BuildPresenceEvent(args, guildId, ctx));
 
                     await ctx.Db.SaveChangesAsync();
 
@@ -120,10 +78,21 @@ internal sealed class PresenceEventHandler(EventPipeline pipeline) :
         var startedActivities = activitiesAfter?.Where(a =>
             !activitiesBefore?.Any(b => IsSameActivity(a, b)) ?? true) ?? [];
 
-        foreach (var ended in endedActivities)
+        var continuingActivities = (activitiesAfter ?? [])
+            .Where(current => activitiesBefore?.Any(b => IsSameActivity(current, b)) == true);
+
+        await EndActivitiesAsync(dbContext, userGuid, endedActivities, now);
+        await StartActivitiesAsync(dbContext, userGuid, startedActivities, now);
+        await TouchContinuingActivitiesAsync(dbContext, userGuid, continuingActivities, now);
+    }
+
+    private static async Task EndActivitiesAsync(
+        DiscordDbContext dbContext, Guid userGuid, IEnumerable<DiscordActivity> ended, DateTime now)
+    {
+        foreach (var activity in ended)
         {
             var existingActivity = await dbContext.Activities
-                .Where(a => a.UserId == userGuid && a.IsActive && a.Name == ended.Name && a.ActivityType == (int)ended.ActivityType)
+                .Where(a => a.UserId == userGuid && a.IsActive && a.Name == activity.Name && a.ActivityType == (int)activity.ActivityType)
                 .FirstOrDefaultAsync();
 
             if (existingActivity is not null)
@@ -133,33 +102,38 @@ internal sealed class PresenceEventHandler(EventPipeline pipeline) :
                 existingActivity.LastSeenAtUtc = now;
             }
         }
+    }
 
-        foreach (var started in startedActivities)
+    private static async Task StartActivitiesAsync(
+        DiscordDbContext dbContext, Guid userGuid, IEnumerable<DiscordActivity> started, DateTime now)
+    {
+        foreach (var startedActivity in started)
         {
             var activity = new ActivityEntity
             {
                 UserId = userGuid,
-                ActivityType = (int)started.ActivityType,
-                Name = started.Name,
-                StreamUrl = started.StreamUrl,
+                ActivityType = (int)startedActivity.ActivityType,
+                Name = startedActivity.Name,
+                StreamUrl = startedActivity.StreamUrl,
                 IsActive = true,
                 FirstSeenAtUtc = now,
                 LastSeenAtUtc = now
             };
 
             // For Spotify/Listening activities, try to get additional data
-            if (started is { ActivityType: DiscordActivityType.ListeningTo, Name: "Spotify" })
+            if (startedActivity is { ActivityType: DiscordActivityType.ListeningTo, Name: "Spotify" })
             {
-                activity.SpotifySongTitle = started.Name;
+                activity.SpotifySongTitle = startedActivity.Name;
             }
 
             await dbContext.Activities.AddAsync(activity);
         }
+    }
 
-        var continuingActivities = (activitiesAfter ?? [])
-            .Where(current => activitiesBefore?.Any(b => IsSameActivity(current, b)) == true);
-
-        foreach (var current in continuingActivities)
+    private static async Task TouchContinuingActivitiesAsync(
+        DiscordDbContext dbContext, Guid userGuid, IEnumerable<DiscordActivity> continuing, DateTime now)
+    {
+        foreach (var current in continuing)
         {
             var existingActivity = await dbContext.Activities
                 .Where(a => a.UserId == userGuid && a.IsActive && a.Name == current.Name && a.ActivityType == (int)current.ActivityType)
@@ -168,6 +142,51 @@ internal sealed class PresenceEventHandler(EventPipeline pipeline) :
             if (existingActivity is not null) existingActivity.LastSeenAtUtc = now;
         }
     }
+
+    // Serialize a DTO rather than the raw event args — DSharpPlus internals don't serialize
+    // cleanly, and the full presence payload is noisy. The pipeline serializes whatever we
+    // pass as the event object, so this DTO becomes the raw_event_logs row.
+    private static object BuildRawEventDto(PresenceUpdatedEventArgs args, ulong guildId) => new
+    {
+        UserId = args.User.Id,
+        GuildId = guildId,
+        Before = args.PresenceBefore is null ? null : new
+        {
+            Desktop = GetStatusValue(args.PresenceBefore.ClientStatus?.Desktop),
+            Mobile = GetStatusValue(args.PresenceBefore.ClientStatus?.Mobile),
+            Web = GetStatusValue(args.PresenceBefore.ClientStatus?.Web),
+            Activities = args.PresenceBefore.Activities?.Select(a => new { a.Name, Type = (int)a.ActivityType, a.StreamUrl })
+        },
+        After = args.PresenceAfter is null ? null : new
+        {
+            Desktop = GetStatusValue(args.PresenceAfter.ClientStatus?.Desktop),
+            Mobile = GetStatusValue(args.PresenceAfter.ClientStatus?.Mobile),
+            Web = GetStatusValue(args.PresenceAfter.ClientStatus?.Web),
+            Activities = args.PresenceAfter.Activities?.Select(a => new { a.Name, Type = (int)a.ActivityType, a.StreamUrl })
+        }
+    };
+
+    private static PresenceEventEntity BuildPresenceEvent(
+        PresenceUpdatedEventArgs args, ulong guildId, EventContext ctx) => new PresenceEventEntity
+    {
+        UserDiscordId = args.User.Id,
+        GuildDiscordId = guildId,
+
+        DesktopStatusBefore = GetStatusValue(args.PresenceBefore?.ClientStatus?.Desktop),
+        MobileStatusBefore = GetStatusValue(args.PresenceBefore?.ClientStatus?.Mobile),
+        WebStatusBefore = GetStatusValue(args.PresenceBefore?.ClientStatus?.Web),
+
+        DesktopStatusAfter = GetStatusValue(args.PresenceAfter?.ClientStatus?.Desktop),
+        MobileStatusAfter = GetStatusValue(args.PresenceAfter?.ClientStatus?.Mobile),
+        WebStatusAfter = GetStatusValue(args.PresenceAfter?.ClientStatus?.Web),
+
+        ActivitiesBeforeJson = SerializeActivities(args.PresenceBefore?.Activities),
+        ActivitiesAfterJson = SerializeActivities(args.PresenceAfter?.Activities),
+
+        EventTimestampUtc = ctx.ReceivedAtUtc,
+        ReceivedAtUtc = ctx.ReceivedAtUtc,
+        RawEventJson = ctx.RawJson
+    };
 
     private static bool IsSameActivity(DiscordActivity a, DiscordActivity b) =>
         a.Name == b.Name && a.ActivityType == b.ActivityType;

--- a/src/DiscordEventService/Services/EventHandlers/RoleEventHandler.cs
+++ b/src/DiscordEventService/Services/EventHandlers/RoleEventHandler.cs
@@ -35,44 +35,9 @@ internal sealed class RoleEventHandler(EventPipeline pipeline) :
                     ctx.Db.ChangeTracker.Clear();
                     await using var tx = await ctx.Db.Database.BeginTransactionAsync();
 
-                    await ctx.Db.Roles.UpsertAsync(
-                        r => r.DiscordId == e.Role.Id,
-                        s => s
-                            .SetProperty(r => r.Name, e.Role.Name)
-                            .SetProperty(r => r.Color, e.Role.Color.Value)
-                            .SetProperty(r => r.IsHoisted, e.Role.IsHoisted)
-                            .SetProperty(r => r.Position, e.Role.Position)
-                            .SetProperty(r => r.Permissions, permissions)
-                            .SetProperty(r => r.IsManaged, e.Role.IsManaged)
-                            .SetProperty(r => r.IsMentionable, e.Role.IsMentionable)
-                            .SetProperty(r => r.IsDeleted, false)
-                            .SetProperty(r => r.DeletedAtUtc, (DateTime?)null),
-                        () => new RoleEntity
-                        {
-                            DiscordId = e.Role.Id,
-                            GuildId = guildGuid,
-                            Name = e.Role.Name,
-                            Color = e.Role.Color.Value,
-                            IsHoisted = e.Role.IsHoisted,
-                            Position = e.Role.Position,
-                            Permissions = permissions,
-                            IsManaged = e.Role.IsManaged,
-                            IsMentionable = e.Role.IsMentionable,
-                            IsDeleted = false
-                        },
-                        r => r.Id);
+                    await UpsertCreatedRoleAsync(ctx, e.Role, guildGuid, permissions);
 
-                    ctx.Db.RoleEvents.Add(new RoleEventEntity
-                    {
-                        RoleDiscordId = e.Role.Id,
-                        GuildDiscordId = e.Guild.Id,
-                        EventType = RoleEventType.Created,
-                        NameAfter = e.Role.Name,
-                        ColorAfter = e.Role.Color.Value,
-                        EventTimestampUtc = ctx.ReceivedAtUtc,
-                        ReceivedAtUtc = ctx.ReceivedAtUtc,
-                        RawEventJson = ctx.RawJson,
-                    });
+                    ctx.Db.RoleEvents.Add(BuildRoleCreatedEvent(e, ctx));
                     await ctx.Db.SaveChangesAsync();
                     await tx.CommitAsync();
                 });
@@ -159,4 +124,47 @@ internal sealed class RoleEventHandler(EventPipeline pipeline) :
         entity.IsDeleted = false;
         entity.DeletedAtUtc = null;
     }
+
+    private static async Task UpsertCreatedRoleAsync(EventContext ctx, DiscordRole role, Guid guildGuid, long permissions)
+    {
+        await ctx.Db.Roles.UpsertAsync(
+            r => r.DiscordId == role.Id,
+            s => s
+                .SetProperty(r => r.Name, role.Name)
+                .SetProperty(r => r.Color, role.Color.Value)
+                .SetProperty(r => r.IsHoisted, role.IsHoisted)
+                .SetProperty(r => r.Position, role.Position)
+                .SetProperty(r => r.Permissions, permissions)
+                .SetProperty(r => r.IsManaged, role.IsManaged)
+                .SetProperty(r => r.IsMentionable, role.IsMentionable)
+                .SetProperty(r => r.IsDeleted, false)
+                .SetProperty(r => r.DeletedAtUtc, (DateTime?)null),
+            () => new RoleEntity
+            {
+                DiscordId = role.Id,
+                GuildId = guildGuid,
+                Name = role.Name,
+                Color = role.Color.Value,
+                IsHoisted = role.IsHoisted,
+                Position = role.Position,
+                Permissions = permissions,
+                IsManaged = role.IsManaged,
+                IsMentionable = role.IsMentionable,
+                IsDeleted = false
+            },
+            r => r.Id);
+    }
+
+    private static RoleEventEntity BuildRoleCreatedEvent(GuildRoleCreatedEventArgs e, EventContext ctx) => new RoleEventEntity
+    {
+        RoleDiscordId = e.Role.Id,
+        GuildDiscordId = e.Guild.Id,
+        EventType = RoleEventType.Created,
+        NameAfter = e.Role.Name,
+        ColorAfter = e.Role.Color.Value,
+        EventTimestampUtc = ctx.ReceivedAtUtc,
+        ReceivedAtUtc = ctx.ReceivedAtUtc,
+        RawEventJson = ctx.RawJson,
+    };
+
 }

--- a/src/DiscordEventService/Services/EventHandlers/RoleEventHandler.cs
+++ b/src/DiscordEventService/Services/EventHandlers/RoleEventHandler.cs
@@ -166,5 +166,4 @@ internal sealed class RoleEventHandler(EventPipeline pipeline) :
         ReceivedAtUtc = ctx.ReceivedAtUtc,
         RawEventJson = ctx.RawJson,
     };
-
 }

--- a/src/DiscordEventService/Services/EventHandlers/SocketLifecycleHandler.cs
+++ b/src/DiscordEventService/Services/EventHandlers/SocketLifecycleHandler.cs
@@ -72,33 +72,7 @@ internal sealed class SocketLifecycleHandler(
             // reconnect) hit SessionResumed instead and don't reach here.
             try
             {
-                // Ready can fire without a preceding Resumed (session invalidated).
-                await tracker.CloseOpenDowntimeAsync(DateTime.UtcNow, onlyType: BotDowntimeType.GatewayDisconnect);
-
-                // The just-closed downtime row's StartedAtUtc is the authoritative
-                // gap start. Reading heartbeats or raw_event_logs here would race
-                // the post-reconnect data — by now AllShardsConnected is true, the
-                // 5s heartbeat may already have written an IsGatewayConnected=true
-                // row, and DSharpPlus has started dispatching events. Both signals
-                // would show fresh timestamps that mask the real gap.
-                //
-                // The closed row covers every downtime classification:
-                // SocketClosed wrote a GatewayDisconnect (in-process session
-                // invalidation); StopAsync wrote a GracefulShutdown/Deploy
-                // (bot restart); InferStartupGapAsync wrote an Inferred
-                // (hard crash / power loss).
-                var mostRecentGapStart = await db.BotDowntimeIntervals
-                    .Where(x => x.EndedAtUtc != null)
-                    .OrderByDescending(x => x.EndedAtUtc)
-                    .Select(x => (DateTime?)x.StartedAtUtc)
-                    .FirstOrDefaultAsync();
-
-                // Fall back to the heartbeat-based heuristic only when no downtime
-                // row exists at all (very first run, no prior shutdown). The
-                // IsGatewayConnected==true filter inside GetLastAliveAtUtcAsync
-                // keeps this conservative even in the fallback case.
-                var lastAlive = mostRecentGapStart
-                    ?? (await tracker.GetLastAliveAtUtcAsync()).LastAliveUtc;
+                var lastAlive = await ResolveGapStartAsync();
                 if (lastAlive is null)
                 {
                     logger.LogInformation("GuildDownloadCompleted: no prior signal, skipping backfill (first run)");
@@ -117,43 +91,83 @@ internal sealed class SocketLifecycleHandler(
                     return;
                 }
 
-                var earliestAllowed = now - MaxReconnectBackfillWindow;
-                var afterTimestamp = lastAlive.Value - ReconnectBackfillBuffer;
-                if (afterTimestamp < earliestAllowed)
-                {
-                    logger.LogInformation(
-                        "Reconnect backfill window capped to {Window} (gap was {GapDuration:c}, capped from {Original:O} to {Capped:O})",
-                        MaxReconnectBackfillWindow, gap, afterTimestamp, earliestAllowed);
-                    afterTimestamp = earliestAllowed;
-                }
-
-                var inProgressGuilds = await db.BackfillCheckpoints
-                    .Where(c => c.Status == BackfillStatus.InProgress)
-                    .Select(c => c.GuildDiscordId)
-                    .Distinct()
-                    .ToListAsync();
-                var inProgressSet = inProgressGuilds.ToHashSet();
-
-                foreach (var guildId in e.Guilds.Keys)
-                {
-                    if (inProgressSet.Contains(guildId))
-                    {
-                        logger.LogInformation(
-                            "Reconnect backfill skipped for guild {GuildId}: backfill already in progress",
-                            guildId);
-                        continue;
-                    }
-
-                    logger.LogInformation(
-                        "Reconnect backfill enqueued for guild {GuildId} after gap {GapDuration:c}, backfilling from {AfterTimestampUtc:O}",
-                        guildId, gap, afterTimestamp);
-                    orchestrator.EnqueueBackfillFrom(guildId, afterTimestamp);
-                }
+                await EnqueueReconnectBackfillsAsync(e.Guilds.Keys, lastAlive.Value, now, gap);
             }
             catch (Exception ex)
             {
                 logger.LogError(ex, "Failed to enqueue reconnect backfill on GuildDownloadCompleted");
             }
+        }
+    }
+
+    private async Task<DateTime?> ResolveGapStartAsync()
+    {
+        // Ready can fire without a preceding Resumed (session invalidated).
+        await tracker.CloseOpenDowntimeAsync(DateTime.UtcNow, onlyType: BotDowntimeType.GatewayDisconnect);
+
+        // The just-closed downtime row's StartedAtUtc is the authoritative
+        // gap start. Reading heartbeats or raw_event_logs here would race
+        // the post-reconnect data — by now AllShardsConnected is true, the
+        // 5s heartbeat may already have written an IsGatewayConnected=true
+        // row, and DSharpPlus has started dispatching events. Both signals
+        // would show fresh timestamps that mask the real gap.
+        //
+        // The closed row covers every downtime classification:
+        // SocketClosed wrote a GatewayDisconnect (in-process session
+        // invalidation); StopAsync wrote a GracefulShutdown/Deploy
+        // (bot restart); InferStartupGapAsync wrote an Inferred
+        // (hard crash / power loss).
+        var mostRecentGapStart = await db.BotDowntimeIntervals
+            .Where(x => x.EndedAtUtc != null)
+            .OrderByDescending(x => x.EndedAtUtc)
+            .Select(x => (DateTime?)x.StartedAtUtc)
+            .FirstOrDefaultAsync();
+
+        // Fall back to the heartbeat-based heuristic only when no downtime
+        // row exists at all (very first run, no prior shutdown). The
+        // IsGatewayConnected==true filter inside GetLastAliveAtUtcAsync
+        // keeps this conservative even in the fallback case.
+        return mostRecentGapStart
+            ?? (await tracker.GetLastAliveAtUtcAsync()).LastAliveUtc;
+    }
+
+    private async Task EnqueueReconnectBackfillsAsync(
+        IEnumerable<ulong> guildIds,
+        DateTime lastAlive,
+        DateTime now,
+        TimeSpan gap)
+    {
+        var earliestAllowed = now - MaxReconnectBackfillWindow;
+        var afterTimestamp = lastAlive - ReconnectBackfillBuffer;
+        if (afterTimestamp < earliestAllowed)
+        {
+            logger.LogInformation(
+                "Reconnect backfill window capped to {Window} (gap was {GapDuration:c}, capped from {Original:O} to {Capped:O})",
+                MaxReconnectBackfillWindow, gap, afterTimestamp, earliestAllowed);
+            afterTimestamp = earliestAllowed;
+        }
+
+        var inProgressGuilds = await db.BackfillCheckpoints
+            .Where(c => c.Status == BackfillStatus.InProgress)
+            .Select(c => c.GuildDiscordId)
+            .Distinct()
+            .ToListAsync();
+        var inProgressSet = inProgressGuilds.ToHashSet();
+
+        foreach (var guildId in guildIds)
+        {
+            if (inProgressSet.Contains(guildId))
+            {
+                logger.LogInformation(
+                    "Reconnect backfill skipped for guild {GuildId}: backfill already in progress",
+                    guildId);
+                continue;
+            }
+
+            logger.LogInformation(
+                "Reconnect backfill enqueued for guild {GuildId} after gap {GapDuration:c}, backfilling from {AfterTimestampUtc:O}",
+                guildId, gap, afterTimestamp);
+            orchestrator.EnqueueBackfillFrom(guildId, afterTimestamp);
         }
     }
 }

--- a/src/DiscordEventService/Services/EventHandlers/StickerEventHandler.cs
+++ b/src/DiscordEventService/Services/EventHandlers/StickerEventHandler.cs
@@ -86,19 +86,19 @@ internal sealed class StickerEventHandler(EventPipeline pipeline) :
         List<ulong> addedIds,
         List<ulong> removedIds,
         List<ulong> updatedIds) => new StickerEventEntity
-    {
-        GuildDiscordId = e.Guild.Id,
-        StickersAddedJson = addedIds.Count > 0
+        {
+            GuildDiscordId = e.Guild.Id,
+            StickersAddedJson = addedIds.Count > 0
             ? JsonSerializer.Serialize(addedIds.Select(id => new { Id = id, e.StickersAfter[id].Name }))
             : null,
-        StickersRemovedJson = removedIds.Count > 0
+            StickersRemovedJson = removedIds.Count > 0
             ? JsonSerializer.Serialize(removedIds.Select(id => new { Id = id, e.StickersBefore[id].Name }))
             : null,
-        StickersUpdatedJson = updatedIds.Count > 0
+            StickersUpdatedJson = updatedIds.Count > 0
             ? JsonSerializer.Serialize(updatedIds.Select(id => new { Id = id, NameBefore = e.StickersBefore[id].Name, NameAfter = e.StickersAfter[id].Name }))
             : null,
-        EventTimestampUtc = ctx.ReceivedAtUtc,
-        ReceivedAtUtc = ctx.ReceivedAtUtc,
-        RawEventJson = ctx.RawJson
-    };
+            EventTimestampUtc = ctx.ReceivedAtUtc,
+            ReceivedAtUtc = ctx.ReceivedAtUtc,
+            RawEventJson = ctx.RawJson
+        };
 }

--- a/src/DiscordEventService/Services/EventHandlers/StickerEventHandler.cs
+++ b/src/DiscordEventService/Services/EventHandlers/StickerEventHandler.cs
@@ -30,59 +30,75 @@ internal sealed class StickerEventHandler(EventPipeline pipeline) :
                                  e.StickersBefore[id].Description != e.StickersAfter[id].Description)
                     .ToList();
 
-                foreach (var sticker in e.StickersAfter.Values)
-                {
-                    var existing = await ctx.Db.Stickers.FirstOrDefaultAsync(s => s.DiscordId == sticker.Id);
-                    if (existing is null)
-                    {
-                        ctx.Db.Stickers.Add(new StickerEntity
-                        {
-                            DiscordId = sticker.Id,
-                            GuildId = guildGuid,
-                            Name = sticker.Name ?? string.Empty,
-                            Description = sticker.Description,
-                            Tags = sticker.Tags is not null ? string.Join(",", sticker.Tags) : null,
-                            Type = (int)sticker.Type,
-                            FormatType = (int)sticker.FormatType,
-                            IsAvailable = true
-                        });
-                    }
-                    else
-                    {
-                        existing.Name = sticker.Name ?? string.Empty;
-                        existing.Description = sticker.Description;
-                        existing.Tags = sticker.Tags is not null ? string.Join(",", sticker.Tags) : null;
-                        existing.IsDeleted = false;
-                        existing.DeletedAtUtc = null;
-                    }
-                }
+                await UpsertStickersAsync(ctx, e, guildGuid);
+                await SoftDeleteRemovedStickersAsync(ctx, removedIds);
 
-                foreach (var id in removedIds)
-                {
-                    await ctx.Db.Stickers.Where(s => s.DiscordId == id)
-                        .ExecuteUpdateAsync(s => s
-                            .SetProperty(st => st.IsDeleted, true)
-                            .SetProperty(st => st.DeletedAtUtc, (DateTime?)ctx.ReceivedAtUtc));
-                }
-
-                ctx.Db.StickerEvents.Add(new StickerEventEntity
-                {
-                    GuildDiscordId = e.Guild.Id,
-                    StickersAddedJson = addedIds.Count > 0
-                        ? JsonSerializer.Serialize(addedIds.Select(id => new { Id = id, e.StickersAfter[id].Name }))
-                        : null,
-                    StickersRemovedJson = removedIds.Count > 0
-                        ? JsonSerializer.Serialize(removedIds.Select(id => new { Id = id, e.StickersBefore[id].Name }))
-                        : null,
-                    StickersUpdatedJson = updatedIds.Count > 0
-                        ? JsonSerializer.Serialize(updatedIds.Select(id => new { Id = id, NameBefore = e.StickersBefore[id].Name, NameAfter = e.StickersAfter[id].Name }))
-                        : null,
-                    EventTimestampUtc = ctx.ReceivedAtUtc,
-                    ReceivedAtUtc = ctx.ReceivedAtUtc,
-                    RawEventJson = ctx.RawJson
-                });
+                ctx.Db.StickerEvents.Add(BuildStickerEvent(e, ctx, addedIds, removedIds, updatedIds));
 
                 await ctx.Db.SaveChangesAsync();
             });
     }
+
+    private static async Task UpsertStickersAsync(EventContext ctx, GuildStickersUpdatedEventArgs e, Guid? guildGuid)
+    {
+        foreach (var sticker in e.StickersAfter.Values)
+        {
+            var existing = await ctx.Db.Stickers.FirstOrDefaultAsync(s => s.DiscordId == sticker.Id);
+            if (existing is null)
+            {
+                ctx.Db.Stickers.Add(new StickerEntity
+                {
+                    DiscordId = sticker.Id,
+                    GuildId = guildGuid,
+                    Name = sticker.Name ?? string.Empty,
+                    Description = sticker.Description,
+                    Tags = sticker.Tags is not null ? string.Join(",", sticker.Tags) : null,
+                    Type = (int)sticker.Type,
+                    FormatType = (int)sticker.FormatType,
+                    IsAvailable = true
+                });
+            }
+            else
+            {
+                existing.Name = sticker.Name ?? string.Empty;
+                existing.Description = sticker.Description;
+                existing.Tags = sticker.Tags is not null ? string.Join(",", sticker.Tags) : null;
+                existing.IsDeleted = false;
+                existing.DeletedAtUtc = null;
+            }
+        }
+    }
+
+    private static async Task SoftDeleteRemovedStickersAsync(EventContext ctx, List<ulong> removedIds)
+    {
+        foreach (var id in removedIds)
+        {
+            await ctx.Db.Stickers.Where(s => s.DiscordId == id)
+                .ExecuteUpdateAsync(s => s
+                    .SetProperty(st => st.IsDeleted, true)
+                    .SetProperty(st => st.DeletedAtUtc, (DateTime?)ctx.ReceivedAtUtc));
+        }
+    }
+
+    private static StickerEventEntity BuildStickerEvent(
+        GuildStickersUpdatedEventArgs e,
+        EventContext ctx,
+        List<ulong> addedIds,
+        List<ulong> removedIds,
+        List<ulong> updatedIds) => new StickerEventEntity
+    {
+        GuildDiscordId = e.Guild.Id,
+        StickersAddedJson = addedIds.Count > 0
+            ? JsonSerializer.Serialize(addedIds.Select(id => new { Id = id, e.StickersAfter[id].Name }))
+            : null,
+        StickersRemovedJson = removedIds.Count > 0
+            ? JsonSerializer.Serialize(removedIds.Select(id => new { Id = id, e.StickersBefore[id].Name }))
+            : null,
+        StickersUpdatedJson = updatedIds.Count > 0
+            ? JsonSerializer.Serialize(updatedIds.Select(id => new { Id = id, NameBefore = e.StickersBefore[id].Name, NameAfter = e.StickersAfter[id].Name }))
+            : null,
+        EventTimestampUtc = ctx.ReceivedAtUtc,
+        ReceivedAtUtc = ctx.ReceivedAtUtc,
+        RawEventJson = ctx.RawJson
+    };
 }

--- a/src/DiscordEventService/Services/FailedEventService.cs
+++ b/src/DiscordEventService/Services/FailedEventService.cs
@@ -52,44 +52,58 @@ internal sealed class FailedEventService(DiscordDbContext db, ILogger<FailedEven
                 "CRITICAL: Failed to record event failure. Original error: {EventType} in {HandlerName} - {OriginalExceptionMessage}",
                 eventType, handlerName, exception.Message);
 
+            await WriteDeadLetterFallbackAsync(
+                eventType, handlerName, guildId, channelId, userId, eventJson, exception, ex);
+        }
+    }
+
+    private async Task WriteDeadLetterFallbackAsync(
+        string eventType,
+        string handlerName,
+        ulong? guildId,
+        ulong? channelId,
+        ulong? userId,
+        string? eventJson,
+        Exception exception,
+        Exception dbException)
+    {
+        try
+        {
+            var failedAtUtc = DateTime.UtcNow;
+            var logsDir = Path.Combine(env.ContentRootPath, "logs");
+            Directory.CreateDirectory(logsDir);
+            var path = Path.Combine(logsDir, $"dead-letter-fallback-{failedAtUtc:yyyy-MM-dd}.jsonl");
+            var record = new
+            {
+                failedAtUtc,
+                eventType,
+                handlerName,
+                guildId,
+                channelId,
+                userId,
+                exceptionType = exception.GetType().FullName,
+                exceptionMessage = exception.Message,
+                stackTrace = exception.StackTrace,
+                eventJson,
+                secondaryExceptionType = dbException.GetType().FullName,
+                secondaryExceptionMessage = dbException.Message
+            };
+            var line = JsonSerializer.Serialize(record);
+            await _fallbackFileLock.WaitAsync();
             try
             {
-                var failedAtUtc = DateTime.UtcNow;
-                var logsDir = Path.Combine(env.ContentRootPath, "logs");
-                Directory.CreateDirectory(logsDir);
-                var path = Path.Combine(logsDir, $"dead-letter-fallback-{failedAtUtc:yyyy-MM-dd}.jsonl");
-                var record = new
-                {
-                    failedAtUtc,
-                    eventType,
-                    handlerName,
-                    guildId,
-                    channelId,
-                    userId,
-                    exceptionType = exception.GetType().FullName,
-                    exceptionMessage = exception.Message,
-                    stackTrace = exception.StackTrace,
-                    eventJson,
-                    secondaryExceptionType = ex.GetType().FullName,
-                    secondaryExceptionMessage = ex.Message
-                };
-                var line = JsonSerializer.Serialize(record);
-                await _fallbackFileLock.WaitAsync();
-                try
-                {
-                    await File.AppendAllTextAsync(path, line + Environment.NewLine);
-                }
-                finally
-                {
-                    _fallbackFileLock.Release();
-                }
+                await File.AppendAllTextAsync(path, line + Environment.NewLine);
             }
-            catch (Exception fallbackEx)
+            finally
             {
-                logger.LogCritical(fallbackEx,
-                    "JSONL fallback also failed for {EventType} in {HandlerName}",
-                    eventType, handlerName);
+                _fallbackFileLock.Release();
             }
+        }
+        catch (Exception fallbackEx)
+        {
+            logger.LogCritical(fallbackEx,
+                "JSONL fallback also failed for {EventType} in {HandlerName}",
+                eventType, handlerName);
         }
     }
 

--- a/src/DiscordEventService/Services/MemberRoleSnapshotBackfillService.cs
+++ b/src/DiscordEventService/Services/MemberRoleSnapshotBackfillService.cs
@@ -61,47 +61,11 @@ internal sealed class MemberRoleSnapshotBackfillService(
                 continue;
             }
 
-            var rolesAdded = evt.RolesAddedJson is not null
-                ? JsonSerializer.Deserialize<List<ulong>>(evt.RolesAddedJson) ?? []
-                : [];
-            var rolesRemoved = evt.RolesRemovedJson is not null
-                ? JsonSerializer.Deserialize<List<ulong>>(evt.RolesRemovedJson) ?? []
-                : [];
+            var (eventCreated, eventClosed) = await ReplayRoleChangeEventAsync(
+                memberId, evt.Id, evt.RolesAddedJson, evt.RolesRemovedJson, evt.EventTimestampUtc, ct);
 
-            var openRoles = (await db.MemberRoleSnapshots
-                .Where(s => s.MemberId == memberId && s.RevokedAtUtc == null)
-                .Select(s => s.RoleDiscordId)
-                .ToListAsync(ct))
-                .ToHashSet();
-
-            foreach (var roleId in rolesAdded)
-            {
-                if (openRoles.Contains(roleId))
-                    continue;
-
-                // Insert-or-ignore: the openRoles pre-check skips known duplicates; this guards
-                // the rare race where a live event inserts the same open snapshot concurrently.
-                var (_, inserted) = await db.MemberRoleSnapshots.GetOrInsertAsync(
-                    s => s.MemberId == memberId && s.RoleDiscordId == roleId && s.RevokedAtUtc == null,
-                    () => new MemberRoleSnapshotEntity
-                    {
-                        MemberId = memberId,
-                        RoleDiscordId = roleId,
-                        GrantedAtUtc = evt.EventTimestampUtc,
-                        SourceEventId = evt.Id
-                    },
-                    ct);
-                if (inserted) created++;
-            }
-
-            foreach (var roleId in rolesRemoved)
-            {
-                var closedCount = await db.MemberRoleSnapshots
-                    .Where(s => s.MemberId == memberId && s.RoleDiscordId == roleId && s.RevokedAtUtc == null)
-                    .ExecuteUpdateAsync(s => s.SetProperty(x => x.RevokedAtUtc, evt.EventTimestampUtc), ct);
-                closed += closedCount;
-            }
-
+            created += eventCreated;
+            closed += eventClosed;
             eventsProcessed++;
         }
 
@@ -111,6 +75,60 @@ internal sealed class MemberRoleSnapshotBackfillService(
         var seeded = await SeedCurrentRolesAsync(memberLookup, ct);
 
         return new Result(eventsProcessed, created, closed, seeded);
+    }
+
+    private async Task<(int Created, int Closed)> ReplayRoleChangeEventAsync(
+        Guid memberId,
+        Guid eventId,
+        string? rolesAddedJson,
+        string? rolesRemovedJson,
+        DateTime eventTimestampUtc,
+        CancellationToken ct)
+    {
+        var created = 0;
+        var closed = 0;
+
+        var rolesAdded = rolesAddedJson is not null
+            ? JsonSerializer.Deserialize<List<ulong>>(rolesAddedJson) ?? []
+            : [];
+        var rolesRemoved = rolesRemovedJson is not null
+            ? JsonSerializer.Deserialize<List<ulong>>(rolesRemovedJson) ?? []
+            : [];
+
+        var openRoles = (await db.MemberRoleSnapshots
+            .Where(s => s.MemberId == memberId && s.RevokedAtUtc == null)
+            .Select(s => s.RoleDiscordId)
+            .ToListAsync(ct))
+            .ToHashSet();
+
+        foreach (var roleId in rolesAdded)
+        {
+            if (openRoles.Contains(roleId))
+                continue;
+
+            // Insert-or-ignore: the openRoles pre-check skips known duplicates; this guards
+            // the rare race where a live event inserts the same open snapshot concurrently.
+            var (_, inserted) = await db.MemberRoleSnapshots.GetOrInsertAsync(
+                s => s.MemberId == memberId && s.RoleDiscordId == roleId && s.RevokedAtUtc == null,
+                () => new MemberRoleSnapshotEntity
+                {
+                    MemberId = memberId,
+                    RoleDiscordId = roleId,
+                    GrantedAtUtc = eventTimestampUtc,
+                    SourceEventId = eventId
+                },
+                ct);
+            if (inserted) created++;
+        }
+
+        foreach (var roleId in rolesRemoved)
+        {
+            closed += await db.MemberRoleSnapshots
+                .Where(s => s.MemberId == memberId && s.RoleDiscordId == roleId && s.RevokedAtUtc == null)
+                .ExecuteUpdateAsync(s => s.SetProperty(x => x.RevokedAtUtc, eventTimestampUtc), ct);
+        }
+
+        return (created, closed);
     }
 
     private async Task<int> SeedCurrentRolesAsync(
@@ -123,60 +141,70 @@ internal sealed class MemberRoleSnapshotBackfillService(
         foreach (var guildDiscordId in guildIds)
         {
             ct.ThrowIfCancellationRequested();
-
-            DSharpPlus.Entities.DiscordGuild guild;
-            try
-            {
-                guild = await discordClient.GetGuildAsync(guildDiscordId);
-            }
-            catch (Exception ex) when (ex is NotFoundException or UnauthorizedException)
-            {
-                logger.LogWarning(ex, "Cannot fetch guild {GuildId} for role seeding — skipping", guildDiscordId);
-                continue;
-            }
-
-            var members = new List<DSharpPlus.Entities.DiscordMember>();
-            await foreach (var member in guild.GetAllMembersAsync())
-                members.Add(member);
-
-            logger.LogInformation("Seeding current roles for {MemberCount} members in guild {GuildId}",
-                members.Count, guildDiscordId);
-
-            foreach (var member in members)
-            {
-                ct.ThrowIfCancellationRequested();
-
-                if (!memberLookup.TryGetValue((member.Id, guildDiscordId), out var memberId))
-                    continue;
-
-                var openRolesForMember = (await db.MemberRoleSnapshots
-                    .Where(s => s.MemberId == memberId && s.RevokedAtUtc == null)
-                    .Select(s => s.RoleDiscordId)
-                    .ToListAsync(ct))
-                    .ToHashSet();
-
-                foreach (var role in member.Roles)
-                {
-                    if (openRolesForMember.Contains(role.Id))
-                        continue;
-
-                    // Insert-or-ignore: openRolesForMember pre-check skips known duplicates; this
-                    // guards the rare race where a live event inserts the same snapshot concurrently.
-                    var (_, inserted) = await db.MemberRoleSnapshots.GetOrInsertAsync(
-                        s => s.MemberId == memberId && s.RoleDiscordId == role.Id && s.RevokedAtUtc == null,
-                        () => new MemberRoleSnapshotEntity
-                        {
-                            MemberId = memberId,
-                            RoleDiscordId = role.Id,
-                            GrantedAtUtc = DateTime.UtcNow
-                        },
-                        ct);
-                    if (inserted) seeded++;
-                }
-            }
+            seeded += await SeedGuildRolesAsync(guildDiscordId, memberLookup, ct);
         }
 
         logger.LogInformation("Current role seeding done: {SeededCount} new snapshots", seeded);
+        return seeded;
+    }
+
+    private async Task<int> SeedGuildRolesAsync(
+        ulong guildDiscordId,
+        Dictionary<(ulong UserDiscordId, ulong GuildDiscordId), Guid> memberLookup,
+        CancellationToken ct)
+    {
+        DSharpPlus.Entities.DiscordGuild guild;
+        try
+        {
+            guild = await discordClient.GetGuildAsync(guildDiscordId);
+        }
+        catch (Exception ex) when (ex is NotFoundException or UnauthorizedException)
+        {
+            logger.LogWarning(ex, "Cannot fetch guild {GuildId} for role seeding — skipping", guildDiscordId);
+            return 0;
+        }
+
+        var members = new List<DSharpPlus.Entities.DiscordMember>();
+        await foreach (var member in guild.GetAllMembersAsync())
+            members.Add(member);
+
+        logger.LogInformation("Seeding current roles for {MemberCount} members in guild {GuildId}",
+            members.Count, guildDiscordId);
+
+        var seeded = 0;
+        foreach (var member in members)
+        {
+            ct.ThrowIfCancellationRequested();
+
+            if (!memberLookup.TryGetValue((member.Id, guildDiscordId), out var memberId))
+                continue;
+
+            var openRolesForMember = (await db.MemberRoleSnapshots
+                .Where(s => s.MemberId == memberId && s.RevokedAtUtc == null)
+                .Select(s => s.RoleDiscordId)
+                .ToListAsync(ct))
+                .ToHashSet();
+
+            foreach (var role in member.Roles)
+            {
+                if (openRolesForMember.Contains(role.Id))
+                    continue;
+
+                // Insert-or-ignore: openRolesForMember pre-check skips known duplicates; this
+                // guards the rare race where a live event inserts the same snapshot concurrently.
+                var (_, inserted) = await db.MemberRoleSnapshots.GetOrInsertAsync(
+                    s => s.MemberId == memberId && s.RoleDiscordId == role.Id && s.RevokedAtUtc == null,
+                    () => new MemberRoleSnapshotEntity
+                    {
+                        MemberId = memberId,
+                        RoleDiscordId = role.Id,
+                        GrantedAtUtc = DateTime.UtcNow
+                    },
+                    ct);
+                if (inserted) seeded++;
+            }
+        }
+
         return seeded;
     }
 }

--- a/src/DiscordEventService/Services/Pipeline/EventPipeline.cs
+++ b/src/DiscordEventService/Services/Pipeline/EventPipeline.cs
@@ -33,9 +33,14 @@ internal sealed class EventPipeline(IServiceScopeFactory scopeFactory, ILoggerFa
                 // GuildUpdateEventHandler); pass logRawEvent: false to skip a duplicate row.
                 if (logRawEvent)
                 {
-                    var serialized = await SerializeAndFlushRawEventAsync(
-                        scope.ServiceProvider, db, e, eventType, guildId, channelId, userId, correlationId);
+                    var rawEventService = scope.ServiceProvider.GetRequiredService<RawEventLogService>();
+                    var serialized = await rawEventService.SerializeAndLogAsync(
+                        e, eventType, guildId, channelId, userId, correlationId: correlationId);
                     rawJson = serialized.Json;
+
+                    // Flush the raw event row before handler logic. Any ChangeTracker.Clear()
+                    // in upsert services would silently drop staged raw_event_logs rows otherwise.
+                    await db.SaveChangesAsync();
 
                     // Serialization failure means raw_event_logs holds an unreplayable stub. The
                     // row is flagged (serialization_failed=true); surface it loudly and record a
@@ -59,27 +64,6 @@ internal sealed class EventPipeline(IServiceScopeFactory scopeFactory, ILoggerFa
                 await RecordFailureAsync(ex);
             }
         }
-    }
-
-    private static async Task<EventSerializationResult> SerializeAndFlushRawEventAsync<TEventArgs>(
-        IServiceProvider services,
-        DiscordDbContext db,
-        TEventArgs e,
-        string eventType,
-        ulong guildId,
-        ulong? channelId,
-        ulong? userId,
-        Guid correlationId) where TEventArgs : class
-    {
-        var rawEventService = services.GetRequiredService<RawEventLogService>();
-        var serialized = await rawEventService.SerializeAndLogAsync(
-            e, eventType, guildId, channelId, userId, correlationId: correlationId);
-
-        // Flush the raw event row before handler logic. Any ChangeTracker.Clear()
-        // in upsert services would silently drop staged raw_event_logs rows otherwise.
-        await db.SaveChangesAsync();
-
-        return serialized;
     }
 
     // Isolated scope so a soft failure can be recorded even after the handler's scope faulted.

--- a/src/DiscordEventService/Services/Pipeline/EventPipeline.cs
+++ b/src/DiscordEventService/Services/Pipeline/EventPipeline.cs
@@ -20,15 +20,8 @@ internal sealed class EventPipeline(IServiceScopeFactory scopeFactory, ILoggerFa
         {
             string? rawJson = null;
 
-            // Isolated scope so a soft failure can be recorded even after the handler's scope faulted.
-            async Task RecordFailureAsync(Exception ex)
-            {
-                using var failureScope = scopeFactory.CreateScope();
-                var failedEventService = failureScope.ServiceProvider.GetRequiredService<FailedEventService>();
-                await failedEventService.RecordFailureAsync(
-                    eventType, handlerName, ex,
-                    guildId, channelId, userId, rawJson, correlationId: correlationId);
-            }
+            async Task RecordFailureAsync(Exception ex) => await RecordHandlerFailureAsync(
+                eventType, handlerName, guildId, channelId, userId, rawJson, correlationId, ex);
 
             try
             {
@@ -40,14 +33,9 @@ internal sealed class EventPipeline(IServiceScopeFactory scopeFactory, ILoggerFa
                 // GuildUpdateEventHandler); pass logRawEvent: false to skip a duplicate row.
                 if (logRawEvent)
                 {
-                    var rawEventService = scope.ServiceProvider.GetRequiredService<RawEventLogService>();
-                    var serialized = await rawEventService.SerializeAndLogAsync(
-                        e, eventType, guildId, channelId, userId, correlationId: correlationId);
+                    var serialized = await SerializeAndFlushRawEventAsync(
+                        scope.ServiceProvider, db, e, eventType, guildId, channelId, userId, correlationId);
                     rawJson = serialized.Json;
-
-                    // Flush the raw event row before handler logic. Any ChangeTracker.Clear()
-                    // in upsert services would silently drop staged raw_event_logs rows otherwise.
-                    await db.SaveChangesAsync();
 
                     // Serialization failure means raw_event_logs holds an unreplayable stub. The
                     // row is flagged (serialization_failed=true); surface it loudly and record a
@@ -71,5 +59,44 @@ internal sealed class EventPipeline(IServiceScopeFactory scopeFactory, ILoggerFa
                 await RecordFailureAsync(ex);
             }
         }
+    }
+
+    private static async Task<EventSerializationResult> SerializeAndFlushRawEventAsync<TEventArgs>(
+        IServiceProvider services,
+        DiscordDbContext db,
+        TEventArgs e,
+        string eventType,
+        ulong guildId,
+        ulong? channelId,
+        ulong? userId,
+        Guid correlationId) where TEventArgs : class
+    {
+        var rawEventService = services.GetRequiredService<RawEventLogService>();
+        var serialized = await rawEventService.SerializeAndLogAsync(
+            e, eventType, guildId, channelId, userId, correlationId: correlationId);
+
+        // Flush the raw event row before handler logic. Any ChangeTracker.Clear()
+        // in upsert services would silently drop staged raw_event_logs rows otherwise.
+        await db.SaveChangesAsync();
+
+        return serialized;
+    }
+
+    // Isolated scope so a soft failure can be recorded even after the handler's scope faulted.
+    private async Task RecordHandlerFailureAsync(
+        string eventType,
+        string handlerName,
+        ulong guildId,
+        ulong? channelId,
+        ulong? userId,
+        string? rawJson,
+        Guid correlationId,
+        Exception ex)
+    {
+        using var failureScope = scopeFactory.CreateScope();
+        var failedEventService = failureScope.ServiceProvider.GetRequiredService<FailedEventService>();
+        await failedEventService.RecordFailureAsync(
+            eventType, handlerName, ex,
+            guildId, channelId, userId, rawJson, correlationId: correlationId);
     }
 }

--- a/src/DiscordEventService/Services/UserService.cs
+++ b/src/DiscordEventService/Services/UserService.cs
@@ -16,54 +16,63 @@ internal sealed class UserService(DiscordDbContext db, ILogger<UserService> logg
             .Select(u => new { u.Id, u.Username, u.GlobalName })
             .FirstOrDefaultAsync();
 
-        var usernameChanged = existing is not null && existing.Username != user.Username;
-        var globalNameChanged = existing is not null && existing.GlobalName != user.GlobalName;
+        if (existing is not null && (existing.Username != user.Username || existing.GlobalName != user.GlobalName))
+            return await UpdateUserWithNameHistoryAsync(user, existing.Username, existing.GlobalName, existing.Id);
 
-        // A name change is the only flow that issues a SECOND write (the history row) after
-        // updating the user. Do it as load-modify-save committed in a SINGLE SaveChanges so the
-        // update and its history row land atomically (one implicit transaction, auto-retried under
-        // EnableRetryOnFailure). This avoids an explicit transaction + ChangeTracker.Clear, which on
-        // this shared DbContext would drop pending rows of batch-staging callers (e.g. the backfill
-        // jobs upsert authors mid-batch while messages/reactions are staged for one SaveChanges).
-        if (existing is not null && (usernameChanged || globalNameChanged))
+        return await UpsertUserUnchangedAsync(user);
+    }
+
+    // A name change is the only flow that issues a SECOND write (the history row) after
+    // updating the user. Do it as load-modify-save committed in a SINGLE SaveChanges so the
+    // update and its history row land atomically (one implicit transaction, auto-retried under
+    // EnableRetryOnFailure). This avoids an explicit transaction + ChangeTracker.Clear, which on
+    // this shared DbContext would drop pending rows of batch-staging callers (e.g. the backfill
+    // jobs upsert authors mid-batch while messages/reactions are staged for one SaveChanges).
+    private async Task<UpsertResult<Guid>> UpdateUserWithNameHistoryAsync(
+        DiscordUser user, string? oldUsername, string? oldGlobalName, Guid existingId)
+    {
+        var usernameChanged = oldUsername != user.Username;
+        var globalNameChanged = oldGlobalName != user.GlobalName;
+
+        var entity = await db.Users.FirstOrDefaultAsync(u => u.DiscordId == user.Id);
+        if (entity is null)
         {
-            var entity = await db.Users.FirstOrDefaultAsync(u => u.DiscordId == user.Id);
-            if (entity is null)
-            {
-                logger.LogError("User upsert lost the row for user {UserId} after detecting a name change", user.Id);
-                return UpsertResult<Guid>.Failure($"User upsert lost the row for DiscordId={user.Id}");
-            }
-
-            entity.Username = user.Username;
-            entity.GlobalName = user.GlobalName;
-            entity.Discriminator = user.Discriminator;
-            entity.AvatarHash = user.AvatarHash;
-
-            db.UserNameHistory.Add(new UserNameHistoryEntity
-            {
-                UserId = existing.Id,
-                UsernameBefore = usernameChanged ? existing.Username : null,
-                UsernameAfter = usernameChanged ? user.Username : null,
-                GlobalNameBefore = globalNameChanged ? existing.GlobalName : null,
-                GlobalNameAfter = globalNameChanged ? user.GlobalName : null,
-                ChangedAtUtc = DateTime.UtcNow
-            });
-
-            await db.SaveChangesAsync();
-
-            logger.LogInformation(
-                "User name changed for {UserId}: username {OldUsername} → {NewUsername}, global name {OldGlobalName} → {NewGlobalName}",
-                user.Id,
-                usernameChanged ? existing.Username : "(unchanged)",
-                usernameChanged ? user.Username : "(unchanged)",
-                globalNameChanged ? existing.GlobalName : "(unchanged)",
-                globalNameChanged ? user.GlobalName : "(unchanged)");
-
-            return UpsertResult<Guid>.Success(existing.Id);
+            logger.LogError("User upsert lost the row for user {UserId} after detecting a name change", user.Id);
+            return UpsertResult<Guid>.Failure($"User upsert lost the row for DiscordId={user.Id}");
         }
 
-        // No name change (or a brand-new user): a single set-based upsert. One statement, race-safe
-        // insert-or-update, and — unlike SaveChanges — it never flushes a caller's staged entities.
+        entity.Username = user.Username;
+        entity.GlobalName = user.GlobalName;
+        entity.Discriminator = user.Discriminator;
+        entity.AvatarHash = user.AvatarHash;
+
+        db.UserNameHistory.Add(new UserNameHistoryEntity
+        {
+            UserId = existingId,
+            UsernameBefore = usernameChanged ? oldUsername : null,
+            UsernameAfter = usernameChanged ? user.Username : null,
+            GlobalNameBefore = globalNameChanged ? oldGlobalName : null,
+            GlobalNameAfter = globalNameChanged ? user.GlobalName : null,
+            ChangedAtUtc = DateTime.UtcNow
+        });
+
+        await db.SaveChangesAsync();
+
+        logger.LogInformation(
+            "User name changed for {UserId}: username {OldUsername} → {NewUsername}, global name {OldGlobalName} → {NewGlobalName}",
+            user.Id,
+            usernameChanged ? oldUsername : "(unchanged)",
+            usernameChanged ? user.Username : "(unchanged)",
+            globalNameChanged ? oldGlobalName : "(unchanged)",
+            globalNameChanged ? user.GlobalName : "(unchanged)");
+
+        return UpsertResult<Guid>.Success(existingId);
+    }
+
+    // No name change (or a brand-new user): a single set-based upsert. One statement, race-safe
+    // insert-or-update, and — unlike SaveChanges — it never flushes a caller's staged entities.
+    private async Task<UpsertResult<Guid>> UpsertUserUnchangedAsync(DiscordUser user)
+    {
         var id = await db.Users.UpsertAsync(
             u => u.DiscordId == user.Id,
             s => s


### PR DESCRIPTION
## Summary
First half of the Tier D method-length backlog: 17 of the 27 flagged >50-line methods, covering all event handlers and services. Strictly behavior-preserving — long lambdas and methods decomposed into named private steps and entity builders; transaction/retry orchestration stays at the call sites.

- **BootQuickSyncService**: per-channel sync, backfilled-message insert, per-member presence snapshot, missing-activity start
- **UserService**: name-history path vs set-based upsert path
- **FailedEventService**: JSONL dead-letter fallback extracted
- **EventPipeline**: failure recording extracted; serialize → rawJson → flush ordering preserved exactly
- **MemberRoleSnapshotBackfillService**: per-event replay + per-guild seeding
- **SocketLifecycleHandler**: gap-start resolution + reconnect-backfill enqueue
- **PresenceEventHandler**: DTO/entity builders; activity tracking split into end/start/touch phases
- **Member/Guild/Emoji/Channel/Role/Sticker/Message handlers**: upsert steps and entity builders extracted (builders invoked inside ExecutionStrategy lambdas — fresh entity per retry preserved)

## Review hardening
A dedicated guidelines review agent diffed every extraction against master and caught two drifts, both fixed in the last commit:
- `BuildMemberUpdatedEvent` now receives the premium/muted/deafened **after-snapshots** as parameters instead of re-reading mutable `e.Member` state inside the retry lambda
- `EventPipeline` keeps master's serialize → `rawJson` → flush ordering so a flush failure still records the replay payload

## Verification
- `dotnet build --no-incremental`: 0 warnings / 0 errors; `dotnet test`: 151/151 after every commit
- Live dev-bot run: cold-boot quick-sync produced 8 presence snapshots (log and DB row counts match), MessageCreated/Updated + edit-history + reaction all persisted through the decomposed paths, zero errors in the boot log

Remaining for D2 (next PR): jobs (MessagesBackfillJob at 186 lines is the worst), 6 controller actions, MemeIndexing services, Program.cs client-factory lambda + registration extraction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)