### PR TITLE
feat: Conversation:EnableSensitiveData flag for prod Langfuse tracing (#257)

### DIFF
--- a/src/DiscordEventService/Configuration/ConversationOptions.cs
+++ b/src/DiscordEventService/Configuration/ConversationOptions.cs
@@ -79,4 +79,9 @@ internal sealed class ConversationOptions
         !string.IsNullOrWhiteSpace(LangfuseHost)
         && !string.IsNullOrWhiteSpace(LangfusePublicKey)
         && !string.IsNullOrWhiteSpace(LangfuseSecretKey);
+
+    // Include full prompts, tool arguments and results in traces (#257). Development
+    // always captures them regardless of this flag; prod opts in explicitly — the
+    // Langfuse instance is LAN-only, so payloads never leave the home network.
+    public bool EnableSensitiveData { get; set; }
 }

--- a/src/DiscordEventService/Services/Conversation/ConversationRegistration.cs
+++ b/src/DiscordEventService/Services/Conversation/ConversationRegistration.cs
@@ -99,7 +99,8 @@ internal static class ConversationRegistration
             .AsBuilder()
             .UseOpenTelemetry(
                 sourceName: ConversationTelemetry.SourceName,
-                configure: client => client.EnableSensitiveData = environment.IsDevelopment())
+                configure: client => client.EnableSensitiveData =
+                    conversation.EnableSensitiveData || environment.IsDevelopment())
             .Build();
     }
 

--- a/src/DiscordEventService/appsettings.json
+++ b/src/DiscordEventService/appsettings.json
@@ -38,7 +38,8 @@
     "AdminUserIds": [],
     "LangfuseHost": "",
     "LangfusePublicKey": "",
-    "LangfuseSecretKey": ""
+    "LangfuseSecretKey": "",
+    "EnableSensitiveData": false
   },
   "HealthCheck": {
     "WebhookUrl": "",


### PR DESCRIPTION
Part of #257 (map #253).

## What

`EnableSensitiveData` on the MEAI OpenTelemetry middleware was hardcoded to `environment.IsDevelopment()`, so prod traces could never carry prompts/tool args/results. #257's HITL decision (2026-07-17): enable it in prod — friend guild, Langfuse is LAN-only, payloads never leave the home network.

- New `Conversation:EnableSensitiveData` bool (default `false`) on `ConversationOptions`
- Wiring becomes `options.EnableSensitiveData || environment.IsDevelopment()` — dev behavior unchanged
- `appsettings.json` documents the key

## Prod rollout (after merge)

Wiktor sets in the prod `.env`:
- `Conversation__LangfuseHost`
- `Conversation__LangfusePublicKey`
- `Conversation__LangfuseSecretKey`
- `Conversation__EnableSensitiveData=true`

Then a real prod conversation gets trace-verified (turn → round generations → tool spans, cost tags) before #257 closes.

## Testing

- `dotnet build` clean (0 warnings)
- No behavioral change while the flag is unset; live trace verification happens at prod rollout per the ticket's AC

🤖 Generated with [Claude Code](https://claude.com/claude-code)