### PR TITLE
ci: full-boot smoke test (catch boot hangs before deploy)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,3 +18,75 @@ jobs:
     with:
       dotnet-version: "10.0.x"
     secrets: inherit
+
+  boot-smoke:
+    # A green build + unit suite does NOT prove the app boots: DI deadlocks, missing
+    # config, and migration failures only surface at builder.Build()/app.Run(), which
+    # VALIDATE_AND_EXIT exits before (and could race past). The §6 boot deadlock shipped
+    # exactly this way. So actually boot the real app — Production environment to match
+    # prod's ValidateScopes=false — with a dummy Discord token against a throwaway Postgres
+    # and require /health to go green. A boot hang fails the PR instead of the deploy.
+    runs-on: ubuntu-latest
+    services:
+      postgres:
+        image: postgres:18
+        env:
+          # trust auth keeps any password out of the committed connection string (secret scanners).
+          POSTGRES_HOST_AUTH_METHOD: trust
+          POSTGRES_DB: postgres
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd "pg_isready -U postgres"
+          --health-interval 5s
+          --health-timeout 5s
+          --health-retries 10
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: "10.0.x"
+      - name: Build
+        run: dotnet build src/DiscordEventService/DiscordEventService.csproj -c Release
+      - name: Boot the app and wait for /health
+        env:
+          ASPNETCORE_ENVIRONMENT: Production
+          ASPNETCORE_URLS: http://127.0.0.1:5099
+          # A long, obviously-fake token clears DiscordOptions' [MinLength(50)] ValidateOnStart
+          # check; the connect then fails fast (caught) so the host still reaches Kestrel — the
+          # boot path runs through the builder.Build()/ValidateOnBuild edge that deadlocked.
+          Discord__Token: smoke-test-not-a-real-discord-token-do-not-use-0000000000
+          # trust auth on the service => no password in the connection string.
+          ConnectionStrings__Postgres: Host=localhost;Port=5432;Database=postgres;Username=postgres
+        run: |
+          set -uo pipefail
+          # --no-build so the /health timeout below measures boot time, not Release compilation.
+          dotnet run --no-build --project src/DiscordEventService/DiscordEventService.csproj -c Release \
+            > /tmp/boot.log 2>&1 &
+          app_pid=$!
+
+          healthy=0
+          for _ in $(seq 1 30); do
+            if ! kill -0 "$app_pid" 2>/dev/null; then
+              echo "::error::App process exited during startup."
+              break
+            fi
+            code=$(curl -s -o /dev/null -w '%{http_code}' --max-time 3 http://127.0.0.1:5099/health || true)
+            if [ "$code" = "200" ]; then
+              healthy=1
+              break
+            fi
+            sleep 3
+          done
+
+          kill -TERM "$app_pid" 2>/dev/null || true
+          wait "$app_pid" 2>/dev/null || true
+
+          echo "==== boot log ===="
+          cat /tmp/boot.log || true
+
+          if [ "$healthy" != "1" ]; then
+            echo "::error::App did not reach a healthy state within the timeout — likely a boot hang or startup failure."
+            exit 1
+          fi
+          echo "App booted and reported healthy."


### PR DESCRIPTION
Follow-up to the §6 boot-deadlock incident (#251) — the durable prevention.

## Why

A green build + unit suite never proved the app *boots*. The §6 deadlock lived at `builder.Build()`/`app.Run()`, which `VALIDATE_AND_EXIT` exits before (and could race past), so CI stayed green while prod hung for ~31 min.

## What

A new `boot-smoke` job in CI that **actually starts the app** and requires `/health` → 200 within a timeout:
- **Production** environment, to match prod's `ValidateScopes=false` (the relevant DI-validation mode).
- A throwaway `postgres:18` service for the DbContext + migrations.
- A **dummy Discord token** — enough to satisfy the required-config check; the connect fails fast and is caught (`DiscordHostedService`), so the host still reaches Kestrel. Critically, the boot path runs through the exact `builder.Build()`/`ValidateOnBuild` edge that deadlocked.
- Build first, then `dotnet run --no-build`, so the `/health` timeout measures boot time, not Release compilation.

A boot hang or startup failure now fails the PR instead of the deploy.

## Verified locally

Production-env boot against the local Postgres reached:
```
DSharpPlus child container DI validation passed (23 services resolved)
Application started.
```
`/health` → 200.

(The pre-fix code would hang at `builder.Build()` here and the job would time out — which is the point.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)