### PR TITLE
chore: dotnet-guidelines Tier D2 — decompose remaining long methods (jobs, controllers, Program.cs)

### DIFF
--- a/src/DiscordEventService/Controllers/GuildController.cs
+++ b/src/DiscordEventService/Controllers/GuildController.cs
@@ -82,5 +82,4 @@ public sealed class GuildController(DiscordDbContext db) : ControllerBase
             .Select(x => new GuildOnlineDto(x.DiscordId, x.Username, x.AvatarHash, x.Status))
             .ToList();
     }
-
 }

--- a/src/DiscordEventService/Controllers/GuildController.cs
+++ b/src/DiscordEventService/Controllers/GuildController.cs
@@ -35,12 +35,21 @@ public sealed class GuildController(DiscordDbContext db) : ControllerBase
             .Select(e => (DateTime?)e.ReceivedAtUtc)
             .FirstOrDefaultAsync(ct);
 
-        // A correlated subquery picks each non-bot user's most-recent presence row
-        // (ReceivedAtUtc desc, Id as a deterministic tiebreak) and projects its three
-        // per-device statuses. We MATERIALIZE first, then derive the overall status
-        // (PresenceStatus.Overall — a priority pick, not a numeric max) and
-        // filter/sort/take in C#: filtering on a correlated subquery in SQL would
-        // evaluate it twice and could disagree on ties.
+        var onlineDtos = await GetOnlineUsersAsync(ct);
+
+        return new GuildDto(
+            guild.DiscordId, guild.Name, guild.IconHash,
+            memberCount, channelCount, userCount, eventSpanStart, onlineDtos);
+    }
+
+    // A correlated subquery picks each non-bot user's most-recent presence row
+    // (ReceivedAtUtc desc, Id as a deterministic tiebreak) and projects its three
+    // per-device statuses. We MATERIALIZE first, then derive the overall status
+    // (PresenceStatus.Overall — a priority pick, not a numeric max) and
+    // filter/sort/take in C#: filtering on a correlated subquery in SQL would
+    // evaluate it twice and could disagree on ties.
+    private async Task<List<GuildOnlineDto>> GetOnlineUsersAsync(CancellationToken ct)
+    {
         var candidates = await db.Users.AsNoTracking()
             .Where(u => !u.IsBot)
             .Select(u => new
@@ -57,7 +66,7 @@ public sealed class GuildController(DiscordDbContext db) : ControllerBase
             })
             .ToListAsync(ct);
 
-        var onlineDtos = candidates
+        return candidates
             .Where(x => x.Latest is not null)
             .Select(x => new
             {
@@ -72,9 +81,6 @@ public sealed class GuildController(DiscordDbContext db) : ControllerBase
             .Take(8)
             .Select(x => new GuildOnlineDto(x.DiscordId, x.Username, x.AvatarHash, x.Status))
             .ToList();
-
-        return new GuildDto(
-            guild.DiscordId, guild.Name, guild.IconHash,
-            memberCount, channelCount, userCount, eventSpanStart, onlineDtos);
     }
+
 }

--- a/src/DiscordEventService/Controllers/PeopleController.cs
+++ b/src/DiscordEventService/Controllers/PeopleController.cs
@@ -254,5 +254,4 @@ public sealed class PeopleController(DiscordDbContext db) : ControllerBase
             : PresenceStatus.Overall(
                 latestPresence.DesktopStatusAfter, latestPresence.MobileStatusAfter, latestPresence.WebStatusAfter);
     }
-
 }

--- a/src/DiscordEventService/Controllers/PeopleController.cs
+++ b/src/DiscordEventService/Controllers/PeopleController.cs
@@ -52,57 +52,17 @@ public sealed class PeopleController(DiscordDbContext db) : ControllerBase
         var memeCount = await db.Messages.AsNoTracking()
             .LongCountAsync(m => m.AuthorId == userId && (m.HasAttachments || m.HasEmbeds), ct);
 
-        // Present reactions on this user's messages (see ReactionEventQueryExtensions).
-        var reactionsReceived = await db.ReactionEvents.AsNoTracking().WherePresent()
-            .Join(
-                db.Messages.AsNoTracking().Where(m => m.AuthorId == userId),
-                r => r.MessageDiscordId,
-                m => m.DiscordId,
-                (r, m) => r.Id)
-            .LongCountAsync(ct);
+        var reactionsReceived = await CountReactionsReceivedAsync(userId, ct);
 
         var voiceMinutes = await VoiceMinutesAsync(discordSf, ct);
         var onlineMinutes = await OnlineMinutesAsync(discordSf, ct);
 
-        // Top emote the user gave (present reactions only).
-        var favoriteEmote = await db.ReactionEvents.AsNoTracking().WherePresent()
-            .Where(r => r.UserDiscordId == discordSf)
-            .GroupBy(r => new { r.EmoteName, r.EmoteDiscordId })
-            .Select(g => new { g.Key.EmoteName, g.Key.EmoteDiscordId, Count = g.LongCount() })
-            .OrderByDescending(x => x.Count)
-            .FirstOrDefaultAsync(ct);
-
-        var favoriteEmoteDto = favoriteEmote is null
-            ? null
-            : new ProfileFavoriteEmoteDto(
-                favoriteEmote.EmoteName, favoriteEmote.EmoteDiscordId, favoriteEmote.EmoteDiscordId is > 0);
-
-        // Channel the user posted in most.
-        var busiestChannel = await db.Messages.AsNoTracking()
-            .Where(m => m.AuthorId == userId)
-            .GroupBy(m => new { m.Channel.Name, m.Channel.DiscordId })
-            .Select(g => new { g.Key.Name, g.Key.DiscordId, Count = g.LongCount() })
-            .OrderByDescending(x => x.Count)
-            .FirstOrDefaultAsync(ct);
-
-        var busiestChannelDto = busiestChannel is null
-            ? null
-            : new ProfileBusiestChannelDto(busiestChannel.Name, busiestChannel.DiscordId);
+        var favoriteEmoteDto = await GetFavoriteEmoteAsync(discordSf, ct);
+        var busiestChannelDto = await GetBusiestChannelAsync(userId, ct);
 
         var messagesDaily14 = await MessagesDaily14Async(userId, ct);
 
-        // Current overall status from the latest presence row, by client-status priority
-        // (online > idle > dnd > offline); "offline" when there are no presence rows.
-        var latestPresence = await db.PresenceEvents.AsNoTracking()
-            .Where(p => p.UserDiscordId == discordSf)
-            .OrderByDescending(p => p.ReceivedAtUtc)
-            .ThenByDescending(p => p.Id)
-            .Select(p => new { p.DesktopStatusAfter, p.MobileStatusAfter, p.WebStatusAfter })
-            .FirstOrDefaultAsync(ct);
-        var status = latestPresence is null
-            ? PresenceStatus.Offline
-            : PresenceStatus.Overall(
-                latestPresence.DesktopStatusAfter, latestPresence.MobileStatusAfter, latestPresence.WebStatusAfter);
+        var status = await GetCurrentStatusAsync(discordSf, ct);
 
         var nameHistory = await db.UserNameHistory.AsNoTracking()
             .Where(h => h.UserId == userId)
@@ -236,4 +196,63 @@ public sealed class PeopleController(DiscordDbContext db) : ControllerBase
 
         return series;
     }
+
+    // Present reactions on this user's messages (see ReactionEventQueryExtensions).
+    private async Task<long> CountReactionsReceivedAsync(Guid userId, CancellationToken ct) =>
+        await db.ReactionEvents.AsNoTracking().WherePresent()
+            .Join(
+                db.Messages.AsNoTracking().Where(m => m.AuthorId == userId),
+                r => r.MessageDiscordId,
+                m => m.DiscordId,
+                (r, m) => r.Id)
+            .LongCountAsync(ct);
+
+    // Top emote the user gave (present reactions only).
+    private async Task<ProfileFavoriteEmoteDto?> GetFavoriteEmoteAsync(ulong discordSf, CancellationToken ct)
+    {
+        var favoriteEmote = await db.ReactionEvents.AsNoTracking().WherePresent()
+            .Where(r => r.UserDiscordId == discordSf)
+            .GroupBy(r => new { r.EmoteName, r.EmoteDiscordId })
+            .Select(g => new { g.Key.EmoteName, g.Key.EmoteDiscordId, Count = g.LongCount() })
+            .OrderByDescending(x => x.Count)
+            .FirstOrDefaultAsync(ct);
+
+        return favoriteEmote is null
+            ? null
+            : new ProfileFavoriteEmoteDto(
+                favoriteEmote.EmoteName, favoriteEmote.EmoteDiscordId, favoriteEmote.EmoteDiscordId is > 0);
+    }
+
+    // Channel the user posted in most.
+    private async Task<ProfileBusiestChannelDto?> GetBusiestChannelAsync(Guid userId, CancellationToken ct)
+    {
+        var busiestChannel = await db.Messages.AsNoTracking()
+            .Where(m => m.AuthorId == userId)
+            .GroupBy(m => new { m.Channel.Name, m.Channel.DiscordId })
+            .Select(g => new { g.Key.Name, g.Key.DiscordId, Count = g.LongCount() })
+            .OrderByDescending(x => x.Count)
+            .FirstOrDefaultAsync(ct);
+
+        return busiestChannel is null
+            ? null
+            : new ProfileBusiestChannelDto(busiestChannel.Name, busiestChannel.DiscordId);
+    }
+
+    // Current overall status from the latest presence row, by client-status priority
+    // (online > idle > dnd > offline); "offline" when there are no presence rows.
+    private async Task<string> GetCurrentStatusAsync(ulong discordSf, CancellationToken ct)
+    {
+        var latestPresence = await db.PresenceEvents.AsNoTracking()
+            .Where(p => p.UserDiscordId == discordSf)
+            .OrderByDescending(p => p.ReceivedAtUtc)
+            .ThenByDescending(p => p.Id)
+            .Select(p => new { p.DesktopStatusAfter, p.MobileStatusAfter, p.WebStatusAfter })
+            .FirstOrDefaultAsync(ct);
+
+        return latestPresence is null
+            ? PresenceStatus.Offline
+            : PresenceStatus.Overall(
+                latestPresence.DesktopStatusAfter, latestPresence.MobileStatusAfter, latestPresence.WebStatusAfter);
+    }
+
 }

