### PR TITLE
fix: transient refresh-urls batch failure must not terminally skip memes

### DIFF
--- a/src/DiscordEventService/Jobs/MemeBenchmarkJob.cs
+++ b/src/DiscordEventService/Jobs/MemeBenchmarkJob.cs
@@ -98,11 +98,18 @@ internal sealed class MemeBenchmarkJob(
     private async Task<BenchmarkItem> BenchmarkOneAsync(
         MemeSampleItem sampleItem,
         string[] models,
-        Dictionary<string, string> freshUrls,
+        AttachmentUrlRefreshResult freshUrls,
         CancellationToken cancellationToken)
     {
-        if (!freshUrls.TryGetValue(AttachmentUrlRefreshService.StripQuery(sampleItem.StoredUrl), out var freshUrl))
-            return Skip(sampleItem, "URL refresh failed (attachment likely gone)");
+        // A benchmark sample is disposable either way — skip on both refresh
+        // outcomes, but keep the reasons distinguishable in the report.
+        switch (freshUrls.GetFreshUrl(sampleItem.StoredUrl, out var freshUrl))
+        {
+            case AttachmentUrlRefreshOutcome.Declined:
+                return Skip(sampleItem, "URL refresh declined (attachment likely gone)");
+            case AttachmentUrlRefreshOutcome.BatchFailed:
+                return Skip(sampleItem, "URL refresh batch failed (transient)");
+        }
 
         byte[] imageBytes;
         try

--- a/src/DiscordEventService/Services/MemeIndexing/AttachmentUrlRefreshService.cs
+++ b/src/DiscordEventService/Services/MemeIndexing/AttachmentUrlRefreshService.cs
@@ -6,6 +6,40 @@ using Microsoft.Extensions.Options;
 
 namespace DiscordEventService.Services.MemeIndexing;
 
+// Declined (2xx response omitting the URL — attachment genuinely gone, terminal)
+// must stay distinct from BatchFailed (transport error or non-2xx — says nothing
+// about the attachment, retryable): conflating them silently loses memes.
+internal enum AttachmentUrlRefreshOutcome
+{
+    Refreshed,
+    Declined,
+    BatchFailed,
+}
+
+internal sealed class AttachmentUrlRefreshResult
+{
+    private readonly Dictionary<string, string> _refreshedByBareUrl = [];
+    private readonly HashSet<string> _failedBatchBareUrls = [];
+
+    public int RefreshedCount => _refreshedByBareUrl.Count;
+    public int FailedBatchCount => _failedBatchBareUrls.Count;
+
+    public AttachmentUrlRefreshOutcome GetFreshUrl(string storedUrl, out string? freshUrl)
+    {
+        var bareUrl = AttachmentUrlRefreshService.StripQuery(storedUrl);
+        if (_refreshedByBareUrl.TryGetValue(bareUrl, out freshUrl))
+            return AttachmentUrlRefreshOutcome.Refreshed;
+
+        return _failedBatchBareUrls.Contains(bareUrl)
+            ? AttachmentUrlRefreshOutcome.BatchFailed
+            : AttachmentUrlRefreshOutcome.Declined;
+    }
+
+    internal void AddRefreshed(string bareUrl, string freshUrl) => _refreshedByBareUrl[bareUrl] = freshUrl;
+
+    internal void MarkBatchFailed(IEnumerable<string> bareUrls) => _failedBatchBareUrls.UnionWith(bareUrls);
+}
+
 internal sealed class AttachmentUrlRefreshService(
     IHttpClientFactory httpClientFactory,
     IOptions<DiscordOptions> discordOptions,
@@ -16,11 +50,11 @@ internal sealed class AttachmentUrlRefreshService(
     private const int BatchSize = 50;
     private static readonly TimeSpan DelayBetweenBatches = TimeSpan.FromMilliseconds(300);
 
-    public async Task<Dictionary<string, string>> RefreshAsync(
+    public async Task<AttachmentUrlRefreshResult> RefreshAsync(
         IReadOnlyCollection<string> storedUrls,
         CancellationToken cancellationToken)
     {
-        var result = new Dictionary<string, string>();
+        var result = new AttachmentUrlRefreshResult();
         var distinct = storedUrls.Select(StripQuery).Distinct().ToList();
 
         for (var offset = 0; offset < distinct.Count; offset += BatchSize)
@@ -34,7 +68,8 @@ internal sealed class AttachmentUrlRefreshService(
             }
             catch (Exception ex) when (ex is HttpRequestException or TaskCanceledException && !cancellationToken.IsCancellationRequested)
             {
-                // Lose this batch only; its URLs surface downstream as skips.
+                // Lose this batch only; its URLs surface downstream as retryable failures.
+                result.MarkBatchFailed(batch);
                 logger.LogWarning(ex, "Attachment URL refresh batch failed for {UrlCount} urls", batch.Count);
             }
 
@@ -42,7 +77,9 @@ internal sealed class AttachmentUrlRefreshService(
                 await Task.Delay(DelayBetweenBatches, cancellationToken);
         }
 
-        logger.LogInformation("Refreshed {RefreshedCount} of {RequestedCount} attachment URLs", result.Count, distinct.Count);
+        logger.LogInformation(
+            "Refreshed {RefreshedCount} of {RequestedCount} attachment URLs ({FailedBatchCount} in failed batches)",
+            result.RefreshedCount, distinct.Count, result.FailedBatchCount);
         return result;
     }
 
@@ -55,7 +92,7 @@ internal sealed class AttachmentUrlRefreshService(
 
     private async Task RefreshBatchAsync(
         List<string> batch,
-        Dictionary<string, string> result,
+        AttachmentUrlRefreshResult result,
         CancellationToken cancellationToken)
     {
         using var request = new HttpRequestMessage(HttpMethod.Post, "attachments/refresh-urls");
@@ -71,6 +108,7 @@ internal sealed class AttachmentUrlRefreshService(
 
         if (!response.IsSuccessStatusCode)
         {
+            result.MarkBatchFailed(batch);
             logger.LogWarning("attachments/refresh-urls returned {StatusCode}: {Body}",
                 (int)response.StatusCode, body.Length <= 300 ? body : body[..300]);
             return;
@@ -80,7 +118,7 @@ internal sealed class AttachmentUrlRefreshService(
         foreach (var entry in parsed?.RefreshedUrls ?? [])
         {
             if (entry.Original is not null && !string.IsNullOrEmpty(entry.Refreshed))
-                result[StripQuery(entry.Original)] = entry.Refreshed;
+                result.AddRefreshed(StripQuery(entry.Original), entry.Refreshed);
         }
     }
 

--- a/src/DiscordEventService/Services/MemeIndexing/MemeAttachmentIndexer.cs
+++ b/src/DiscordEventService/Services/MemeIndexing/MemeAttachmentIndexer.cs
@@ -55,22 +55,32 @@ internal sealed class MemeAttachmentIndexer(
         DiscordDbContext db,
         MemeIndexEntity row,
         MemeSampleItem item,
-        Dictionary<string, string> freshUrls,
+        AttachmentUrlRefreshResult freshUrls,
         MemeIndexRunCounters counters,
         CancellationToken cancellationToken)
     {
         var memeOptions = memeIndexOptions.Value;
         var openRouter = openRouterOptions.Value;
 
+        var refreshOutcome = freshUrls.GetFreshUrl(item.StoredUrl, out var freshUrl);
+        if (refreshOutcome == AttachmentUrlRefreshOutcome.BatchFailed)
+        {
+            // Transient refresh failure — the attachment itself was never
+            // attempted, so this must stay retryable without burning one of
+            // the sweep's capped attempts.
+            Fail(row, counters, "transient: refresh-urls batch failed");
+            return;
+        }
+
         row.AttemptCount++;
 
-        if (!freshUrls.TryGetValue(AttachmentUrlRefreshService.StripQuery(item.StoredUrl), out var freshUrl))
+        if (refreshOutcome == AttachmentUrlRefreshOutcome.Declined)
         {
             Skip(row, counters, "dead attachment: refresh-urls declined to re-sign");
             return;
         }
 
-        var imageBytes = await DownloadImageAsync(freshUrl, row, counters, cancellationToken);
+        var imageBytes = await DownloadImageAsync(freshUrl!, row, counters, cancellationToken);
         if (imageBytes is null) return;
 
         row.FileSizeBytes = imageBytes.Length;

--- a/tests/DiscordEventService.Tests/AttachmentUrlRefreshServiceTests.cs
+++ b/tests/DiscordEventService.Tests/AttachmentUrlRefreshServiceTests.cs
@@ -30,14 +30,14 @@ public sealed class AttachmentUrlRefreshServiceTests
             .Select(i => $"https://cdn.discordapp.com/attachments/1/{i}/f{i}.png?ex=old&hm=sig")
             .ToList();
 
-        var map = await service.RefreshAsync(stored, CancellationToken.None);
+        var result = await service.RefreshAsync(stored, CancellationToken.None);
 
         Assert.Equal(3, requests.Count);
         Assert.All(requests, batch => Assert.True(batch.Count <= 50));
         Assert.All(requests.SelectMany(b => b), url => Assert.DoesNotContain("?", url));
-        Assert.Equal(120, map.Count);
-        var key = AttachmentUrlRefreshService.StripQuery(stored[7]);
-        Assert.Equal(key + "?ex=fresh", map[key]);
+        Assert.Equal(120, result.RefreshedCount);
+        Assert.Equal(AttachmentUrlRefreshOutcome.Refreshed, result.GetFreshUrl(stored[7], out var freshUrl));
+        Assert.Equal(AttachmentUrlRefreshService.StripQuery(stored[7]) + "?ex=fresh", freshUrl);
     }
 
     [Fact]
@@ -61,10 +61,27 @@ public sealed class AttachmentUrlRefreshServiceTests
             .Select(i => $"https://cdn.discordapp.com/attachments/1/{i}/f{i}.png")
             .ToList();
 
-        var map = await service.RefreshAsync(stored, CancellationToken.None);
+        var result = await service.RefreshAsync(stored, CancellationToken.None);
 
-        // First batch of 50 lost, second batch of 10 mapped.
-        Assert.Equal(10, map.Count);
+        // First batch of 50 failed but stays retryable; second batch of 10 mapped.
+        Assert.Equal(10, result.RefreshedCount);
+        Assert.Equal(50, result.FailedBatchCount);
+        Assert.Equal(AttachmentUrlRefreshOutcome.BatchFailed, result.GetFreshUrl(stored[0], out _));
+        Assert.Equal(AttachmentUrlRefreshOutcome.Refreshed, result.GetFreshUrl(stored[59], out _));
+    }
+
+    [Fact]
+    public async Task RefreshAsync_TransportError_MarksBatchFailedNotDeclined()
+    {
+        var service = NewService(_ => throw new HttpRequestException("connection reset"));
+
+        var result = await service.RefreshAsync(
+            ["https://cdn.discordapp.com/a/1.png?ex=old"],
+            CancellationToken.None);
+
+        Assert.Equal(0, result.RefreshedCount);
+        Assert.Equal(AttachmentUrlRefreshOutcome.BatchFailed,
+            result.GetFreshUrl("https://cdn.discordapp.com/a/1.png?ex=old", out _));
     }
 
     [Fact]
@@ -79,11 +96,13 @@ public sealed class AttachmentUrlRefreshServiceTests
             return Json(HttpStatusCode.OK, JsonSerializer.Serialize(new { refreshed_urls = refreshed }));
         });
 
-        var map = await service.RefreshAsync(
+        var result = await service.RefreshAsync(
             ["https://cdn.discordapp.com/a/1.png", "https://cdn.discordapp.com/a/2.png"],
             CancellationToken.None);
 
-        Assert.Single(map);
+        Assert.Equal(1, result.RefreshedCount);
+        Assert.Equal(AttachmentUrlRefreshOutcome.Declined,
+            result.GetFreshUrl("https://cdn.discordapp.com/a/2.png", out _));
     }
 
     private static AttachmentUrlRefreshService NewService(Func<HttpRequestMessage, Task<HttpResponseMessage>> respond) =>

--- a/tests/DiscordEventService.Tests/MemeIndexingJobTests.cs
+++ b/tests/DiscordEventService.Tests/MemeIndexingJobTests.cs
@@ -162,6 +162,79 @@ public sealed class MemeIndexingJobTests(PostgresFixture fixture) : IClassFixtur
     }
 
     [Fact]
+    public async Task ExecuteAsync_RefreshBatchFailure_MarksFailedAndLaterRunHeals()
+    {
+        // A transient refresh-urls failure (5xx/timeout) must not mark the
+        // batch Skipped — Skipped is terminal and the memes would be silently
+        // lost from search forever. It also must not burn a retry attempt:
+        // the attachment itself was never actually processed.
+        AddMessage(1001UL, Attachment(11UL, "a.png"), Attachment(12UL, "b.png"));
+        await _db.SaveChangesAsync();
+        _http.SetImage(11UL, Png(1));
+        _http.SetImage(12UL, Png(2));
+        _http.RefreshFailuresRemaining = 1;
+
+        await RunJobAsync();
+
+        await using var verify = NewContext();
+        var rows = await verify.MemeIndex.ToListAsync();
+        Assert.Equal(2, rows.Count);
+        Assert.All(rows, r =>
+        {
+            Assert.Equal(MemeIndexStatus.Failed, r.Status);
+            Assert.Equal(0, r.AttemptCount);
+        });
+        Assert.Equal(0, _http.ModelCalls);
+
+        // Next run: refresh succeeds, both rows index normally.
+        await RunJobAsync();
+
+        await using var verify2 = NewContext();
+        var healed = await verify2.MemeIndex.ToListAsync();
+        Assert.All(healed, r => Assert.Equal(MemeIndexStatus.Indexed, r.Status));
+        Assert.Equal(2, _http.ModelCalls);
+    }
+
+    [Fact]
+    public async Task ExecuteSweepAsync_RefreshBatchFailures_NeverExhaustAttemptCap()
+    {
+        // The sweep abandons rows at SweepMaxFailedAttempts — repeated batch
+        // failures must stay below it so a flaky week can't orphan a meme.
+        AddMessage(1001UL, Attachment(11UL, "a.png"));
+        await _db.SaveChangesAsync();
+        _http.SetImage(11UL, Png(1));
+
+        for (var i = 0; i < MemeIndexingJob.SweepMaxFailedAttempts + 1; i++)
+        {
+            _http.RefreshFailuresRemaining = 1;
+            await RunSweepAsync();
+        }
+
+        await RunSweepAsync();
+
+        await using var verify = NewContext();
+        var row = await verify.MemeIndex.SingleAsync(m => m.AttachmentDiscordId == 11UL);
+        Assert.Equal(MemeIndexStatus.Indexed, row.Status);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_UrlDeclinedByDiscord_StaysSkipped()
+    {
+        // Contrast case: a 2xx refresh response that omits the URL means the
+        // attachment is genuinely gone — terminal Skip remains correct.
+        AddMessage(1001UL, Attachment(11UL, "deleted.png"));
+        await _db.SaveChangesAsync();
+        _http.DeadAttachments.Add(11UL);
+
+        await RunJobAsync();
+
+        await using var verify = NewContext();
+        var row = await verify.MemeIndex.SingleAsync(m => m.AttachmentDiscordId == 11UL);
+        Assert.Equal(MemeIndexStatus.Skipped, row.Status);
+        Assert.StartsWith("dead attachment", row.Error);
+    }
+
+    [Fact]
     public async Task ExecuteAsync_StrandedPendingRow_IsReprocessed()
     {
         // A mid-attachment interruption leaves a committed Pending row behind
@@ -244,7 +317,11 @@ public sealed class MemeIndexingJobTests(PostgresFixture fixture) : IClassFixtur
         Assert.Equal(3, _http.ModelCalls);
     }
 
-    private async Task RunJobAsync(int maxImagesPerRun = 500)
+    private Task RunJobAsync(int maxImagesPerRun = 500) => RunAsync(maxImagesPerRun, sweep: false);
+
+    private Task RunSweepAsync() => RunAsync(maxImagesPerRun: 500, sweep: true);
+
+    private async Task RunAsync(int maxImagesPerRun, bool sweep)
     {
         var services = new ServiceCollection();
         services.AddLogging();
@@ -273,8 +350,11 @@ public sealed class MemeIndexingJobTests(PostgresFixture fixture) : IClassFixtur
 
         await using var provider = services.BuildServiceProvider();
         using var scope = provider.CreateScope();
-        await scope.ServiceProvider.GetRequiredService<MemeIndexingJob>()
-            .ExecuteAsync(GuildDiscordId, CancellationToken.None);
+        var job = scope.ServiceProvider.GetRequiredService<MemeIndexingJob>();
+        if (sweep)
+            await job.ExecuteSweepAsync(GuildDiscordId, CancellationToken.None);
+        else
+            await job.ExecuteAsync(GuildDiscordId, CancellationToken.None);
     }
 
     private void AddMessage(ulong discordId, params string[] attachments)
@@ -316,6 +396,7 @@ internal sealed class FakeMemeHttpHandler : HttpMessageHandler
     public HashSet<ulong> DeadAttachments { get; } = [];
     public List<byte[]> RefusalFor { get; } = [];
     public List<byte[]> TransientErrorFor { get; } = [];
+    public int RefreshFailuresRemaining { get; set; }
     public int ModelCalls { get; private set; }
 
     public void SetImage(ulong attachmentId, byte[] bytes) => _imagesByAttachment[attachmentId] = bytes;
@@ -335,6 +416,12 @@ internal sealed class FakeMemeHttpHandler : HttpMessageHandler
 
     private async Task<HttpResponseMessage> HandleRefreshAsync(HttpRequestMessage request, CancellationToken cancellationToken)
     {
+        if (RefreshFailuresRemaining > 0)
+        {
+            RefreshFailuresRemaining--;
+            return Json(HttpStatusCode.InternalServerError, """{"message":"upstream exploded"}""");
+        }
+
         var body = await request.Content!.ReadAsStringAsync(cancellationToken);
         var urls = JsonDocument.Parse(body).RootElement.GetProperty("attachment_urls");
 


### PR DESCRIPTION
## The bug (found in the 2026-07-11 meme-pipeline review)

`AttachmentUrlRefreshService.RefreshAsync` swallows a failed `attachments/refresh-urls` batch (transport error or non-2xx), and `MemeAttachmentIndexer.ProcessOneAsync` treated **any** URL missing from the refresh result as "dead attachment: refresh-urls declined to re-sign" → `Skipped`. Skipped is terminal by design — no backfill re-run or weekly sweep ever revisits it.

Net effect: one flaky 5xx or 30s timeout on a refresh batch permanently marks up to 50 memes unsearchable, with only a warning log. The #223 prod backfill (~5k images, many batches) would likely hit this at least once — this must land before that backfill runs.

## The fix

- `RefreshAsync` now returns `AttachmentUrlRefreshResult`, which classifies each stored URL:
  - **Refreshed** — fresh URL available;
  - **Declined** — Discord answered 2xx but omitted the URL → attachment genuinely gone → terminal `Skip` stays correct;
  - **BatchFailed** — the whole batch failed → says nothing about the attachment → row marked `Failed` (retryable).
- `BatchFailed` does **not** increment `AttemptCount`: the attachment was never actually attempted, so refresh flakiness can't burn through the sweep's `SweepMaxFailedAttempts` cap and orphan rows that way.
- `MemeBenchmarkJob` (throwaway samples) keeps skipping both non-refreshed cases, with distinguishable reasons in the report.

## Testing

- New Testcontainers tests (red before the fix): refresh 500 → rows `Failed` with `AttemptCount == 0`, zero model calls, next run heals to `Indexed`; repeated batch failures across sweeps never exhaust the attempt cap; contrast test pins that a 2xx-declined URL still ends `Skipped`.
- New unit tests pin the `BatchFailed` vs `Declined` classification for both the non-2xx and transport-exception paths.
- Full suite: 205/205 passed.
- Live-verified on the dev bot: posted a fresh image via webhook → live indexing path went through the new result type, `Refreshed 1 of 1 attachment URLs (0 in failed batches)`, row `Indexed` in DB, 1 model call ($0.0012).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Pn7ecskaV1fdn6yLPV4EFd