### PR TITLE
fix: §6 boot deadlock — don't forward DiscordClient into the child container

### DIFF
--- a/src/DiscordEventService/Program.cs
+++ b/src/DiscordEventService/Program.cs
@@ -205,6 +205,10 @@ var app = builder.Build();
 // at startup (before app.Run()) if anything is missing or misregistered.
 {
     var discordClient = app.Services.GetRequiredService<DiscordClient>();
+    // §6: hand the built client to the accessor before anything uses it (handlers fire only after
+    // app.Run). The action services read it from here instead of resolving DiscordClient out of the
+    // child container, which would re-enter the client's own construction and deadlock boot.
+    app.Services.GetRequiredService<DiscordClientAccessor>().Client = discordClient;
     StartupValidator.ValidateChildContainer(
         discordClient.ServiceProvider,
         app.Services.GetRequiredService<ILogger<Program>>());

--- a/src/DiscordEventService/Services/Conversation/ConfirmationService.cs
+++ b/src/DiscordEventService/Services/Conversation/ConfirmationService.cs
@@ -40,7 +40,7 @@ internal interface IConfirmationService
 // after the tool's ConversationContext.IsAdmin check, and the *clicker* is re-checked against
 // AdminUserIds by the component handler at click time.
 internal sealed class ConfirmationService(
-    DiscordClient client,
+    DiscordClientAccessor clientAccessor,
     IOptions<ConversationOptions> options,
     ILogger<ConfirmationService> logger) : IConfirmationService
 {
@@ -136,7 +136,7 @@ internal sealed class ConfirmationService(
                 new DiscordButtonComponent(DiscordButtonStyle.Secondary, CancelPrefix + token, "Cancel"))
             .WithAllowedMentions(Mentions.None);
 
-        var channel = await client.GetChannelAsync(channelId);
+        var channel = await clientAccessor.Client.GetChannelAsync(channelId);
         return await channel.SendMessageAsync(builder);
     }
 

--- a/src/DiscordEventService/Services/Conversation/ConversationRegistration.cs
+++ b/src/DiscordEventService/Services/Conversation/ConversationRegistration.cs
@@ -2,7 +2,6 @@ using System.ClientModel;
 using System.Text;
 using DiscordEventService.Configuration;
 using DiscordEventService.Infrastructure;
-using DSharpPlus;
 using Microsoft.Extensions.AI;
 using Microsoft.Extensions.Options;
 using OpenAI;
@@ -35,6 +34,9 @@ internal static class ConversationRegistration
         // GuildActionService is stateless over the singleton DiscordClient, and ConfirmationService
         // holds pending confirmations in memory across the turn that stages one and the click that
         // confirms it. (Both also registered in the child container, which is where they're used.)
+        // They reach the DiscordClient via DiscordClientAccessor (a plain holder), NEVER by
+        // registering DiscordClient in a container — see DiscordClientAccessor for why that deadlocks.
+        services.AddSingleton<DiscordClientAccessor>();
         services.AddSingleton<IGuildActionService, GuildActionService>();
         services.AddSingleton<IConfirmationService, ConfirmationService>();
 
@@ -66,10 +68,10 @@ internal static class ConversationRegistration
         // container too (DatabaseQueryService/GuildStatsService use the shared DiscordDbContext).
         services.AddSingleton(_ => rootSp.GetRequiredService<DatabaseSchemaHint>());
 
-        // §6: forward the singleton DiscordClient so the action services can perform Discord writes
-        // from the child container (the conversation + confirm-button handlers run here). The lambda
-        // is lazy — it returns the already-built root singleton, so there's no construction cycle.
-        services.AddSingleton(_ => rootSp.GetRequiredService<DiscordClient>());
+        // §6: forward the DiscordClientAccessor (a plain holder) so the action services reach the
+        // DiscordClient without DiscordClient ever being a registration in this child container —
+        // forwarding DiscordClient itself re-enters its own construction and deadlocks boot.
+        services.AddSingleton(_ => rootSp.GetRequiredService<DiscordClientAccessor>());
 
         // §6 action seam — its own child-container singletons. The ConfirmationService store is the
         // one that matters: staging (during a turn) and the confirm click both run in this child

--- a/src/DiscordEventService/Services/Conversation/DiscordClientAccessor.cs
+++ b/src/DiscordEventService/Services/Conversation/DiscordClientAccessor.cs
@@ -1,0 +1,25 @@
+using DSharpPlus;
+
+namespace DiscordEventService.Services.Conversation;
+
+// Hands the singleton DiscordClient to the §6 action services WITHOUT registering DiscordClient
+// in the DSharpPlus child container. Forwarding DiscordClient into the container it itself owns
+// (`services.AddSingleton(_ => rootSp.GetRequiredService<DiscordClient>())`) is a re-entrant edge:
+// ValidateOnBuild constructs the root DiscordClient (clientBuilder.Build builds that child
+// container), and resolving the forwarded DiscordClient back out of it during build deadlocks the
+// host before any log line — a hang VALIDATE_AND_EXIT can race past but a real boot does not.
+//
+// This holder has no dependencies, so resolving it never touches DiscordClient. Program.cs sets
+// Client once, right after the DiscordClient singleton is built and before app.Run(), so it is
+// always populated by the time any handler or tool reads it.
+internal sealed class DiscordClientAccessor
+{
+    private DiscordClient? _client;
+
+    public DiscordClient Client
+    {
+        get => _client ?? throw new InvalidOperationException(
+            "DiscordClientAccessor.Client was read before it was set during startup.");
+        set => _client = value;
+    }
+}

--- a/src/DiscordEventService/Services/Conversation/GuildActionService.cs
+++ b/src/DiscordEventService/Services/Conversation/GuildActionService.cs
@@ -12,8 +12,8 @@ namespace DiscordEventService.Services.Conversation;
 // itself lives a layer up, in the tool closures (ConversationContext.IsAdmin) and the confirm
 // button — this service performs, it does not authorize.
 //
-// Stateless and singleton: it depends only on the singleton DiscordClient, so the deferred
-// execute delegate a staged action captures can safely outlive the turn that staged it.
+// Stateless and singleton: it reads the singleton DiscordClient from the accessor, so the
+// deferred execute delegate a staged action captures can safely outlive the turn that staged it.
 internal interface IGuildActionService
 {
     // Reversible — run immediately after the admin gate.
@@ -33,11 +33,15 @@ internal interface IGuildActionService
     Task<string> DescribeRoleAsync(ulong guildId, ulong roleId, CancellationToken cancellationToken);
 }
 
-internal sealed class GuildActionService(DiscordClient client, ILogger<GuildActionService> logger)
+internal sealed class GuildActionService(DiscordClientAccessor clientAccessor, ILogger<GuildActionService> logger)
     : IGuildActionService
 {
     // Discord caps a timeout at 28 days; clamp so the API never rejects an over-long request.
     private const int MaxTimeoutMinutes = 28 * 24 * 60;
+
+    // Resolved from the accessor (never injected directly) so DiscordClient stays out of the
+    // child container's DI graph — see DiscordClientAccessor for why.
+    private DiscordClient Client => clientAccessor.Client;
 
     public Task<string> AddReactionAsync(ulong channelId, ulong messageId, string emoji, CancellationToken cancellationToken) =>
         RunAsync("message", async () =>
@@ -69,7 +73,7 @@ internal sealed class GuildActionService(DiscordClient client, ILogger<GuildActi
         ulong guildId, ulong userId, ulong roleId, string reason, CancellationToken cancellationToken) =>
         RunAsync("user or role", async () =>
         {
-            var guild = await client.GetGuildAsync(guildId);
+            var guild = await Client.GetGuildAsync(guildId);
             var member = await guild.GetMemberAsync(userId);
             var role = await guild.GetRoleAsync(roleId);
             await member.GrantRoleAsync(role, reason);
@@ -80,7 +84,7 @@ internal sealed class GuildActionService(DiscordClient client, ILogger<GuildActi
         ulong guildId, ulong userId, ulong roleId, string reason, CancellationToken cancellationToken) =>
         RunAsync("user or role", async () =>
         {
-            var guild = await client.GetGuildAsync(guildId);
+            var guild = await Client.GetGuildAsync(guildId);
             var member = await guild.GetMemberAsync(userId);
             var role = await guild.GetRoleAsync(roleId);
             await member.RevokeRoleAsync(role, reason);
@@ -92,7 +96,7 @@ internal sealed class GuildActionService(DiscordClient client, ILogger<GuildActi
         RunAsync("user", async () =>
         {
             var clamped = Math.Clamp(minutes, 1, MaxTimeoutMinutes);
-            var guild = await client.GetGuildAsync(guildId);
+            var guild = await Client.GetGuildAsync(guildId);
             var member = await guild.GetMemberAsync(userId);
             await member.TimeoutAsync(DateTimeOffset.UtcNow.AddMinutes(clamped), reason);
             return $"Timed out {member.DisplayName} for {clamped} minute(s).";
@@ -101,7 +105,7 @@ internal sealed class GuildActionService(DiscordClient client, ILogger<GuildActi
     public Task<string> KickMemberAsync(ulong guildId, ulong userId, string reason, CancellationToken cancellationToken) =>
         RunAsync("user", async () =>
         {
-            var guild = await client.GetGuildAsync(guildId);
+            var guild = await Client.GetGuildAsync(guildId);
             var member = await guild.GetMemberAsync(userId);
             await member.RemoveAsync(reason);
             return $"Kicked {member.DisplayName}.";
@@ -110,7 +114,7 @@ internal sealed class GuildActionService(DiscordClient client, ILogger<GuildActi
     public Task<string> BanMemberAsync(ulong guildId, ulong userId, string reason, CancellationToken cancellationToken) =>
         RunAsync("user", async () =>
         {
-            var guild = await client.GetGuildAsync(guildId);
+            var guild = await Client.GetGuildAsync(guildId);
             // Ban by id so it works even when the target isn't a resolvable member (already gone).
             await guild.BanMemberAsync(userId, TimeSpan.Zero, reason);
             return $"Banned user {userId}.";
@@ -128,7 +132,7 @@ internal sealed class GuildActionService(DiscordClient client, ILogger<GuildActi
     {
         try
         {
-            var guild = await client.GetGuildAsync(guildId);
+            var guild = await Client.GetGuildAsync(guildId);
             var member = await guild.GetMemberAsync(userId);
             return $"{member.DisplayName} ({userId})";
         }
@@ -144,7 +148,7 @@ internal sealed class GuildActionService(DiscordClient client, ILogger<GuildActi
     {
         try
         {
-            var guild = await client.GetGuildAsync(guildId);
+            var guild = await Client.GetGuildAsync(guildId);
             var role = await guild.GetRoleAsync(roleId);
             return $"{role.Name} ({roleId})";
         }
@@ -156,7 +160,7 @@ internal sealed class GuildActionService(DiscordClient client, ILogger<GuildActi
 
     private async Task<DiscordMessage> FetchMessageAsync(ulong channelId, ulong messageId)
     {
-        var channel = await client.GetChannelAsync(channelId);
+        var channel = await Client.GetChannelAsync(channelId);
         return await channel.GetMessageAsync(messageId);
     }
 

--- a/tests/DiscordEventService.Tests/ConfirmationServiceTests.cs
+++ b/tests/DiscordEventService.Tests/ConfirmationServiceTests.cs
@@ -54,7 +54,7 @@ public sealed class ConfirmationServiceTests
     }
 
     private static ConfirmationService NewService() =>
-        new(client: null!, Options.Create(new ConversationOptions()), NullLogger<ConfirmationService>.Instance);
+        new(clientAccessor: null!, Options.Create(new ConversationOptions()), NullLogger<ConfirmationService>.Instance);
 }
 
 public sealed class ConversationOptionsAdminTests

--- a/tests/DiscordEventService.Tests/ConversationRegistrationTests.cs
+++ b/tests/DiscordEventService.Tests/ConversationRegistrationTests.cs
@@ -1,0 +1,32 @@
+using DiscordEventService.Services.Conversation;
+using DSharpPlus;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace DiscordEventService.Tests;
+
+// Regression guard for the §6 boot deadlock. Registering DiscordClient in the DSharpPlus child
+// container forwards into the very container the client owns, so resolving it re-enters the
+// client's own construction during builder.Build() and hangs boot before any log line — which is
+// why it slipped past CI (VALIDATE_AND_EXIT could race past it) and only surfaced as an unhealthy,
+// silent prod container. The action services must reach the client via DiscordClientAccessor (a
+// plain holder set after the client is built), never by registering DiscordClient in a container.
+public sealed class ConversationRegistrationTests
+{
+    [Fact]
+    public void AddConversationChildServices_NeverRegistersDiscordClientInTheChildContainer()
+    {
+        var services = new ServiceCollection();
+        // The forwards are registered as lambdas and not invoked here, so an empty root provider
+        // and empty configuration are enough to inspect what gets registered.
+        var emptyRoot = new ServiceCollection().BuildServiceProvider();
+        var configuration = new ConfigurationBuilder().Build();
+
+        ConversationRegistration.AddConversationChildServices(services, emptyRoot, configuration);
+
+        Assert.DoesNotContain(services, descriptor => descriptor.ServiceType == typeof(DiscordClient));
+        // The accessor is the sanctioned, cycle-free way the action services reach the client.
+        Assert.Contains(services, descriptor => descriptor.ServiceType == typeof(DiscordClientAccessor));
+    }
+}


### PR DESCRIPTION
**Hotfix — prod is down.** The §6 merge (#250) hangs the service at boot.

## What broke

§6 forwarded the singleton `DiscordClient` into the DSharpPlus child container (so the action services could perform Discord writes). That container is **owned by the DiscordClient**, so resolving the forwarded `DiscordClient` re-enters the client's own construction during `builder.Build()` (`ValidateOnBuild`) → **deadlock**, before any log line.

It slipped through because the deadlock is a **startup race**: `VALIDATE_AND_EXIT` (CI + local smoke) could win it and exit 0, but a real boot loses it deterministically. In prod the container was "running" but **unhealthy, silent, never connected, zero events ingested** (the downtime row from the previous shutdown stayed open). A restart did not recover it.

## The fix

`DiscordClientAccessor` — a plain holder with no dependencies. `Program.cs` sets its `Client` once, right after the `DiscordClient` singleton is built and before `app.Run()`. `GuildActionService` / `ConfirmationService` read the client from the accessor, so **`DiscordClient` is never a registration in any container** and the re-entrant edge is gone.

Verified by a full local dev-bot boot (not just `VALIDATE_AND_EXIT`):
```
DSharpPlus child container DI validation passed (23 services resolved)
Connected to Discord as Devtuś
Now listening on: http://localhost:5099
Application started.
```
`/health` → 200, `bot_heartbeats` writing.

## Prevention

`ConversationRegistrationTests` asserts `AddConversationChildServices` **never registers `DiscordClient`** in the child container (and does register the accessor) — a deterministic guard against re-introducing the cycle. (A deeper follow-up: a CI full-boot smoke test, since `VALIDATE_AND_EXIT` exits before `app.Run()` and can race past a boot hang.)

Full suite **201 passed / 1 skipped**; build `-warnaserror` + `dotnet format` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)