--- a/src/DiscordEventService/Controllers/StatsController.cs
+++ b/src/DiscordEventService/Controllers/StatsController.cs
@@ -80,30 +80,8 @@ public sealed class StatsController(DiscordDbContext db) : ControllerBase
     [ProducesResponseType<OverviewDto>(StatusCodes.Status200OK)]
     public async Task<ActionResult<OverviewDto>> Overview(CancellationToken ct)
     {
-        var messages = await QuerySingleAsync(
-            $"""
-            SELECT count(*) FILTER (WHERE created_at_utc >= {TodayStart})::bigint,
-                   count(*) FILTER (WHERE created_at_utc >= now() - interval '7 days')::bigint,
-                   count(*) FILTER (WHERE created_at_utc >= now() - interval '30 days')::bigint,
-                   count(*)::bigint
-            FROM messages
-            """,
-            r => new WindowCountsDto(r.GetInt64(0), r.GetInt64(1), r.GetInt64(2), r.GetInt64(3)), ct)
-            ?? new WindowCountsDto(0, 0, 0, 0);
-
-        // Reactions that are "present": Added (0) live + Backfilled (4) historical. Removed
-        // (1) / Cleared (2) / EmojiCleared (3) are excluded. Backfill imported ~26k of these,
-        // so filtering to event_type=0 alone would under-count reactions ~30x.
-        var reactions = await QuerySingleAsync(
-            $"""
-            SELECT count(*) FILTER (WHERE received_at_utc >= {TodayStart})::bigint,
-                   count(*) FILTER (WHERE received_at_utc >= now() - interval '7 days')::bigint,
-                   count(*) FILTER (WHERE received_at_utc >= now() - interval '30 days')::bigint,
-                   count(*)::bigint
-            FROM reaction_events WHERE {ReactionPresentSql}
-            """,
-            r => new WindowCountsDto(r.GetInt64(0), r.GetInt64(1), r.GetInt64(2), r.GetInt64(3)), ct)
-            ?? new WindowCountsDto(0, 0, 0, 0);
+        var messages = await GetMessageWindowCountsAsync(ct);
+        var reactions = await GetReactionWindowCountsAsync(ct);
 
         var counts = await QuerySingleAsync(
             """
@@ -113,17 +91,7 @@ public sealed class StatsController(DiscordDbContext db) : ControllerBase
             """,
             r => (Users: r.GetInt64(0), Channels: r.GetInt64(1), Events: r.GetInt64(2)), ct);
 
-        var voiceMinutes = await QuerySingleAsync(
-            $"""
-            SELECT COALESCE(round(SUM({VoiceSegmentMinutes})), 0)::bigint
-            FROM (
-                SELECT received_at_utc, channel_discord_id_after,
-                       LEAD(received_at_utc) OVER (PARTITION BY user_discord_id ORDER BY received_at_utc) AS next_ts
-                FROM voice_state_events
-            ) v
-            WHERE v.channel_discord_id_after IS NOT NULL AND v.next_ts IS NOT NULL
-            """,
-            r => r.GetInt64(0), ct);
+        var voiceMinutes = await GetTotalVoiceMinutesAsync(ct);
 
         var topChatter = await TopChatters().FirstOrDefaultAsync(ct);
 
@@ -131,24 +99,7 @@ public sealed class StatsController(DiscordDbContext db) : ControllerBase
             $"{ChannelActivitySql} 1",
             r => new ChannelActivityDto(r.GetString(0), Snowflake(r, 1), r.GetInt64(2), r.GetInt64(3)), ct);
 
-        // Dense 30-CET-day series (today + prior 29), zero-filled. The cutoff is the
-        // UTC instant of the earliest CET day's midnight (not now()-30d), so the first
-        // bucket isn't understated by the UTC/CET offset; missing days render as 0 so the
-        // index-positioned area chart isn't compressed.
-        var messagesDaily = await QueryAsync(
-            $"""
-            WITH {DaysCte(30)},
-            counts AS (
-                SELECT date_trunc('day', created_at_utc AT TIME ZONE '{Tz}')::date AS d, count(*)::bigint AS c
-                FROM messages
-                WHERE created_at_utc >= ((date_trunc('day', now() AT TIME ZONE '{Tz}') - interval '29 days') AT TIME ZONE '{Tz}')
-                GROUP BY 1
-            )
-            SELECT days.d::text, COALESCE(counts.c, 0)::bigint
-            FROM days LEFT JOIN counts ON counts.d = days.d
-            ORDER BY days.d
-            """,
-            r => new DailyPointDto(r.GetString(0), r.GetInt64(1)), ct);
+        var messagesDaily = await GetMessagesDaily30Async(ct);
 
         var topEmojis = await TopEmojisAsync(OverviewTopEmojis, ct);
 
@@ -304,99 +255,8 @@ public sealed class StatsController(DiscordDbContext db) : ControllerBase
         var (curStart, curEnd, prevStart, prevEnd, sparkDays, label, prevLabel) =
             await ResolveWindowAsync(range, ct);
 
-        var hasPrev = prevStart is not null && prevEnd is not null;
-
-        // ---- Count metrics: value/prev via LINQ; dense daily sparks stay raw (see SparkAsync). ----
-        var messages = new CommunityMetricDto(
-            await db.Messages.AsNoTracking()
-                .LongCountAsync(m => m.CreatedAtUtc >= curStart && m.CreatedAtUtc <= curEnd, ct),
-            !hasPrev ? null : await db.Messages.AsNoTracking()
-                .LongCountAsync(m => m.CreatedAtUtc >= prevStart!.Value && m.CreatedAtUtc <= prevEnd!.Value, ct),
-            await SparkAsync("messages", "created_at_utc", null, "count(*)", sparkDays, ct));
-
-        var memes = new CommunityMetricDto(
-            await db.Messages.AsNoTracking()
-                .LongCountAsync(m => (m.HasAttachments || m.HasEmbeds)
-                    && m.CreatedAtUtc >= curStart && m.CreatedAtUtc <= curEnd, ct),
-            !hasPrev ? null : await db.Messages.AsNoTracking()
-                .LongCountAsync(m => (m.HasAttachments || m.HasEmbeds)
-                    && m.CreatedAtUtc >= prevStart!.Value && m.CreatedAtUtc <= prevEnd!.Value, ct),
-            await SparkAsync("messages", "created_at_utc", "(has_attachments OR has_embeds)", "count(*)", sparkDays, ct));
-
-        var reactions = new CommunityMetricDto(
-            await db.ReactionEvents.AsNoTracking().WherePresent()
-                .LongCountAsync(r => r.ReceivedAtUtc >= curStart && r.ReceivedAtUtc <= curEnd, ct),
-            !hasPrev ? null : await db.ReactionEvents.AsNoTracking().WherePresent()
-                .LongCountAsync(r => r.ReceivedAtUtc >= prevStart!.Value && r.ReceivedAtUtc <= prevEnd!.Value, ct),
-            await SparkAsync("reaction_events", "received_at_utc", ReactionPresentSql, "count(*)", sparkDays, ct));
-
-        var activeMembers = new CommunityMetricDto(
-            await db.Messages.AsNoTracking()
-                .Where(m => m.CreatedAtUtc >= curStart && m.CreatedAtUtc <= curEnd)
-                .Select(m => m.AuthorId).Distinct().LongCountAsync(ct),
-            !hasPrev ? null : await db.Messages.AsNoTracking()
-                .Where(m => m.CreatedAtUtc >= prevStart!.Value && m.CreatedAtUtc <= prevEnd!.Value)
-                .Select(m => m.AuthorId).Distinct().LongCountAsync(ct),
-            await SparkAsync("messages", "created_at_utc", null, "count(DISTINCT author_id)", sparkDays, ct));
-
-        var voiceMinutes = await VoiceMinutesMetricAsync(curStart, curEnd, prevStart, prevEnd, sparkDays, ct);
-        var onlineMinutes = await OnlineMinutesMetricAsync(curStart, curEnd, prevStart, prevEnd, sparkDays, ct);
-
-        // ---- Leaderboards: chatters/memes/reactions via LINQ; voice stays raw (LEAD sessionization). ----
-        var topChatters = await db.Messages.AsNoTracking()
-            .Where(m => m.CreatedAtUtc >= curStart && m.CreatedAtUtc <= curEnd)
-            .GroupBy(m => new { m.Author.Username, m.Author.DiscordId, m.Author.AvatarHash })
-            .Select(g => new { g.Key.Username, g.Key.DiscordId, g.Key.AvatarHash, Value = g.LongCount() })
-            .OrderByDescending(x => x.Value)
-            .ThenBy(x => x.DiscordId)
-            .Take(CommunityLeaderboardSize)
-            .Select(x => new CommunityLeaderEntryDto(x.Username, x.DiscordId, x.AvatarHash, x.Value))
-            .ToListAsync(ct);
-
-        var memeLords = await db.Messages.AsNoTracking()
-            .Where(m => (m.HasAttachments || m.HasEmbeds) && m.CreatedAtUtc >= curStart && m.CreatedAtUtc <= curEnd)
-            .GroupBy(m => new { m.Author.Username, m.Author.DiscordId, m.Author.AvatarHash })
-            .Select(g => new { g.Key.Username, g.Key.DiscordId, g.Key.AvatarHash, Value = g.LongCount() })
-            .OrderByDescending(x => x.Value)
-            .ThenBy(x => x.DiscordId)
-            .Take(CommunityLeaderboardSize)
-            .Select(x => new CommunityLeaderEntryDto(x.Username, x.DiscordId, x.AvatarHash, x.Value))
-            .ToListAsync(ct);
-
-        var reactionsReceived = await db.ReactionEvents.AsNoTracking().WherePresent()
-            .Where(r => r.ReceivedAtUtc >= curStart && r.ReceivedAtUtc <= curEnd)
-            .Join(
-                db.Messages.AsNoTracking(),
-                r => r.MessageDiscordId,
-                m => m.DiscordId,
-                (r, m) => m.Author)
-            .GroupBy(a => new { a.Username, a.DiscordId, a.AvatarHash })
-            .Select(g => new { g.Key.Username, g.Key.DiscordId, g.Key.AvatarHash, Value = g.LongCount() })
-            .OrderByDescending(x => x.Value)
-            .ThenBy(x => x.DiscordId)
-            .Take(CommunityLeaderboardSize)
-            .Select(x => new CommunityLeaderEntryDto(x.Username, x.DiscordId, x.AvatarHash, x.Value))
-            .ToListAsync(ct);
-
-        var voice = await LeaderAsync(
-            $"""
-            SELECT u.username, v.user_discord_id, u.avatar_hash,
-                   round(SUM({VoiceSegmentMinutes}))::bigint
-            FROM (
-                SELECT user_discord_id, received_at_utc, channel_discord_id_after,
-                       LEAD(received_at_utc) OVER (PARTITION BY user_discord_id ORDER BY received_at_utc) AS next_ts
-                FROM voice_state_events
-            ) v
-            LEFT JOIN users u ON u.discord_id = v.user_discord_id
-            WHERE v.channel_discord_id_after IS NOT NULL AND v.next_ts IS NOT NULL
-              AND v.received_at_utc BETWEEN {Sql(curStart)} AND {Sql(curEnd)}
-            GROUP BY u.username, v.user_discord_id, u.avatar_hash ORDER BY 4 DESC, v.user_discord_id LIMIT {CommunityLeaderboardSize}
-            """, ct);
-
-        var leaderboards = new CommunityLeaderboardsDto(topChatters, memeLords, reactionsReceived, voice);
-
-        var metrics = new CommunityMetricsDto(
-            messages, memes, reactions, voiceMinutes, onlineMinutes, activeMembers);
+        var metrics = await BuildCommunityMetricsAsync(curStart, curEnd, prevStart, prevEnd, sparkDays, ct);
+        var leaderboards = await BuildCommunityLeaderboardsAsync(curStart, curEnd, ct);
 
         return new CommunityDto(range, label, prevLabel, metrics, leaderboards);
     }
@@ -490,6 +350,168 @@ public sealed class StatsController(DiscordDbContext db) : ControllerBase
             .Select(x => new EmojiStatDto(x.EmoteName, x.EmoteDiscordId, x.EmoteDiscordId is > 0, x.Count))
             .ToList();
     }
+
+    // ---- Count metrics: value/prev via LINQ; dense daily sparks stay raw (see SparkAsync). ----
+    private async Task<CommunityMetricsDto> BuildCommunityMetricsAsync(
+        DateTime curStart, DateTime curEnd, DateTime? prevStart, DateTime? prevEnd, int sparkDays, CancellationToken ct)
+    {
+        var hasPrev = prevStart is not null && prevEnd is not null;
+
+
+        var messages = new CommunityMetricDto(
+            await db.Messages.AsNoTracking()
+                .LongCountAsync(m => m.CreatedAtUtc >= curStart && m.CreatedAtUtc <= curEnd, ct),
+            !hasPrev ? null : await db.Messages.AsNoTracking()
+                .LongCountAsync(m => m.CreatedAtUtc >= prevStart!.Value && m.CreatedAtUtc <= prevEnd!.Value, ct),
+            await SparkAsync("messages", "created_at_utc", null, "count(*)", sparkDays, ct));
+
+        var memes = new CommunityMetricDto(
+            await db.Messages.AsNoTracking()
+                .LongCountAsync(m => (m.HasAttachments || m.HasEmbeds)
+                    && m.CreatedAtUtc >= curStart && m.CreatedAtUtc <= curEnd, ct),
+            !hasPrev ? null : await db.Messages.AsNoTracking()
+                .LongCountAsync(m => (m.HasAttachments || m.HasEmbeds)
+                    && m.CreatedAtUtc >= prevStart!.Value && m.CreatedAtUtc <= prevEnd!.Value, ct),
+            await SparkAsync("messages", "created_at_utc", "(has_attachments OR has_embeds)", "count(*)", sparkDays, ct));
+
+        var reactions = new CommunityMetricDto(
+            await db.ReactionEvents.AsNoTracking().WherePresent()
+                .LongCountAsync(r => r.ReceivedAtUtc >= curStart && r.ReceivedAtUtc <= curEnd, ct),
+            !hasPrev ? null : await db.ReactionEvents.AsNoTracking().WherePresent()
+                .LongCountAsync(r => r.ReceivedAtUtc >= prevStart!.Value && r.ReceivedAtUtc <= prevEnd!.Value, ct),
+            await SparkAsync("reaction_events", "received_at_utc", ReactionPresentSql, "count(*)", sparkDays, ct));
+
+        var activeMembers = new CommunityMetricDto(
+            await db.Messages.AsNoTracking()
+                .Where(m => m.CreatedAtUtc >= curStart && m.CreatedAtUtc <= curEnd)
+                .Select(m => m.AuthorId).Distinct().LongCountAsync(ct),
+            !hasPrev ? null : await db.Messages.AsNoTracking()
+                .Where(m => m.CreatedAtUtc >= prevStart!.Value && m.CreatedAtUtc <= prevEnd!.Value)
+                .Select(m => m.AuthorId).Distinct().LongCountAsync(ct),
+            await SparkAsync("messages", "created_at_utc", null, "count(DISTINCT author_id)", sparkDays, ct));
+
+        var voiceMinutes = await VoiceMinutesMetricAsync(curStart, curEnd, prevStart, prevEnd, sparkDays, ct);
+        var onlineMinutes = await OnlineMinutesMetricAsync(curStart, curEnd, prevStart, prevEnd, sparkDays, ct);
+
+        return new CommunityMetricsDto(messages, memes, reactions, voiceMinutes, onlineMinutes, activeMembers);
+    }
+
+    // ---- Leaderboards: chatters/memes/reactions via LINQ; voice stays raw (LEAD sessionization). ----
+    private async Task<CommunityLeaderboardsDto> BuildCommunityLeaderboardsAsync(
+        DateTime curStart, DateTime curEnd, CancellationToken ct)
+    {
+        var topChatters = await db.Messages.AsNoTracking()
+            .Where(m => m.CreatedAtUtc >= curStart && m.CreatedAtUtc <= curEnd)
+            .GroupBy(m => new { m.Author.Username, m.Author.DiscordId, m.Author.AvatarHash })
+            .Select(g => new { g.Key.Username, g.Key.DiscordId, g.Key.AvatarHash, Value = g.LongCount() })
+            .OrderByDescending(x => x.Value)
+            .ThenBy(x => x.DiscordId)
+            .Take(CommunityLeaderboardSize)
+            .Select(x => new CommunityLeaderEntryDto(x.Username, x.DiscordId, x.AvatarHash, x.Value))
+            .ToListAsync(ct);
+
+        var memeLords = await db.Messages.AsNoTracking()
+            .Where(m => (m.HasAttachments || m.HasEmbeds) && m.CreatedAtUtc >= curStart && m.CreatedAtUtc <= curEnd)
+            .GroupBy(m => new { m.Author.Username, m.Author.DiscordId, m.Author.AvatarHash })
+            .Select(g => new { g.Key.Username, g.Key.DiscordId, g.Key.AvatarHash, Value = g.LongCount() })
+            .OrderByDescending(x => x.Value)
+            .ThenBy(x => x.DiscordId)
+            .Take(CommunityLeaderboardSize)
+            .Select(x => new CommunityLeaderEntryDto(x.Username, x.DiscordId, x.AvatarHash, x.Value))
+            .ToListAsync(ct);
+
+        var reactionsReceived = await db.ReactionEvents.AsNoTracking().WherePresent()
+            .Where(r => r.ReceivedAtUtc >= curStart && r.ReceivedAtUtc <= curEnd)
+            .Join(
+                db.Messages.AsNoTracking(),
+                r => r.MessageDiscordId,
+                m => m.DiscordId,
+                (r, m) => m.Author)
+            .GroupBy(a => new { a.Username, a.DiscordId, a.AvatarHash })
+            .Select(g => new { g.Key.Username, g.Key.DiscordId, g.Key.AvatarHash, Value = g.LongCount() })
+            .OrderByDescending(x => x.Value)
+            .ThenBy(x => x.DiscordId)
+            .Take(CommunityLeaderboardSize)
+            .Select(x => new CommunityLeaderEntryDto(x.Username, x.DiscordId, x.AvatarHash, x.Value))
+            .ToListAsync(ct);
+
+        var voice = await LeaderAsync(
+            $"""
+            SELECT u.username, v.user_discord_id, u.avatar_hash,
+                   round(SUM({VoiceSegmentMinutes}))::bigint
+            FROM (
+                SELECT user_discord_id, received_at_utc, channel_discord_id_after,
+                       LEAD(received_at_utc) OVER (PARTITION BY user_discord_id ORDER BY received_at_utc) AS next_ts
+                FROM voice_state_events
+            ) v
+            LEFT JOIN users u ON u.discord_id = v.user_discord_id
+            WHERE v.channel_discord_id_after IS NOT NULL AND v.next_ts IS NOT NULL
+              AND v.received_at_utc BETWEEN {Sql(curStart)} AND {Sql(curEnd)}
+            GROUP BY u.username, v.user_discord_id, u.avatar_hash ORDER BY 4 DESC, v.user_discord_id LIMIT {CommunityLeaderboardSize}
+            """, ct);
+
+        return new CommunityLeaderboardsDto(topChatters, memeLords, reactionsReceived, voice);
+    }
+
+    private async Task<WindowCountsDto> GetMessageWindowCountsAsync(CancellationToken ct) =>
+        await QuerySingleAsync(
+            $"""
+            SELECT count(*) FILTER (WHERE created_at_utc >= {TodayStart})::bigint,
+                   count(*) FILTER (WHERE created_at_utc >= now() - interval '7 days')::bigint,
+                   count(*) FILTER (WHERE created_at_utc >= now() - interval '30 days')::bigint,
+                   count(*)::bigint
+            FROM messages
+            """,
+            r => new WindowCountsDto(r.GetInt64(0), r.GetInt64(1), r.GetInt64(2), r.GetInt64(3)), ct)
+            ?? new WindowCountsDto(0, 0, 0, 0);
+
+    // Reactions that are "present": Added (0) live + Backfilled (4) historical. Removed
+    // (1) / Cleared (2) / EmojiCleared (3) are excluded. Backfill imported ~26k of these,
+    // so filtering to event_type=0 alone would under-count reactions ~30x.
+    private async Task<WindowCountsDto> GetReactionWindowCountsAsync(CancellationToken ct) =>
+        await QuerySingleAsync(
+            $"""
+            SELECT count(*) FILTER (WHERE received_at_utc >= {TodayStart})::bigint,
+                   count(*) FILTER (WHERE received_at_utc >= now() - interval '7 days')::bigint,
+                   count(*) FILTER (WHERE received_at_utc >= now() - interval '30 days')::bigint,
+                   count(*)::bigint
+            FROM reaction_events WHERE {ReactionPresentSql}
+            """,
+            r => new WindowCountsDto(r.GetInt64(0), r.GetInt64(1), r.GetInt64(2), r.GetInt64(3)), ct)
+            ?? new WindowCountsDto(0, 0, 0, 0);
+
+    private Task<long> GetTotalVoiceMinutesAsync(CancellationToken ct) =>
+        QuerySingleAsync(
+            $"""
+            SELECT COALESCE(round(SUM({VoiceSegmentMinutes})), 0)::bigint
+            FROM (
+                SELECT received_at_utc, channel_discord_id_after,
+                       LEAD(received_at_utc) OVER (PARTITION BY user_discord_id ORDER BY received_at_utc) AS next_ts
+                FROM voice_state_events
+            ) v
+            WHERE v.channel_discord_id_after IS NOT NULL AND v.next_ts IS NOT NULL
+            """,
+            r => r.GetInt64(0), ct);
+
+    // Dense 30-CET-day series (today + prior 29), zero-filled. The cutoff is the
+    // UTC instant of the earliest CET day's midnight (not now()-30d), so the first
+    // bucket isn't understated by the UTC/CET offset; missing days render as 0 so the
+    // index-positioned area chart isn't compressed.
+    private Task<List<DailyPointDto>> GetMessagesDaily30Async(CancellationToken ct) =>
+        QueryAsync(
+            $"""
+            WITH {DaysCte(30)},
+            counts AS (
+                SELECT date_trunc('day', created_at_utc AT TIME ZONE '{Tz}')::date AS d, count(*)::bigint AS c
+                FROM messages
+                WHERE created_at_utc >= ((date_trunc('day', now() AT TIME ZONE '{Tz}') - interval '29 days') AT TIME ZONE '{Tz}')
+                GROUP BY 1
+            )
+            SELECT days.d::text, COALESCE(counts.c, 0)::bigint
+            FROM days LEFT JOIN counts ON counts.d = days.d
+            ORDER BY days.d
+            """,
+            r => new DailyPointDto(r.GetString(0), r.GetInt64(1)), ct);
 
     private async Task<List<T>> QueryAsync<T>(string sql, Func<NpgsqlDataReader, T> map, CancellationToken ct)
     {

--- a/src/DiscordEventService/Controllers/StatsController.cs
+++ b/src/DiscordEventService/Controllers/StatsController.cs
@@ -357,7 +357,6 @@ public sealed class StatsController(DiscordDbContext db) : ControllerBase
     {
         var hasPrev = prevStart is not null && prevEnd is not null;
 
-
         var messages = new CommunityMetricDto(
             await db.Messages.AsNoTracking()
                 .LongCountAsync(m => m.CreatedAtUtc >= curStart && m.CreatedAtUtc <= curEnd, ct),

--- a/src/DiscordEventService/Controllers/TablesController.cs
+++ b/src/DiscordEventService/Controllers/TablesController.cs
@@ -95,38 +95,55 @@ public sealed class TablesController(DiscordDbContext db, SchemaCatalog catalog)
 
         var total = await CountAsync(connection, quotedTable, where, filter, ct);
 
-        var rows = new List<Dictionary<string, object?>>(pageSize);
-        await using (var cmd = connection.CreateCommand())
-        {
-            cmd.CommandText =
-                $"SELECT * FROM {quotedTable}{where} " +
-                $"ORDER BY {Quote(sortColumn)} {direction} LIMIT @limit OFFSET @offset";
-            if (hasFilter)
-                cmd.Parameters.AddWithValue("filter", $"%{filter}%");
-            cmd.Parameters.AddWithValue("limit", pageSize);
-            cmd.Parameters.AddWithValue("offset", offset);
-
-            await using var reader = await cmd.ExecuteReaderAsync(ct);
-            while (await reader.ReadAsync(ct))
-            {
-                var row = new Dictionary<string, object?>(reader.FieldCount, StringComparer.Ordinal);
-                for (var i = 0; i < reader.FieldCount; i++)
-                {
-                    var name = reader.GetName(i);
-                    var value = await reader.IsDBNullAsync(i, ct) ? null : reader.GetValue(i);
-
-                    // Snowflakes are stored as bigint; box back to ulong so the global
-                    // JSON converter emits them as strings (JS number precision).
-                    if (value is long l && meta.Column(name)?.Kind == ColumnKind.Snowflake)
-                        value = unchecked((ulong)l);
-
-                    row[name] = value;
-                }
-                rows.Add(row);
-            }
-        }
+        var rows = await QueryRowsAsync(
+            connection, meta, quotedTable, where, sortColumn, direction, hasFilter, filter, pageSize, offset, ct);
 
         return Ok(new PagedResult<Dictionary<string, object?>>(rows, total, page, pageSize));
+    }
+
+    private static async Task<List<Dictionary<string, object?>>> QueryRowsAsync(
+        NpgsqlConnection connection,
+        TableMeta meta,
+        string quotedTable,
+        string where,
+        string sortColumn,
+        string direction,
+        bool hasFilter,
+        string? filter,
+        int pageSize,
+        long offset,
+        CancellationToken ct)
+    {
+        var rows = new List<Dictionary<string, object?>>(pageSize);
+        await using var cmd = connection.CreateCommand();
+        cmd.CommandText =
+            $"SELECT * FROM {quotedTable}{where} " +
+            $"ORDER BY {Quote(sortColumn)} {direction} LIMIT @limit OFFSET @offset";
+        if (hasFilter)
+            cmd.Parameters.AddWithValue("filter", $"%{filter}%");
+        cmd.Parameters.AddWithValue("limit", pageSize);
+        cmd.Parameters.AddWithValue("offset", offset);
+
+        await using var reader = await cmd.ExecuteReaderAsync(ct);
+        while (await reader.ReadAsync(ct))
+        {
+            var row = new Dictionary<string, object?>(reader.FieldCount, StringComparer.Ordinal);
+            for (var i = 0; i < reader.FieldCount; i++)
+            {
+                var name = reader.GetName(i);
+                var value = await reader.IsDBNullAsync(i, ct) ? null : reader.GetValue(i);
+
+                // Snowflakes are stored as bigint; box back to ulong so the global
+                // JSON converter emits them as strings (JS number precision).
+                if (value is long l && meta.Column(name)?.Kind == ColumnKind.Snowflake)
+                    value = unchecked((ulong)l);
+
+                row[name] = value;
+            }
+            rows.Add(row);
+        }
+
+        return rows;
     }
 
     private static async Task<long> CountAsync(

--- a/src/DiscordEventService/Controllers/TimelineController.cs
+++ b/src/DiscordEventService/Controllers/TimelineController.cs
@@ -1,6 +1,7 @@
 using System.Globalization;
 using System.Text;
 using DiscordEventService.Data;
+using DiscordEventService.Data.Entities.Events;
 using DiscordEventService.Dtos;
 using DiscordEventService.Infrastructure;
 using Microsoft.AspNetCore.Mvc;
@@ -31,27 +32,7 @@ public sealed class TimelineController(DiscordDbContext db) : ControllerBase
     {
         pageSize = Math.Clamp(pageSize, 1, MaxPageSize);
 
-        var query = db.RawEventLogs.AsNoTracking();
-
-        if (after is not null)
-        {
-            var afterUtc = after.Value.ToUtcInstant();
-            query = query.Where(r => r.ReceivedAtUtc >= afterUtc);
-        }
-        if (before is not null)
-        {
-            var beforeUtc = before.Value.ToUtcInstant();
-            query = query.Where(r => r.ReceivedAtUtc <= beforeUtc);
-        }
-        if (!string.IsNullOrWhiteSpace(eventType))
-        {
-            var types = eventType.Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
-            query = query.Where(r => types.Contains(r.EventType));
-        }
-        if (userId is not null)
-            query = query.Where(r => r.UserDiscordId == userId.Value);
-        if (channelId is not null)
-            query = query.Where(r => r.ChannelDiscordId == channelId.Value);
+        var query = ApplyFilters(db.RawEventLogs.AsNoTracking(), after, before, eventType, userId, channelId);
 
         if (TryDecodeCursor(cursor, out var cursorTs, out var cursorId))
         {
@@ -99,6 +80,37 @@ public sealed class TimelineController(DiscordDbContext db) : ControllerBase
             : null;
 
         return Ok(new TimelinePage(events, nextCursor, hasMore));
+    }
+
+    private static IQueryable<RawEventLogEntity> ApplyFilters(
+        IQueryable<RawEventLogEntity> query,
+        DateTime? after,
+        DateTime? before,
+        string? eventType,
+        ulong? userId,
+        ulong? channelId)
+    {
+        if (after is not null)
+        {
+            var afterUtc = after.Value.ToUtcInstant();
+            query = query.Where(r => r.ReceivedAtUtc >= afterUtc);
+        }
+        if (before is not null)
+        {
+            var beforeUtc = before.Value.ToUtcInstant();
+            query = query.Where(r => r.ReceivedAtUtc <= beforeUtc);
+        }
+        if (!string.IsNullOrWhiteSpace(eventType))
+        {
+            var types = eventType.Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
+            query = query.Where(r => types.Contains(r.EventType));
+        }
+        if (userId is not null)
+            query = query.Where(r => r.UserDiscordId == userId.Value);
+        if (channelId is not null)
+            query = query.Where(r => r.ChannelDiscordId == channelId.Value);
+
+        return query;
     }
 
     private static string EncodeCursor(DateTime receivedAtUtc, Guid id)

--- a/src/DiscordEventService/Jobs/BackfillJobBase.cs
+++ b/src/DiscordEventService/Jobs/BackfillJobBase.cs
@@ -20,6 +20,44 @@ internal abstract class BackfillJobBase
 
     protected Task SaveProgressAsync(DiscordDbContext db, BackfillCheckpointEntity checkpoint, CancellationToken cancellationToken) => db.SaveChangesAsync(cancellationToken);
 
+    // Fetches one REST batch of messages scrolling backwards from beforeId. Returns the
+    // batch, or a non-null failure reason when the channel is unreadable (no permission /
+    // deleted) and the per-channel loop should stop.
+    protected async Task<(List<DSharpPlus.Entities.DiscordMessage>? Messages, string? FailureReason)> FetchMessageBatchAsync(
+        DiscordDbContext db,
+        DSharpPlus.Entities.DiscordChannel channel,
+        BackfillCheckpointEntity checkpoint,
+        ulong? beforeId,
+        int batchSize,
+        ILogger logger,
+        CancellationToken cancellationToken)
+    {
+        try
+        {
+            var asyncMessages = beforeId.HasValue
+                ? channel.GetMessagesBeforeAsync(beforeId.Value, batchSize)
+                : channel.GetMessagesAsync(batchSize);
+
+            List<DSharpPlus.Entities.DiscordMessage> messages = [];
+            await foreach (var msg in asyncMessages)
+                messages.Add(msg);
+
+            return (messages, null);
+        }
+        catch (DSharpPlus.Exceptions.UnauthorizedException ex)
+        {
+            logger.LogWarning("No permission to read messages in channel {ChannelId}", channel.Id);
+            await RecordErrorAsync(db, checkpoint, ex, cancellationToken);
+            return (null, "UnauthorizedException");
+        }
+        catch (DSharpPlus.Exceptions.NotFoundException ex)
+        {
+            logger.LogWarning("Channel {ChannelId} not found (may have been deleted)", channel.Id);
+            await RecordErrorAsync(db, checkpoint, ex, cancellationToken);
+            return (null, "NotFoundException");
+        }
+    }
+
     // Drives the per-item resume-cursor loop shared by the history jobs (Messages, Reactions): skip to the
     // channel a genuinely-interrupted run stopped on (CurrentChannelId, reset to null by the executor after a
     // terminal run), then walk the rest, clearing the per-channel batch cursor (LastProcessedId) only AFTER an

--- a/src/DiscordEventService/Jobs/HealthCheckJob.cs
+++ b/src/DiscordEventService/Jobs/HealthCheckJob.cs
@@ -158,53 +158,11 @@ internal sealed class HealthCheckJob(
             .Where(r => r.ReceivedAtUtc > recentStart)
             .GroupBy(r => r.EventType)
             .Select(g => new { EventType = g.Key, Count = g.Count() })
-            .ToDictionaryAsync(g => g.EventType, g => g.Count);
+            .ToDictionaryAsync(g => g.EventType, g => g.Count, cancellationToken);
 
-        // Baseline = the same wall-clock window on each of the previous N days, so
-        // Discord's day/night activity cycle doesn't read as a drop (voice events
-        // legitimately fall to 0 overnight). Whole-day offsets keep this comparison
-        // independent of the database session timezone.
-        var baselineTotals = new Dictionary<string, int>();
-        for (var dayOffset = 1; dayOffset <= opts.EventRatioBaselineDays; dayOffset++)
-        {
-            var windowStart = recentStart.AddDays(-dayOffset);
-            var windowEnd = now.AddDays(-dayOffset);
-            var counts = await db.RawEventLogs
-                .Where(r => r.ReceivedAtUtc > windowStart && r.ReceivedAtUtc <= windowEnd)
-                .GroupBy(r => r.EventType)
-                .Select(g => new { EventType = g.Key, Count = g.Count() })
-                .ToListAsync(cancellationToken);
-            foreach (var c in counts)
-                baselineTotals[c.EventType] = baselineTotals.GetValueOrDefault(c.EventType) + c.Count;
-        }
-
-        var excluded = new HashSet<string>(opts.EventRatioExcludedEventTypes, StringComparer.OrdinalIgnoreCase);
-
-        var dropped = baselineTotals
-            .Where(b => !excluded.Contains(b.Key))
-            .Select(b => new { EventType = b.Key, ExpectedInWindow = (double)b.Value / opts.EventRatioBaselineDays })
-            .Where(b => b.ExpectedInWindow >= opts.EventRatioMinWindowBaseline)
-            .Where(b => recent.GetValueOrDefault(b.EventType, 0) < b.ExpectedInWindow * opts.EventRatioDropThreshold)
-            .ToList();
-
-        // A drop must persist across EventRatioConsecutiveRuns consecutive runs before it
-        // alerts; types that recover have their streak cleared. Only "confirmed" types are
-        // eligible — debounces transient lulls on a low-traffic server.
-        var droppedTypes = dropped.Select(d => d.EventType).ToHashSet();
-        List<string> confirmedTypes;
-        lock (_lock)
-        {
-            foreach (var key in _eventRatioDropStreaks.Keys.Where(k => !droppedTypes.Contains(k)).ToList())
-                _eventRatioDropStreaks.Remove(key);
-
-            foreach (var type in droppedTypes)
-                _eventRatioDropStreaks[type] = _eventRatioDropStreaks.GetValueOrDefault(type) + 1;
-
-            confirmedTypes = _eventRatioDropStreaks
-                .Where(kvp => kvp.Value >= opts.EventRatioConsecutiveRuns)
-                .Select(kvp => kvp.Key)
-                .ToList();
-        }
+        var baselineTotals = await ComputeBaselineTotalsAsync(db, opts, recentStart, now, cancellationToken);
+        var dropped = FindDroppedEventTypes(recent, baselineTotals, opts);
+        var confirmedTypes = ConfirmDropStreaks(dropped.Select(d => d.EventType).ToHashSet(), opts);
 
         var confirmed = dropped.Where(d => confirmedTypes.Contains(d.EventType)).ToList();
         if (confirmed.Count == 0)
@@ -257,4 +215,62 @@ internal sealed class HealthCheckJob(
             return false;
         }
     }
+
+    // Baseline = the same wall-clock window on each of the previous N days, so
+    // Discord's day/night activity cycle doesn't read as a drop (voice events
+    // legitimately fall to 0 overnight). Whole-day offsets keep this comparison
+    // independent of the database session timezone.
+    private static async Task<Dictionary<string, int>> ComputeBaselineTotalsAsync(
+        DiscordDbContext db, HealthCheckOptions opts, DateTime recentStart, DateTime now, CancellationToken cancellationToken)
+    {
+        var baselineTotals = new Dictionary<string, int>();
+        for (var dayOffset = 1; dayOffset <= opts.EventRatioBaselineDays; dayOffset++)
+        {
+            var windowStart = recentStart.AddDays(-dayOffset);
+            var windowEnd = now.AddDays(-dayOffset);
+            var counts = await db.RawEventLogs
+                .Where(r => r.ReceivedAtUtc > windowStart && r.ReceivedAtUtc <= windowEnd)
+                .GroupBy(r => r.EventType)
+                .Select(g => new { EventType = g.Key, Count = g.Count() })
+                .ToListAsync(cancellationToken);
+            foreach (var c in counts)
+                baselineTotals[c.EventType] = baselineTotals.GetValueOrDefault(c.EventType) + c.Count;
+        }
+
+        return baselineTotals;
+    }
+
+    private static List<(string EventType, double ExpectedInWindow)> FindDroppedEventTypes(
+        Dictionary<string, int> recent, Dictionary<string, int> baselineTotals, HealthCheckOptions opts)
+    {
+        var excluded = new HashSet<string>(opts.EventRatioExcludedEventTypes, StringComparer.OrdinalIgnoreCase);
+
+        return baselineTotals
+            .Where(b => !excluded.Contains(b.Key))
+            .Select(b => (EventType: b.Key, ExpectedInWindow: (double)b.Value / opts.EventRatioBaselineDays))
+            .Where(b => b.ExpectedInWindow >= opts.EventRatioMinWindowBaseline)
+            .Where(b => recent.GetValueOrDefault(b.EventType, 0) < b.ExpectedInWindow * opts.EventRatioDropThreshold)
+            .ToList();
+    }
+
+    // A drop must persist across EventRatioConsecutiveRuns consecutive runs before it
+    // alerts; types that recover have their streak cleared. Only "confirmed" types are
+    // eligible — debounces transient lulls on a low-traffic server.
+    private static List<string> ConfirmDropStreaks(HashSet<string> droppedTypes, HealthCheckOptions opts)
+    {
+        lock (_lock)
+        {
+            foreach (var key in _eventRatioDropStreaks.Keys.Where(k => !droppedTypes.Contains(k)).ToList())
+                _eventRatioDropStreaks.Remove(key);
+
+            foreach (var type in droppedTypes)
+                _eventRatioDropStreaks[type] = _eventRatioDropStreaks.GetValueOrDefault(type) + 1;
+
+            return _eventRatioDropStreaks
+                .Where(kvp => kvp.Value >= opts.EventRatioConsecutiveRuns)
+                .Select(kvp => kvp.Key)
+                .ToList();
+        }
+    }
+
 }

--- a/src/DiscordEventService/Jobs/HealthCheckJob.cs
+++ b/src/DiscordEventService/Jobs/HealthCheckJob.cs
@@ -272,5 +272,4 @@ internal sealed class HealthCheckJob(
                 .ToList();
         }
     }
-
 }

--- a/src/DiscordEventService/Jobs/MemeIndexingJob.cs
+++ b/src/DiscordEventService/Jobs/MemeIndexingJob.cs
@@ -242,5 +242,4 @@ internal sealed class MemeIndexingJob(
             }
         }
     }
-
 }

--- a/src/DiscordEventService/Jobs/MemeIndexingJob.cs
+++ b/src/DiscordEventService/Jobs/MemeIndexingJob.cs
@@ -53,15 +53,7 @@ internal sealed class MemeIndexingJob(
             .OrderBy(c => c.AttachmentDiscordId)
             .ToList();
 
-        // Terminal rows stay untouched — relevant when Hangfire retries this
-        // job after a crash that landed between attachments.
-        var attachmentIds = candidates.Select(c => c.AttachmentDiscordId).ToList();
-        var terminal = await db.MemeIndex
-            .Where(m => attachmentIds.Contains(m.AttachmentDiscordId)
-                        && (m.Status == MemeIndexStatus.Indexed || m.Status == MemeIndexStatus.Skipped))
-            .Select(m => m.AttachmentDiscordId)
-            .ToListAsync(cancellationToken);
-        var pending = candidates.Where(c => !terminal.Contains(c.AttachmentDiscordId)).ToList();
+        var pending = await FilterTerminalAsync(db, candidates, cancellationToken);
 
         if (pending.Count == 0)
         {
@@ -137,34 +129,7 @@ internal sealed class MemeIndexingJob(
                 guildId, pending.Count, openRouterOptions.Model);
 
             var counters = new MemeIndexRunCounters();
-
-            var position = 0;
-            foreach (var batch in pending.Chunk(UrlRefreshBatchSize))
-            {
-                cancellationToken.ThrowIfCancellationRequested();
-
-                var freshUrls = await urlRefreshService.RefreshAsync(
-                    batch.Select(b => b.StoredUrl).ToList(), cancellationToken);
-
-                foreach (var item in batch)
-                {
-                    cancellationToken.ThrowIfCancellationRequested();
-
-                    var row = await indexer.GetOrCreateRowAsync(ctx.Db, item, cancellationToken);
-                    await indexer.ProcessOneAsync(ctx.Db, row, item, freshUrls, counters, cancellationToken);
-
-                    position++;
-                    ctx.Checkpoint.ProcessedCount++;
-                    // Advance the resume cursor only once a message's LAST pending
-                    // attachment is done — a mid-message cursor would skip siblings.
-                    var lastOfMessage = position == pending.Count
-                        || pending[position].MessageDiscordId != item.MessageDiscordId;
-                    if (lastOfMessage)
-                        ctx.Checkpoint.LastProcessedId = item.MessageDiscordId;
-
-                    await SaveProgressAsync(ctx.Db, ctx.Checkpoint, cancellationToken);
-                }
-            }
+            await ProcessPendingBatchesAsync(ctx, indexer, urlRefreshService, pending, counters, cancellationToken);
 
             logger.LogInformation(
                 "Meme indexing finished for guild {GuildId}: {Indexed} indexed, {Deduped} deduped, {Skipped} skipped, {Failed} failed; " +
@@ -226,4 +191,56 @@ internal sealed class MemeIndexingJob(
 
         return pending;
     }
+
+    // Terminal rows stay untouched — relevant when Hangfire retries this
+    // job after a crash that landed between attachments.
+    private static async Task<List<MemeSampleItem>> FilterTerminalAsync(
+        DiscordDbContext db, List<MemeSampleItem> candidates, CancellationToken cancellationToken)
+    {
+        var attachmentIds = candidates.Select(c => c.AttachmentDiscordId).ToList();
+        var terminal = await db.MemeIndex
+            .Where(m => attachmentIds.Contains(m.AttachmentDiscordId)
+                        && (m.Status == MemeIndexStatus.Indexed || m.Status == MemeIndexStatus.Skipped))
+            .Select(m => m.AttachmentDiscordId)
+            .ToListAsync(cancellationToken);
+        return candidates.Where(c => !terminal.Contains(c.AttachmentDiscordId)).ToList();
+    }
+
+    private async Task ProcessPendingBatchesAsync(
+        BackfillContext ctx,
+        MemeAttachmentIndexer indexer,
+        AttachmentUrlRefreshService urlRefreshService,
+        List<MemeSampleItem> pending,
+        MemeIndexRunCounters counters,
+        CancellationToken cancellationToken)
+    {
+        var position = 0;
+        foreach (var batch in pending.Chunk(UrlRefreshBatchSize))
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+
+            var freshUrls = await urlRefreshService.RefreshAsync(
+                batch.Select(b => b.StoredUrl).ToList(), cancellationToken);
+
+            foreach (var item in batch)
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+
+                var row = await indexer.GetOrCreateRowAsync(ctx.Db, item, cancellationToken);
+                await indexer.ProcessOneAsync(ctx.Db, row, item, freshUrls, counters, cancellationToken);
+
+                position++;
+                ctx.Checkpoint.ProcessedCount++;
+                // Advance the resume cursor only once a message's LAST pending
+                // attachment is done — a mid-message cursor would skip siblings.
+                var lastOfMessage = position == pending.Count
+                    || pending[position].MessageDiscordId != item.MessageDiscordId;
+                if (lastOfMessage)
+                    ctx.Checkpoint.LastProcessedId = item.MessageDiscordId;
+
+                await SaveProgressAsync(ctx.Db, ctx.Checkpoint, cancellationToken);
+            }
+        }
+    }
+
 }

--- a/src/DiscordEventService/Jobs/MessagesBackfillJob.cs
+++ b/src/DiscordEventService/Jobs/MessagesBackfillJob.cs
@@ -83,33 +83,14 @@ internal sealed class MessagesBackfillJob(
             cancellationToken.ThrowIfCancellationRequested();
             batchNum++;
 
-            List<DiscordMessage> messages;
-            try
+            var (messages, fetchFailure) = await FetchMessageBatchAsync(db, channel, checkpoint, beforeId, BatchSize, logger, cancellationToken);
+            if (fetchFailure is not null)
             {
-                var asyncMessages = beforeId.HasValue
-                    ? channel.GetMessagesBeforeAsync(beforeId.Value, BatchSize)
-                    : channel.GetMessagesAsync(BatchSize);
-
-                messages = [];
-                await foreach (var msg in asyncMessages)
-                    messages.Add(msg);
-            }
-            catch (DSharpPlus.Exceptions.UnauthorizedException ex)
-            {
-                logger.LogWarning("No permission to read messages in channel {ChannelId}", channel.Id);
-                await RecordErrorAsync(db, checkpoint, ex, cancellationToken);
-                exitReason = "UnauthorizedException";
-                break;
-            }
-            catch (DSharpPlus.Exceptions.NotFoundException ex)
-            {
-                logger.LogWarning("Channel {ChannelId} not found (may have been deleted)", channel.Id);
-                await RecordErrorAsync(db, checkpoint, ex, cancellationToken);
-                exitReason = "NotFoundException";
+                exitReason = fetchFailure;
                 break;
             }
 
-            if (messages.Count == 0)
+            if (messages!.Count == 0)
             {
                 logger.LogDebug(
                     "Channel {ChannelName} batch {BatchNum} returned no messages before cursor {BeforeId}; stopping",
@@ -131,76 +112,8 @@ internal sealed class MessagesBackfillJob(
             {
                 try
                 {
-                    if (message.Author is null)
+                    if (await TryInsertBackfilledMessageAsync(db, userService, message, channelEntity, guildEntity, channel, cancellationToken))
                     {
-                        logger.LogDebug("Message {MessageId} has null author, skipping", message.Id);
-                        continue;
-                    }
-
-                    await userService.UpsertUserAsync(message.Author);
-
-                    var authorEntity = await db.Users.FirstOrDefaultAsync(u => u.DiscordId == message.Author.Id, cancellationToken);
-
-                    var exists = await db.Messages.AnyAsync(m => m.DiscordId == message.Id, cancellationToken);
-                    if (!exists)
-                    {
-                        // §P2.6: MessageEntity.ChannelId/GuildId/AuthorId are NOT NULL. Skip
-                        // if any required FK row hasn't been backfilled yet — next run of
-                        // the corresponding backfill job + the next MessagesBackfillJob will
-                        // pick it up.
-                        if (channelEntity is null || authorEntity is null)
-                        {
-                            logger.LogWarning(
-                                "Skipping backfill insert for message {MessageId}: channel resolved {ChannelPresent}, author resolved {AuthorPresent}",
-                                message.Id, channelEntity is not null, authorEntity is not null);
-                            continue;
-                        }
-                        var attachmentsJson = message.Attachments.Count > 0
-                            ? JsonSerializer.Serialize(message.Attachments.Select(a => new { a.Id, a.Url, a.FileName, a.FileSize }))
-                            : null;
-                        var embedsJson = message.Embeds.Count > 0
-                            ? JsonSerializer.Serialize(message.Embeds)
-                            : null;
-
-                        db.Messages.Add(new MessageEntity
-                        {
-                            DiscordId = message.Id,
-                            ChannelId = channelEntity.Id,
-                            GuildId = guildEntity.Id,
-                            AuthorId = authorEntity.Id,
-                            Content = string.IsNullOrEmpty(message.Content) ? null : message.Content,
-                            ReplyToDiscordId = message.ReferencedMessage?.Id,
-                            HasAttachments = message.Attachments.Count > 0,
-                            HasEmbeds = message.Embeds.Count > 0,
-                            AttachmentsJson = attachmentsJson,
-                            EmbedsJson = embedsJson,
-                            Flags = (int)(message.Flags ?? 0),
-                            CreatedAtUtc = message.Timestamp.UtcDateTime,
-                            EditedAtUtc = message.EditedTimestamp?.UtcDateTime
-                        });
-
-                        // Symmetric provenance marker: every backfilled message gets a
-                        // message_events row with EventType=Backfilled. Mirrors
-                        // ReactionsBackfillJob's ReactionEventType.Backfilled pattern.
-                        // RawEventJson is null because backfill came via REST, not gateway.
-                        db.MessageEvents.Add(new MessageEventEntity
-                        {
-                            MessageDiscordId = message.Id,
-                            ChannelDiscordId = channel.Id,
-                            AuthorDiscordId = message.Author.Id,
-                            GuildDiscordId = guildEntity.DiscordId,
-                            EventType = MessageEventType.Backfilled,
-                            Content = string.IsNullOrEmpty(message.Content) ? null : message.Content,
-                            HasAttachments = message.Attachments.Count > 0,
-                            HasEmbeds = message.Embeds.Count > 0,
-                            ReplyToMessageDiscordId = message.ReferencedMessage?.Id,
-                            AttachmentsJson = attachmentsJson,
-                            EmbedsJson = embedsJson,
-                            EventTimestampUtc = message.Timestamp.UtcDateTime,
-                            ReceivedAtUtc = DateTime.UtcNow,
-                            RawEventJson = null
-                        });
-
                         checkpoint.ProcessedCount++;
                         totalInserted++;
                     }
@@ -235,4 +148,102 @@ internal sealed class MessagesBackfillJob(
             "Channel {ChannelName} ({ChannelId}) done after {BatchCount} batches: inserted {InsertedCount} messages, stopped because {ExitReason}, cursor at {BeforeId}",
             channel.Name, channel.Id, batchNum, totalInserted, exitReason, beforeId);
     }
+
+    private async Task<bool> TryInsertBackfilledMessageAsync(
+        DiscordDbContext db,
+        UserService userService,
+        DiscordMessage message,
+        ChannelEntity? channelEntity,
+        GuildEntity guildEntity,
+        DiscordChannel channel,
+        CancellationToken cancellationToken)
+    {
+        if (message.Author is null)
+        {
+            logger.LogDebug("Message {MessageId} has null author, skipping", message.Id);
+            return false;
+        }
+
+        await userService.UpsertUserAsync(message.Author);
+
+        var authorEntity = await db.Users.FirstOrDefaultAsync(u => u.DiscordId == message.Author.Id, cancellationToken);
+
+        var exists = await db.Messages.AnyAsync(m => m.DiscordId == message.Id, cancellationToken);
+        if (exists) return false;
+
+        // §P2.6: MessageEntity.ChannelId/GuildId/AuthorId are NOT NULL. Skip
+        // if any required FK row hasn't been backfilled yet — next run of
+        // the corresponding backfill job + the next MessagesBackfillJob will
+        // pick it up.
+        if (channelEntity is null || authorEntity is null)
+        {
+            logger.LogWarning(
+                "Skipping backfill insert for message {MessageId}: channel resolved {ChannelPresent}, author resolved {AuthorPresent}",
+                message.Id, channelEntity is not null, authorEntity is not null);
+            return false;
+        }
+
+        var attachmentsJson = message.Attachments.Count > 0
+            ? JsonSerializer.Serialize(message.Attachments.Select(a => new { a.Id, a.Url, a.FileName, a.FileSize }))
+            : null;
+        var embedsJson = message.Embeds.Count > 0
+            ? JsonSerializer.Serialize(message.Embeds)
+            : null;
+
+        db.Messages.Add(BuildBackfilledMessage(message, channelEntity, guildEntity, authorEntity, attachmentsJson, embedsJson));
+
+        // Symmetric provenance marker: every backfilled message gets a
+        // message_events row with EventType=Backfilled. Mirrors
+        // ReactionsBackfillJob's ReactionEventType.Backfilled pattern.
+        // RawEventJson is null because backfill came via REST, not gateway.
+        db.MessageEvents.Add(BuildBackfilledMessageEvent(message, channel, guildEntity, attachmentsJson, embedsJson));
+
+        return true;
+    }
+
+    private static MessageEntity BuildBackfilledMessage(
+        DiscordMessage message,
+        ChannelEntity channelEntity,
+        GuildEntity guildEntity,
+        UserEntity authorEntity,
+        string? attachmentsJson,
+        string? embedsJson) => new MessageEntity
+        {
+            DiscordId = message.Id,
+            ChannelId = channelEntity.Id,
+            GuildId = guildEntity.Id,
+            AuthorId = authorEntity.Id,
+            Content = string.IsNullOrEmpty(message.Content) ? null : message.Content,
+            ReplyToDiscordId = message.ReferencedMessage?.Id,
+            HasAttachments = message.Attachments.Count > 0,
+            HasEmbeds = message.Embeds.Count > 0,
+            AttachmentsJson = attachmentsJson,
+            EmbedsJson = embedsJson,
+            Flags = (int)(message.Flags ?? 0),
+            CreatedAtUtc = message.Timestamp.UtcDateTime,
+            EditedAtUtc = message.EditedTimestamp?.UtcDateTime
+        };
+
+    private static MessageEventEntity BuildBackfilledMessageEvent(
+        DiscordMessage message,
+        DiscordChannel channel,
+        GuildEntity guildEntity,
+        string? attachmentsJson,
+        string? embedsJson) => new MessageEventEntity
+        {
+            MessageDiscordId = message.Id,
+            ChannelDiscordId = channel.Id,
+            AuthorDiscordId = message.Author!.Id,
+            GuildDiscordId = guildEntity.DiscordId,
+            EventType = MessageEventType.Backfilled,
+            Content = string.IsNullOrEmpty(message.Content) ? null : message.Content,
+            HasAttachments = message.Attachments.Count > 0,
+            HasEmbeds = message.Embeds.Count > 0,
+            ReplyToMessageDiscordId = message.ReferencedMessage?.Id,
+            AttachmentsJson = attachmentsJson,
+            EmbedsJson = embedsJson,
+            EventTimestampUtc = message.Timestamp.UtcDateTime,
+            ReceivedAtUtc = DateTime.UtcNow,
+            RawEventJson = null
+        };
 }

--- a/src/DiscordEventService/Jobs/ReactionsBackfillJob.cs
+++ b/src/DiscordEventService/Jobs/ReactionsBackfillJob.cs
@@ -73,31 +73,11 @@ internal sealed class ReactionsBackfillJob(
         {
             cancellationToken.ThrowIfCancellationRequested();
 
-            List<DiscordMessage> messages;
-            try
-            {
-                var asyncMessages = beforeId.HasValue
-                    ? channel.GetMessagesBeforeAsync(beforeId.Value, MessageBatchSize)
-                    : channel.GetMessagesAsync(MessageBatchSize);
-
-                messages = [];
-                await foreach (var msg in asyncMessages)
-                    messages.Add(msg);
-            }
-            catch (DSharpPlus.Exceptions.UnauthorizedException ex)
-            {
-                logger.LogWarning("No permission to read messages in channel {ChannelId}", channel.Id);
-                await RecordErrorAsync(db, checkpoint, ex, cancellationToken);
+            var (messages, fetchFailure) = await FetchMessageBatchAsync(db, channel, checkpoint, beforeId, MessageBatchSize, logger, cancellationToken);
+            if (fetchFailure is not null)
                 break;
-            }
-            catch (DSharpPlus.Exceptions.NotFoundException ex)
-            {
-                logger.LogWarning("Channel {ChannelId} not found (may have been deleted)", channel.Id);
-                await RecordErrorAsync(db, checkpoint, ex, cancellationToken);
-                break;
-            }
 
-            if (messages.Count == 0)
+            if (messages!.Count == 0)
             {
                 hasMore = false;
                 break;

--- a/src/DiscordEventService/Program.cs
+++ b/src/DiscordEventService/Program.cs
@@ -1,17 +1,12 @@
-using DiscordEventService.Commands;
 using DiscordEventService.Configuration;
 using DiscordEventService.Data;
 using DiscordEventService.Endpoints;
 using DiscordEventService.Infrastructure;
 using DiscordEventService.Jobs;
 using DiscordEventService.Services;
-using DiscordEventService.Services.EventHandlers;
 using DiscordEventService.Services.MemeIndexing;
-using DiscordEventService.Services.Pipeline;
 using DotNetEnv;
 using DSharpPlus;
-using DSharpPlus.Commands;
-using DSharpPlus.Commands.Processors.SlashCommands;
 using Hangfire;
 using Hangfire.PostgreSql;
 using Microsoft.EntityFrameworkCore;
@@ -81,87 +76,9 @@ void AddDiscordDbContext(IServiceCollection services) =>
 
 AddDiscordDbContext(builder.Services);
 
-// Discord Client with services configured for DI
-var discordToken = builder.Configuration.GetSection(DiscordOptions.SectionName).Get<DiscordOptions>()?.Token
-    ?? throw new InvalidOperationException("Discord:Token is required");
-var commandGuildId = builder.Configuration.GetSection(DiscordOptions.SectionName).Get<DiscordOptions>()?.CommandGuildId;
-
-builder.Services.AddSingleton(rootSp =>
-{
-    var clientBuilder = DiscordClientBuilder.CreateDefault(discordToken, DiscordIntents.All);
-
-    // Register ASP.NET Core services in DSharpPlus's DI container. Services event
-    // handlers share with the root container come from AddCoreServices(); add new
-    // shared services to CoreServiceRegistration.CoreServiceTypes (one line, both
-    // containers + StartupValidator pick them up automatically).
-    clientBuilder.ConfigureServices(services =>
-    {
-        AddDiscordDbContext(services);
-
-        services.AddSingleton<IHostEnvironment>(builder.Environment);
-        services.AddSingleton<EventPipeline>();
-        services.AddCoreServices();
-        // #222: MessageEventHandler's live meme-index hook reads the configured
-        // meme channels; root-container option bindings aren't visible here.
-        services.AddOptions<MemeIndexOptions>()
-            .Bind(builder.Configuration.GetSection(MemeIndexOptions.SectionName));
-        // IBackgroundJobClient forwards to the root container's registration.
-        // Hangfire registers IBackgroundJobClient as Transient with DI-based
-        // JobStorage resolution; using `new BackgroundJobClient()` directly
-        // would read JobStorage.Current (a static set by AddHangfireServer's
-        // HostedService at app.Run() time), which is null at validator time
-        // post-Build but pre-Run. Forwarding resolves through Hangfire's
-        // DI-aware factory which works at any time after Build.
-        services.AddSingleton<IBackgroundJobClient>(_ => rootSp.GetRequiredService<IBackgroundJobClient>());
-        services.AddMemoryCache();
-    });
-
-    clientBuilder.ConfigureEventHandlers(b => b
-        .AddEventHandlers<MessageEventHandler>(ServiceLifetime.Scoped)
-        .AddEventHandlers<ReactionEventHandler>(ServiceLifetime.Scoped)
-        .AddEventHandlers<PollEventHandler>(ServiceLifetime.Scoped)
-        .AddEventHandlers<PinEventHandler>(ServiceLifetime.Scoped)
-        .AddEventHandlers<VoiceEventHandler>(ServiceLifetime.Scoped)
-        .AddEventHandlers<VoiceServerEventHandler>(ServiceLifetime.Scoped)
-        .AddEventHandlers<PresenceEventHandler>(ServiceLifetime.Scoped)
-        .AddEventHandlers<MemberEventHandler>(ServiceLifetime.Scoped)
-        .AddEventHandlers<BanEventHandler>(ServiceLifetime.Scoped)
-        .AddEventHandlers<GuildMembersChunkHandler>(ServiceLifetime.Scoped)
-        .AddEventHandlers<GuildEventHandler>(ServiceLifetime.Scoped)
-        .AddEventHandlers<GuildUpdateEventHandler>(ServiceLifetime.Scoped)
-        .AddEventHandlers<EmojiEventHandler>(ServiceLifetime.Scoped)
-        .AddEventHandlers<StickerEventHandler>(ServiceLifetime.Scoped)
-        .AddEventHandlers<ChannelEventHandler>(ServiceLifetime.Scoped)
-        .AddEventHandlers<RoleEventHandler>(ServiceLifetime.Scoped)
-        .AddEventHandlers<ThreadEventHandler>(ServiceLifetime.Scoped)
-        .AddEventHandlers<ThreadSyncHandler>(ServiceLifetime.Scoped)
-        .AddEventHandlers<StageInstanceEventHandler>(ServiceLifetime.Scoped)
-        .AddEventHandlers<ScheduledEventHandler>(ServiceLifetime.Scoped)
-        .AddEventHandlers<AutoModEventHandler>(ServiceLifetime.Scoped)
-        .AddEventHandlers<AutoModRuleEventHandler>(ServiceLifetime.Scoped)
-        .AddEventHandlers<InviteEventHandler>(ServiceLifetime.Scoped)
-        .AddEventHandlers<TypingEventHandler>(ServiceLifetime.Scoped)
-        .AddEventHandlers<WebhookEventHandler>(ServiceLifetime.Scoped)
-        .AddEventHandlers<IntegrationEventHandler>(ServiceLifetime.Scoped)
-        .AddEventHandlers<AuditLogEventHandler>(ServiceLifetime.Scoped)
-        .AddEventHandlers<SocketLifecycleHandler>(ServiceLifetime.Scoped)
-    );
-
-    // #224: the bot's first user-facing command. Slash-only (no text-prefix
-    // processor — the bot must keep ignoring message content), guild-scoped
-    // registration so it shows up instantly. Without Discord:CommandGuildId
-    // the commands subsystem isn't wired at all (pure passive logger).
-    if (commandGuildId is { } commandGuild)
-    {
-        clientBuilder.UseCommands((_, extension) =>
-        {
-            extension.AddProcessor(new SlashCommandProcessor());
-            extension.AddCommands([typeof(MemeCommand)], commandGuild);
-        }, new CommandsConfiguration { RegisterDefaultCommandProcessors = false });
-    }
-
-    return clientBuilder.Build();
-});
+// Discord Client with services configured for DI: child container, event-handler
+// roster and slash commands live in DiscordClientRegistration.
+builder.Services.AddDiscordClient(builder.Configuration, builder.Environment, AddDiscordDbContext);
 
 // Order is load-bearing: DiscordHostedService.StartAsync runs InferStartupGapAsync
 // (against the stale last_heartbeat_utc) before HeartbeatBackgroundService can write

--- a/src/DiscordEventService/Services/DiscordClientRegistration.cs
+++ b/src/DiscordEventService/Services/DiscordClientRegistration.cs
@@ -1,0 +1,121 @@
+using DiscordEventService.Commands;
+using DiscordEventService.Configuration;
+using DiscordEventService.Services.EventHandlers;
+using DiscordEventService.Services.Pipeline;
+using DSharpPlus;
+using DSharpPlus.Commands;
+using DSharpPlus.Commands.Processors.SlashCommands;
+using Hangfire;
+
+namespace DiscordEventService.Services;
+
+// Builds the DSharpPlus client singleton: the child DI container, the full
+// event-handler roster, and the slash-command subsystem. Services the child
+// container shares with the root come from AddCoreServices() — see
+// CoreServiceRegistration.
+internal static class DiscordClientRegistration
+{
+    public static void AddDiscordClient(
+        this IServiceCollection rootServices,
+        IConfiguration configuration,
+        IHostEnvironment environment,
+        Action<IServiceCollection> addDiscordDbContext)
+    {
+        var discordToken = configuration.GetSection(DiscordOptions.SectionName).Get<DiscordOptions>()?.Token
+            ?? throw new InvalidOperationException("Discord:Token is required");
+        var commandGuildId = configuration.GetSection(DiscordOptions.SectionName).Get<DiscordOptions>()?.CommandGuildId;
+
+        rootServices.AddSingleton(rootSp =>
+        {
+            var clientBuilder = DiscordClientBuilder.CreateDefault(discordToken, DiscordIntents.All);
+
+            ConfigureChildServices(clientBuilder, rootSp, configuration, environment, addDiscordDbContext);
+            ConfigureEventHandlers(clientBuilder);
+            ConfigureCommands(clientBuilder, commandGuildId);
+
+            return clientBuilder.Build();
+        });
+    }
+
+    // Register ASP.NET Core services in DSharpPlus's DI container. Services event
+    // handlers share with the root container come from AddCoreServices(); add new
+    // shared services to CoreServiceRegistration.CoreServiceTypes (one line, both
+    // containers + StartupValidator pick them up automatically).
+    private static void ConfigureChildServices(
+        DiscordClientBuilder clientBuilder,
+        IServiceProvider rootSp,
+        IConfiguration configuration,
+        IHostEnvironment environment,
+        Action<IServiceCollection> addDiscordDbContext)
+    {
+        clientBuilder.ConfigureServices(services =>
+        {
+            addDiscordDbContext(services);
+
+            services.AddSingleton(environment);
+            services.AddSingleton<EventPipeline>();
+            services.AddCoreServices();
+            // #222: MessageEventHandler's live meme-index hook reads the configured
+            // meme channels; root-container option bindings aren't visible here.
+            services.AddOptions<MemeIndexOptions>()
+                .Bind(configuration.GetSection(MemeIndexOptions.SectionName));
+            // IBackgroundJobClient forwards to the root container's registration.
+            // Hangfire registers IBackgroundJobClient as Transient with DI-based
+            // JobStorage resolution; using `new BackgroundJobClient()` directly
+            // would read JobStorage.Current (a static set by AddHangfireServer's
+            // HostedService at app.Run() time), which is null at validator time
+            // post-Build but pre-Run. Forwarding resolves through Hangfire's
+            // DI-aware factory which works at any time after Build.
+            services.AddSingleton<IBackgroundJobClient>(_ => rootSp.GetRequiredService<IBackgroundJobClient>());
+            services.AddMemoryCache();
+        });
+    }
+
+    private static void ConfigureEventHandlers(DiscordClientBuilder clientBuilder) =>
+        clientBuilder.ConfigureEventHandlers(b => b
+            .AddEventHandlers<MessageEventHandler>(ServiceLifetime.Scoped)
+            .AddEventHandlers<ReactionEventHandler>(ServiceLifetime.Scoped)
+            .AddEventHandlers<PollEventHandler>(ServiceLifetime.Scoped)
+            .AddEventHandlers<PinEventHandler>(ServiceLifetime.Scoped)
+            .AddEventHandlers<VoiceEventHandler>(ServiceLifetime.Scoped)
+            .AddEventHandlers<VoiceServerEventHandler>(ServiceLifetime.Scoped)
+            .AddEventHandlers<PresenceEventHandler>(ServiceLifetime.Scoped)
+            .AddEventHandlers<MemberEventHandler>(ServiceLifetime.Scoped)
+            .AddEventHandlers<BanEventHandler>(ServiceLifetime.Scoped)
+            .AddEventHandlers<GuildMembersChunkHandler>(ServiceLifetime.Scoped)
+            .AddEventHandlers<GuildEventHandler>(ServiceLifetime.Scoped)
+            .AddEventHandlers<GuildUpdateEventHandler>(ServiceLifetime.Scoped)
+            .AddEventHandlers<EmojiEventHandler>(ServiceLifetime.Scoped)
+            .AddEventHandlers<StickerEventHandler>(ServiceLifetime.Scoped)
+            .AddEventHandlers<ChannelEventHandler>(ServiceLifetime.Scoped)
+            .AddEventHandlers<RoleEventHandler>(ServiceLifetime.Scoped)
+            .AddEventHandlers<ThreadEventHandler>(ServiceLifetime.Scoped)
+            .AddEventHandlers<ThreadSyncHandler>(ServiceLifetime.Scoped)
+            .AddEventHandlers<StageInstanceEventHandler>(ServiceLifetime.Scoped)
+            .AddEventHandlers<ScheduledEventHandler>(ServiceLifetime.Scoped)
+            .AddEventHandlers<AutoModEventHandler>(ServiceLifetime.Scoped)
+            .AddEventHandlers<AutoModRuleEventHandler>(ServiceLifetime.Scoped)
+            .AddEventHandlers<InviteEventHandler>(ServiceLifetime.Scoped)
+            .AddEventHandlers<TypingEventHandler>(ServiceLifetime.Scoped)
+            .AddEventHandlers<WebhookEventHandler>(ServiceLifetime.Scoped)
+            .AddEventHandlers<IntegrationEventHandler>(ServiceLifetime.Scoped)
+            .AddEventHandlers<AuditLogEventHandler>(ServiceLifetime.Scoped)
+            .AddEventHandlers<SocketLifecycleHandler>(ServiceLifetime.Scoped)
+        );
+
+    // #224: the bot's first user-facing command. Slash-only (no text-prefix
+    // processor — the bot must keep ignoring message content), guild-scoped
+    // registration so it shows up instantly. Without Discord:CommandGuildId
+    // the commands subsystem isn't wired at all (pure passive logger).
+    private static void ConfigureCommands(DiscordClientBuilder clientBuilder, ulong? commandGuildId)
+    {
+        if (commandGuildId is { } commandGuild)
+        {
+            clientBuilder.UseCommands((_, extension) =>
+            {
+                extension.AddProcessor(new SlashCommandProcessor());
+                extension.AddCommands([typeof(MemeCommand)], commandGuild);
+            }, new CommandsConfiguration { RegisterDefaultCommandProcessors = false });
+        }
+    }
+}

--- a/src/DiscordEventService/Services/MemeIndexing/MemeAttachmentIndexer.cs
+++ b/src/DiscordEventService/Services/MemeIndexing/MemeAttachmentIndexer.cs
@@ -70,24 +70,8 @@ internal sealed class MemeAttachmentIndexer(
             return;
         }
 
-        byte[] imageBytes;
-        try
-        {
-            var client = httpClientFactory.CreateClient(MemeBenchmarkJob.DownloadHttpClientName);
-            imageBytes = await client.GetByteArrayAsync(freshUrl, cancellationToken);
-        }
-        catch (HttpRequestException ex) when (ex.StatusCode is System.Net.HttpStatusCode.NotFound
-            or System.Net.HttpStatusCode.Forbidden or System.Net.HttpStatusCode.Gone)
-        {
-            Skip(row, counters, $"dead attachment: download HTTP {(int)ex.StatusCode!}");
-            return;
-        }
-        catch (Exception ex) when (ex is HttpRequestException
-            || (ex is TaskCanceledException && !cancellationToken.IsCancellationRequested))
-        {
-            Fail(row, counters, $"download failed: {ex.Message}");
-            return;
-        }
+        var imageBytes = await DownloadImageAsync(freshUrl, row, counters, cancellationToken);
+        if (imageBytes is null) return;
 
         row.FileSizeBytes = imageBytes.Length;
 
@@ -108,32 +92,8 @@ internal sealed class MemeAttachmentIndexer(
         var contentHash = Convert.ToHexStringLower(SHA256.HashData(imageBytes));
         row.ContentHash = contentHash;
 
-        // Repost dedupe: same bytes already Indexed → copy its metadata, no
-        // model call. RawResponseJson stays null — provenance lives on the
-        // original row, found via the shared content_hash.
-        var original = await db.MemeIndex.AsNoTracking()
-            .Where(m => m.ContentHash == contentHash && m.Status == MemeIndexStatus.Indexed && m.Id != row.Id)
-            .Select(m => new { m.DescriptionPl, m.DescriptionEn, m.OcrText, m.Tags, m.Source, m.Template, m.ModelId })
-            .FirstOrDefaultAsync(cancellationToken);
-
-        if (original is not null)
-        {
-            row.DescriptionPl = original.DescriptionPl;
-            row.DescriptionEn = original.DescriptionEn;
-            row.OcrText = original.OcrText;
-            row.Tags = original.Tags;
-            row.Source = original.Source;
-            row.Template = original.Template;
-            row.ModelId = original.ModelId;
-            row.RawResponseJson = null;
-            row.IndexedAtUtc = DateTime.UtcNow;
-            row.Status = MemeIndexStatus.Indexed;
-            row.Error = null;
-            counters.Deduped++;
-            logger.LogDebug("Meme attachment {AttachmentId} deduped via content hash {ContentHash}",
-                row.AttachmentDiscordId, contentHash);
+        if (await TryDedupeByContentHashAsync(db, row, contentHash, counters, cancellationToken))
             return;
-        }
 
         var result = await openRouterClient.AnalyzeImageAsync(imageBytes, mimeType, openRouter.Model, cancellationToken);
         counters.ModelCalls++;
@@ -141,6 +101,67 @@ internal sealed class MemeAttachmentIndexer(
         counters.CompletionTokens += result.Usage?.CompletionTokens ?? 0;
         counters.CostUsd += result.Usage?.CostUsd ?? 0;
 
+        ApplyAnalysisResult(row, result, openRouter.Model, counters);
+
+        await Task.Delay(TimeSpan.FromMilliseconds(openRouter.RequestDelayMs), cancellationToken);
+    }
+
+    // Returns null when the row was already terminally marked (Skip on dead/oversized
+    // attachment, Fail on transient download error) and processing should stop.
+    private async Task<byte[]?> DownloadImageAsync(
+        string freshUrl, MemeIndexEntity row, MemeIndexRunCounters counters, CancellationToken cancellationToken)
+    {
+        try
+        {
+            var client = httpClientFactory.CreateClient(MemeBenchmarkJob.DownloadHttpClientName);
+            return await client.GetByteArrayAsync(freshUrl, cancellationToken);
+        }
+        catch (HttpRequestException ex) when (ex.StatusCode is System.Net.HttpStatusCode.NotFound
+            or System.Net.HttpStatusCode.Forbidden or System.Net.HttpStatusCode.Gone)
+        {
+            Skip(row, counters, $"dead attachment: download HTTP {(int)ex.StatusCode!}");
+            return null;
+        }
+        catch (Exception ex) when (ex is HttpRequestException
+            || (ex is TaskCanceledException && !cancellationToken.IsCancellationRequested))
+        {
+            Fail(row, counters, $"download failed: {ex.Message}");
+            return null;
+        }
+    }
+
+    // Repost dedupe: same bytes already Indexed → copy its metadata, no
+    // model call. RawResponseJson stays null — provenance lives on the
+    // original row, found via the shared content_hash.
+    private async Task<bool> TryDedupeByContentHashAsync(
+        DiscordDbContext db, MemeIndexEntity row, string contentHash, MemeIndexRunCounters counters, CancellationToken cancellationToken)
+    {
+        var original = await db.MemeIndex.AsNoTracking()
+            .Where(m => m.ContentHash == contentHash && m.Status == MemeIndexStatus.Indexed && m.Id != row.Id)
+            .Select(m => new { m.DescriptionPl, m.DescriptionEn, m.OcrText, m.Tags, m.Source, m.Template, m.ModelId })
+            .FirstOrDefaultAsync(cancellationToken);
+
+        if (original is null) return false;
+
+        row.DescriptionPl = original.DescriptionPl;
+        row.DescriptionEn = original.DescriptionEn;
+        row.OcrText = original.OcrText;
+        row.Tags = original.Tags;
+        row.Source = original.Source;
+        row.Template = original.Template;
+        row.ModelId = original.ModelId;
+        row.RawResponseJson = null;
+        row.IndexedAtUtc = DateTime.UtcNow;
+        row.Status = MemeIndexStatus.Indexed;
+        row.Error = null;
+        counters.Deduped++;
+        logger.LogDebug("Meme attachment {AttachmentId} deduped via content hash {ContentHash}",
+            row.AttachmentDiscordId, contentHash);
+        return true;
+    }
+
+    private void ApplyAnalysisResult(MemeIndexEntity row, MemeAnalysisResult result, string model, MemeIndexRunCounters counters)
+    {
         switch (result.Outcome)
         {
             case MemeAnalysisOutcome.Success:
@@ -150,7 +171,7 @@ internal sealed class MemeAttachmentIndexer(
                 row.Tags = result.Metadata.Tags;
                 row.Source = result.Metadata.Source;
                 row.Template = result.Metadata.Template;
-                row.ModelId = openRouter.Model;
+                row.ModelId = model;
                 row.RawResponseJson = result.RawContent;
                 row.IndexedAtUtc = DateTime.UtcNow;
                 row.Status = MemeIndexStatus.Indexed;
@@ -166,8 +187,6 @@ internal sealed class MemeAttachmentIndexer(
                 Fail(row, counters, result.Error ?? "unknown analysis error");
                 break;
         }
-
-        await Task.Delay(TimeSpan.FromMilliseconds(openRouter.RequestDelayMs), cancellationToken);
     }
 
     private void Skip(MemeIndexEntity row, MemeIndexRunCounters counters, string reason)

--- a/src/DiscordEventService/Services/MemeIndexing/MemeSampleService.cs
+++ b/src/DiscordEventService/Services/MemeIndexing/MemeSampleService.cs
@@ -100,22 +100,9 @@ internal sealed class MemeSampleService(
         var candidates = new List<MemeSampleItem>();
         foreach (var row in rows)
         {
-            List<StoredAttachment>? attachments;
-            try
-            {
-                attachments = JsonSerializer.Deserialize<List<StoredAttachment>>(row.AttachmentsJson!);
-            }
-            catch (JsonException ex)
-            {
-                logger.LogWarning(ex, "Unparseable attachments_json on message {MessageId}", row.DiscordId);
-                continue;
-            }
-
-            if (attachments is null)
-                continue;
+            var attachments = ParseIndexableAttachments(row.AttachmentsJson!, row.DiscordId);
 
             candidates.AddRange(attachments
-                .Where(a => a.FileName is not null && a.Url is not null && ImageMagic.IsIndexableFileName(a.FileName))
                 .Select(a => new MemeSampleItem(
                     row.GuildDiscordId,
                     row.ChannelDiscordId,
@@ -129,5 +116,23 @@ internal sealed class MemeSampleService(
         }
 
         return candidates;
+    }
+
+    private List<StoredAttachment> ParseIndexableAttachments(string attachmentsJson, ulong messageDiscordId)
+    {
+        List<StoredAttachment>? attachments;
+        try
+        {
+            attachments = JsonSerializer.Deserialize<List<StoredAttachment>>(attachmentsJson);
+        }
+        catch (JsonException ex)
+        {
+            logger.LogWarning(ex, "Unparseable attachments_json on message {MessageId}", messageDiscordId);
+            return [];
+        }
+
+        return attachments
+            ?.Where(a => a.FileName is not null && a.Url is not null && ImageMagic.IsIndexableFileName(a.FileName))
+            .ToList() ?? [];
     }
 }

--- a/src/DiscordEventService/Services/MemeIndexing/OpenRouterClient.cs
+++ b/src/DiscordEventService/Services/MemeIndexing/OpenRouterClient.cs
@@ -69,34 +69,7 @@ internal sealed class OpenRouterClient(
         if (!opts.IsConfigured)
             return MemeAnalysisResult.Failed("OpenRouter:ApiKey is not configured", isTransient: false);
 
-        var payload = new
-        {
-            model,
-            messages = new object[]
-            {
-                new { role = "system", content = SystemPrompt },
-                new
-                {
-                    role = "user",
-                    content = new object[]
-                    {
-                        new
-                        {
-                            type = "image_url",
-                            image_url = new { url = $"data:{mimeType};base64,{Convert.ToBase64String(imageBytes)}" },
-                        },
-                    },
-                },
-            },
-            // No reasoning override: effort=low made gemini-2.5-flash return
-            // empty content; the raised max_tokens budget is what thinking
-            // models actually need.
-            response_format = ResponseSchema,
-            max_tokens = opts.MaxOutputTokens,
-            temperature = 0.2,
-            // include=true returns the real cost from OpenRouter instead of us keeping price tables.
-            usage = new { include = true },
-        };
+        var payload = BuildAnalysisPayload(imageBytes, mimeType, model, opts);
 
         using var request = new HttpRequestMessage(HttpMethod.Post, "chat/completions");
         request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", opts.ApiKey);
@@ -136,6 +109,35 @@ internal sealed class OpenRouterClient(
 
         return ParseResponse(body, model);
     }
+
+    private static object BuildAnalysisPayload(byte[] imageBytes, string mimeType, string model, OpenRouterOptions opts) => new
+    {
+        model,
+        messages = new object[]
+        {
+            new { role = "system", content = SystemPrompt },
+            new
+            {
+                role = "user",
+                content = new object[]
+                {
+                    new
+                    {
+                        type = "image_url",
+                        image_url = new { url = $"data:{mimeType};base64,{Convert.ToBase64String(imageBytes)}" },
+                    },
+                },
+            },
+        },
+        // No reasoning override: effort=low made gemini-2.5-flash return
+        // empty content; the raised max_tokens budget is what thinking
+        // models actually need.
+        response_format = ResponseSchema,
+        max_tokens = opts.MaxOutputTokens,
+        temperature = 0.2,
+        // include=true returns the real cost from OpenRouter instead of us keeping price tables.
+        usage = new { include = true },
+    };
 
     private MemeAnalysisResult ParseResponse(string body, string model)
     {


### PR DESCRIPTION
## Summary
Completes the Tier D method-length backlog — the final 10 of 27 flagged >50-line methods. Strictly behavior-preserving decomposition into named private steps; a dedicated review agent diffed every extraction against master and found **zero semantic drift**.

- **MessagesBackfillJob** (`BackfillChannelMessagesAsync`, 186 lines → batch fetch / per-message insert / entity builders). The REST batch-fetch is hoisted to `BackfillJobBase` and shared with **ReactionsBackfillJob**.
- **HealthCheckJob** (`CheckEventTypeRatioAsync` → baseline computation / drop detection / streak confirmation; the previously-missed `ToDictionaryAsync` token is now threaded).
- **MemeIndexingJob** (terminal filter + batched processing loop), **MemeAttachmentIndexer** (`ProcessOneAsync`, 118 lines → download / content-hash dedupe / analysis-result application), **OpenRouterClient** (payload builder), **MemeSampleService** (attachment parsing).
- **Controllers**: `GuildController.Get`, `PeopleController.Profile`, `TablesController.GetRows`, `TimelineController.GetTimeline`, `StatsController.Overview` and `Community` — query blocks extracted into named helpers.
- **Program.cs**: the ~94-line `DiscordClient` factory lambda moves into a new `Services/DiscordClientRegistration.cs` extension class (child container / 28-handler roster / slash commands as separate steps); Program.cs drops from ~370 to ~270 lines.

## Verification
- `dotnet build --no-incremental`: 0 warnings / 0 errors; `dotnet test`: 151/151
- `dotnet format --verify-no-changes`: clean (ran it before pushing this time)
- Review agent confirmed behavior-preservation on all high-risk paths: MessagesBackfillJob exitReason/checkpoint/SaveChanges sequence, the shared `FetchMessageBatchAsync` catch behavior for both jobs, HealthCheckJob streak-lock semantics, MemeAttachmentIndexer assignment order + post-analysis delay, all child-container registrations + 28 handlers, StatsController.Community await order, Timeline cursor-after-filters
- Live dev-bot run: message create/edit/reaction persisted through decomposed handlers; all 6 decomposed controller endpoints (`overview`, `community`, `guild`, `people/top-messages`, `timeline`, `tables`) returned 200; decomposed health-check job ran clean; zero errors in the boot log

This closes the dotnet-guidelines audit (Tier A #232, C #233, B1 #234, B2 #235, D1 #236, D2 here).

🤖 Generated with [Claude Code](https://claude.com/claude-code)