### PR TITLE
feat: #267 §1 conversation memory (full-turn persistence) + usage ledger

### DIFF
--- a/src/DiscordEventService/Configuration/ConversationOptions.cs
+++ b/src/DiscordEventService/Configuration/ConversationOptions.cs
@@ -58,6 +58,14 @@ internal sealed class ConversationOptions
     // Hard ceiling on a single turn's model round-trip.
     public int RequestTimeoutSeconds { get; set; } = 120;
 
+    // Conversation memory replay window (#267). The budget is summed over locally
+    // estimated message sizes (chars/4 — OpenRouter normalizes counts to a GPT
+    // tokenizer, so it's a fair proxy; the per-request provider usage can't size a
+    // per-message window). WindowMaxMessages is the row backstop against a few huge
+    // tool dumps blowing the estimate.
+    public int WindowTokenBudget { get; set; } = 12000;
+    public int WindowMaxMessages { get; set; } = 40;
+
     // query_database (#238 §4). The query runs inside a read-only transaction that first drops to
     // QueryRoleName via SET LOCAL ROLE — a non-superuser, SELECT-only role — so the model's SQL can
     // neither write nor reach privileged/file functions (the app login is a superuser; the read-only

--- a/src/DiscordEventService/Data/Configurations/ConversationEntityConfiguration.cs
+++ b/src/DiscordEventService/Data/Configurations/ConversationEntityConfiguration.cs
@@ -1,0 +1,16 @@
+using DiscordEventService.Data.Entities.Conversations;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
+namespace DiscordEventService.Data.Configurations;
+
+internal sealed class ConversationEntityConfiguration : IEntityTypeConfiguration<ConversationEntity>
+{
+    public void Configure(EntityTypeBuilder<ConversationEntity> builder)
+    {
+        builder.ToTable("conversation");
+
+        // The conversation key: one conversation per thread / DM channel.
+        builder.HasIndex(c => c.ChannelDiscordId).IsUnique();
+    }
+}

--- a/src/DiscordEventService/Data/Configurations/ConversationMessageEntityConfiguration.cs
+++ b/src/DiscordEventService/Data/Configurations/ConversationMessageEntityConfiguration.cs
@@ -1,0 +1,33 @@
+using DiscordEventService.Data.Entities.Conversations;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
+namespace DiscordEventService.Data.Configurations;
+
+internal sealed class ConversationMessageEntityConfiguration : IEntityTypeConfiguration<ConversationMessageEntity>
+{
+    // Role decides which columns a row carries: assistant rows may bundle tool calls,
+    // tool rows must name the call they answer, user rows carry only text.
+    private const string RoleShapeConstraintSql =
+        "(role = 0 AND tool_calls_json IS NULL AND tool_call_id IS NULL AND tool_result IS NULL) OR " +
+        "(role = 1 AND tool_call_id IS NULL AND tool_result IS NULL) OR " +
+        "(role = 2 AND tool_call_id IS NOT NULL AND tool_result IS NOT NULL AND tool_calls_json IS NULL)";
+
+    public void Configure(EntityTypeBuilder<ConversationMessageEntity> builder)
+    {
+        builder.ToTable("conversation_message",
+            t => t.HasCheckConstraint("ck_conversation_message_role_shape", RoleShapeConstraintSql));
+
+        // Window loads walk one conversation newest-first; the uuidv7 PK is the
+        // insertion order within it.
+        builder.HasIndex(m => new { m.ConversationId, m.Id });
+
+        builder.Property(m => m.ToolCallsJson).HasColumnType("jsonb");
+
+        // Append-only history — never cascade-delete it with the conversation row.
+        builder.HasOne(m => m.Conversation)
+            .WithMany()
+            .HasForeignKey(m => m.ConversationId)
+            .OnDelete(DeleteBehavior.Restrict);
+    }
+}

--- a/src/DiscordEventService/Data/Configurations/ConversationUsageEntityConfiguration.cs
+++ b/src/DiscordEventService/Data/Configurations/ConversationUsageEntityConfiguration.cs
@@ -1,0 +1,22 @@
+using DiscordEventService.Data.Entities.Conversations;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
+namespace DiscordEventService.Data.Configurations;
+
+internal sealed class ConversationUsageEntityConfiguration : IEntityTypeConfiguration<ConversationUsageEntity>
+{
+    public void Configure(EntityTypeBuilder<ConversationUsageEntity> builder)
+    {
+        builder.ToTable("conversation_usage");
+
+        // "Cost per user this month" is a single WHERE over these two (#256).
+        builder.HasIndex(u => new { u.InvokerId, u.CreatedAtUtc });
+        builder.HasIndex(u => u.ConversationId);
+
+        builder.HasOne(u => u.Conversation)
+            .WithMany()
+            .HasForeignKey(u => u.ConversationId)
+            .OnDelete(DeleteBehavior.Restrict);
+    }
+}

--- a/src/DiscordEventService/Data/DiscordDbContext.cs
+++ b/src/DiscordEventService/Data/DiscordDbContext.cs
@@ -1,3 +1,4 @@
+using DiscordEventService.Data.Entities.Conversations;
 using DiscordEventService.Data.Entities.Core;
 using DiscordEventService.Data.Entities.Events;
 using Microsoft.EntityFrameworkCore;
@@ -77,6 +78,12 @@ public sealed class DiscordDbContext(DbContextOptions<DiscordDbContext> options)
 
     // Indexed memes (#218): vision metadata per meme-channel image attachment
     public DbSet<MemeIndexEntity> MemeIndex => Set<MemeIndexEntity>();
+
+    // Conversational assistant memory + usage ledger (#267) — the assistant's replay
+    // store, deliberately separate from the ingestion tables above.
+    public DbSet<ConversationEntity> Conversations => Set<ConversationEntity>();
+    public DbSet<ConversationMessageEntity> ConversationMessages => Set<ConversationMessageEntity>();
+    public DbSet<ConversationUsageEntity> ConversationUsage => Set<ConversationUsageEntity>();
 
     protected override void OnModelCreating(ModelBuilder modelBuilder)
     {

--- a/src/DiscordEventService/Data/Entities/Conversations/ConversationEntity.cs
+++ b/src/DiscordEventService/Data/Entities/Conversations/ConversationEntity.cs
@@ -1,0 +1,22 @@
+namespace DiscordEventService.Data.Entities.Conversations;
+
+// One conversation per thread / DM channel (#267, ADR-0006 ¶15) — the channel
+// snowflake is the natural conversation key. Deliberately separate from the
+// ingestion tables (messages/message_events): this is the assistant's replay
+// store, not an ingested event (CONTEXT.md, three senses of "message").
+public class ConversationEntity
+{
+    public Guid Id { get; set; }
+
+    // Thread or DM channel snowflake — unique; the conversation key the handler
+    // already passes as ConversationContext.ChannelId.
+    public ulong ChannelDiscordId { get; set; }
+
+    // Null for a DM.
+    public ulong? GuildDiscordId { get; set; }
+
+    public DateTime CreatedAtUtc { get; set; }
+
+    // Bumped on every persisted message; pruning/ordering handle.
+    public DateTime LastActivityAtUtc { get; set; }
+}

--- a/src/DiscordEventService/Data/Entities/Conversations/ConversationMessageEntity.cs
+++ b/src/DiscordEventService/Data/Entities/Conversations/ConversationMessageEntity.cs
@@ -1,0 +1,61 @@
+namespace DiscordEventService.Data.Entities.Conversations;
+
+// Persisted as int in the DB — values are a data contract; never renumber or strip explicit values.
+public enum ConversationMessageRole
+{
+    User = 0,
+    Assistant = 1,
+    Tool = 2
+}
+
+// One row per ChatMessage the agentic loop appended (#267) — NOT one row per tool
+// call: an assistant message bundles N FunctionCallContent (its ToolCallsJson array),
+// while each tool result is already its own ChatMessage and gets its own row.
+// Append-only; the uuidv7 PK doubles as insertion order within a conversation.
+public class ConversationMessageEntity
+{
+    public Guid Id { get; set; }
+
+    public Guid ConversationId { get; set; }
+
+    // Monotonic per conversation: every message persisted during one
+    // GenerateReplyAsync turn (user + assistant rounds + tool results) shares it.
+    public int TurnIndex { get; set; }
+
+    public ConversationMessageRole Role { get; set; }
+
+    // The message's text content; null for a pure tool-call assistant message
+    // and for tool rows.
+    public string? Text { get; set; }
+
+    // Assistant rows only: JSON array of { id, name, argumentsJson } — arguments kept
+    // as raw JSON so rehydration rebuilds FunctionCallContent without re-serializing
+    // a dictionary of JsonElements.
+    public string? ToolCallsJson { get; set; }
+
+    // Tool rows only. ToolResult is the tool's raw string, stored as plain text —
+    // NEVER a serialized ChatMessage blob: rehydrating FunctionResultContent with a
+    // string Result keeps the OpenAI adapter's `as string` fast-path and byte-identical
+    // wire replay (a JsonElement Result replays quote-wrapped/escaped).
+    public string? ToolCallId { get; set; }
+    public string? ToolName { get; set; }
+    public string? ToolResult { get; set; }
+
+    // Reasoning content persisted for the record but STRIPPED on replay — stale
+    // thinking signatures aren't echoed back (research A-OQ2); revisit if reply
+    // quality suffers.
+    public string? Reasoning { get; set; }
+
+    // Provider-reported usage for the round that produced this message (assistant
+    // rows); null otherwise.
+    public int? PromptTokens { get; set; }
+    public int? CompletionTokens { get; set; }
+
+    // Local chars/4 estimate — the window budget currency (the per-request provider
+    // usage can't size a per-message window).
+    public int EstTokens { get; set; }
+
+    public DateTime CreatedAtUtc { get; set; }
+
+    public ConversationEntity Conversation { get; set; } = null!;
+}

--- a/src/DiscordEventService/Data/Entities/Conversations/ConversationUsageEntity.cs
+++ b/src/DiscordEventService/Data/Entities/Conversations/ConversationUsageEntity.cs
@@ -1,0 +1,43 @@
+namespace DiscordEventService.Data.Entities.Conversations;
+
+// The usage ledger (#267): one row per model-call ATTEMPT (a turn is multiple rounds;
+// §2 retries add attempt > 1 rows — failed attempts may still bill, so they are
+// recorded, not dropped). This table is the §3 soft-cap source and the future
+// enforcement seam.
+public class ConversationUsageEntity
+{
+    public Guid Id { get; set; }
+
+    public Guid ConversationId { get; set; }
+
+    // Who triggered the turn — denormalized on purpose (#256 amendment): per-user
+    // cost sums need a plain WHERE; joining through conversations misattributes
+    // multi-invoker threads.
+    public ulong InvokerId { get; set; }
+
+    public int TurnIndex { get; set; }
+    public int Round { get; set; }
+    public int Attempt { get; set; }
+
+    public string Model { get; set; } = "";
+
+    public int? PromptTokens { get; set; }
+    public int? CompletionTokens { get; set; }
+
+    // OpenRouter usage.cost (USD) recovered from the raw ChatTokenUsage patch.
+    public double? CostUsd { get; set; }
+
+    // Itemised §5 server-tool spend (cost_details / server-tool usage details);
+    // null until the provider reports them.
+    public double? UpstreamInferenceCostUsd { get; set; }
+    public int? WebSearchRequests { get; set; }
+
+    public long LatencyMs { get; set; }
+
+    // Mid-stream/pre-stream failure (§2 writes these; a failed attempt may still bill).
+    public bool Failed { get; set; }
+
+    public DateTime CreatedAtUtc { get; set; }
+
+    public ConversationEntity Conversation { get; set; } = null!;
+}

--- a/src/DiscordEventService/Data/Migrations/20260717201214_AddConversationMemoryAndUsageLedger.Designer.cs
+++ b/src/DiscordEventService/Data/Migrations/20260717201214_AddConversationMemoryAndUsageLedger.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using DiscordEventService.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using NpgsqlTypes;
@@ -12,9 +13,11 @@ using NpgsqlTypes;
 namespace DiscordEventService.Data.Migrations
 {
     [DbContext(typeof(DiscordDbContext))]
-    partial class DiscordDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260717201214_AddConversationMemoryAndUsageLedger")]
+    partial class AddConversationMemoryAndUsageLedger
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/DiscordEventService/Data/Migrations/20260717201214_AddConversationMemoryAndUsageLedger.cs
+++ b/src/DiscordEventService/Data/Migrations/20260717201214_AddConversationMemoryAndUsageLedger.cs
@@ -1,0 +1,126 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace DiscordEventService.Data.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddConversationMemoryAndUsageLedger : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "conversation",
+                columns: table => new
+                {
+                    id = table.Column<Guid>(type: "uuid", nullable: false, defaultValueSql: "uuidv7()"),
+                    channel_discord_id = table.Column<long>(type: "bigint", nullable: false),
+                    guild_discord_id = table.Column<long>(type: "bigint", nullable: true),
+                    created_at_utc = table.Column<DateTime>(type: "timestamp with time zone", nullable: false),
+                    last_activity_at_utc = table.Column<DateTime>(type: "timestamp with time zone", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("pk_conversation", x => x.id);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "conversation_message",
+                columns: table => new
+                {
+                    id = table.Column<Guid>(type: "uuid", nullable: false, defaultValueSql: "uuidv7()"),
+                    conversation_id = table.Column<Guid>(type: "uuid", nullable: false),
+                    turn_index = table.Column<int>(type: "integer", nullable: false),
+                    role = table.Column<int>(type: "integer", nullable: false),
+                    text = table.Column<string>(type: "text", nullable: true),
+                    tool_calls_json = table.Column<string>(type: "jsonb", nullable: true),
+                    tool_call_id = table.Column<string>(type: "text", nullable: true),
+                    tool_name = table.Column<string>(type: "text", nullable: true),
+                    tool_result = table.Column<string>(type: "text", nullable: true),
+                    reasoning = table.Column<string>(type: "text", nullable: true),
+                    prompt_tokens = table.Column<int>(type: "integer", nullable: true),
+                    completion_tokens = table.Column<int>(type: "integer", nullable: true),
+                    est_tokens = table.Column<int>(type: "integer", nullable: false),
+                    created_at_utc = table.Column<DateTime>(type: "timestamp with time zone", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("pk_conversation_message", x => x.id);
+                    table.CheckConstraint("ck_conversation_message_role_shape", "(role = 0 AND tool_calls_json IS NULL AND tool_call_id IS NULL AND tool_result IS NULL) OR (role = 1 AND tool_call_id IS NULL AND tool_result IS NULL) OR (role = 2 AND tool_call_id IS NOT NULL AND tool_result IS NOT NULL AND tool_calls_json IS NULL)");
+                    table.ForeignKey(
+                        name: "fk_conversation_message_conversation_conversation_id",
+                        column: x => x.conversation_id,
+                        principalTable: "conversation",
+                        principalColumn: "id",
+                        onDelete: ReferentialAction.Restrict);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "conversation_usage",
+                columns: table => new
+                {
+                    id = table.Column<Guid>(type: "uuid", nullable: false, defaultValueSql: "uuidv7()"),
+                    conversation_id = table.Column<Guid>(type: "uuid", nullable: false),
+                    invoker_id = table.Column<long>(type: "bigint", nullable: false),
+                    turn_index = table.Column<int>(type: "integer", nullable: false),
+                    round = table.Column<int>(type: "integer", nullable: false),
+                    attempt = table.Column<int>(type: "integer", nullable: false),
+                    model = table.Column<string>(type: "text", nullable: false),
+                    prompt_tokens = table.Column<int>(type: "integer", nullable: true),
+                    completion_tokens = table.Column<int>(type: "integer", nullable: true),
+                    cost_usd = table.Column<double>(type: "double precision", nullable: true),
+                    upstream_inference_cost_usd = table.Column<double>(type: "double precision", nullable: true),
+                    web_search_requests = table.Column<int>(type: "integer", nullable: true),
+                    latency_ms = table.Column<long>(type: "bigint", nullable: false),
+                    failed = table.Column<bool>(type: "boolean", nullable: false),
+                    created_at_utc = table.Column<DateTime>(type: "timestamp with time zone", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("pk_conversation_usage", x => x.id);
+                    table.ForeignKey(
+                        name: "fk_conversation_usage_conversations_conversation_id",
+                        column: x => x.conversation_id,
+                        principalTable: "conversation",
+                        principalColumn: "id",
+                        onDelete: ReferentialAction.Restrict);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "ix_conversation_channel_discord_id",
+                table: "conversation",
+                column: "channel_discord_id",
+                unique: true);
+
+            migrationBuilder.CreateIndex(
+                name: "ix_conversation_message_conversation_id_id",
+                table: "conversation_message",
+                columns: new[] { "conversation_id", "id" });
+
+            migrationBuilder.CreateIndex(
+                name: "ix_conversation_usage_conversation_id",
+                table: "conversation_usage",
+                column: "conversation_id");
+
+            migrationBuilder.CreateIndex(
+                name: "ix_conversation_usage_invoker_id_created_at_utc",
+                table: "conversation_usage",
+                columns: new[] { "invoker_id", "created_at_utc" });
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "conversation_message");
+
+            migrationBuilder.DropTable(
+                name: "conversation_usage");
+
+            migrationBuilder.DropTable(
+                name: "conversation");
+        }
+    }
+}

--- a/src/DiscordEventService/Services/Conversation/ConversationMemoryService.cs
+++ b/src/DiscordEventService/Services/Conversation/ConversationMemoryService.cs
@@ -56,16 +56,22 @@ internal sealed class ConversationMemoryService(
             .SingleOrDefaultAsync(c => c.ChannelDiscordId == channelDiscordId, cancellationToken);
         if (conversation is null)
         {
-            conversation = new ConversationEntity
-            {
-                ChannelDiscordId = channelDiscordId,
-                GuildDiscordId = guildDiscordId,
-                CreatedAtUtc = DateTime.UtcNow,
-                LastActivityAtUtc = DateTime.UtcNow,
-            };
-            db.Conversations.Add(conversation);
-            await db.SaveChangesAsync(cancellationToken);
-            logger.LogDebug("Started conversation store for channel {ChannelId}", channelDiscordId);
+            // The first two messages of a brand-new conversation can race this create;
+            // GetOrInsertAsync resolves the unique-index conflict to the winner's row.
+            var (existing, inserted) = await db.Conversations.GetOrInsertAsync(
+                c => c.ChannelDiscordId == channelDiscordId,
+                () => new ConversationEntity
+                {
+                    ChannelDiscordId = channelDiscordId,
+                    GuildDiscordId = guildDiscordId,
+                    CreatedAtUtc = DateTime.UtcNow,
+                    LastActivityAtUtc = DateTime.UtcNow,
+                },
+                cancellationToken);
+            conversation = existing ?? throw new InvalidOperationException(
+                $"Conversation row for channel {channelDiscordId} vanished during get-or-insert");
+            if (inserted)
+                logger.LogDebug("Started conversation store for channel {ChannelId}", channelDiscordId);
         }
 
         var lastTurnIndex = await db.ConversationMessages
@@ -246,6 +252,9 @@ internal sealed class ConversationMemoryService(
         return included
             .SelectMany(group => group)
             .Select(Rehydrate)
+            // A reasoning-only assistant row rehydrates to zero contents (reasoning is
+            // stripped) — don't replay an empty message some providers could reject.
+            .Where(message => message.Contents.Count > 0)
             .ToList();
     }
 

--- a/src/DiscordEventService/Services/Conversation/ConversationMemoryService.cs
+++ b/src/DiscordEventService/Services/Conversation/ConversationMemoryService.cs
@@ -1,0 +1,367 @@
+using System.Text.Json;
+using DiscordEventService.Configuration;
+using DiscordEventService.Data;
+using DiscordEventService.Data.Entities.Conversations;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.AI;
+using Microsoft.Extensions.Options;
+
+namespace DiscordEventService.Services.Conversation;
+
+// A turn's handle into the conversation store (#267): which conversation it belongs to,
+// its monotonic turn index, and the token-windowed replay of everything stored so far.
+internal sealed record ConversationTurnState(
+    Guid ConversationId, int TurnIndex, IReadOnlyList<ChatMessage> Window);
+
+// One model-call attempt's ledger row content (#267). §1 always writes Attempt=1 and
+// Failed=false; the §2 retry policy adds attempt>1 and failed rows (which may still bill).
+internal sealed record ConversationRoundUsage(
+    int Round, int Attempt, string Model,
+    int? PromptTokens, int? CompletionTokens,
+    double? CostUsd, double? UpstreamInferenceCostUsd, int? WebSearchRequests,
+    long LatencyMs, bool Failed);
+
+// The conversation store + usage ledger (#267, ADR-0006 ¶15): durable per-conversation
+// memory for the agentic loop. Append-only writes at the loop's append points (awaited,
+// inside the turn — a crash leaves a consistent prefix) and a token-windowed rehydration
+// that replays byte-identical wire messages (see ToWireText for the object?-Result trap).
+// Scoped over the request DbContext like MemeSearchService; dual-registered via
+// CoreServiceRegistration.CoreServiceTypes.
+internal sealed class ConversationMemoryService(
+    DiscordDbContext db,
+    IOptions<ConversationOptions> conversationOptions,
+    ILogger<ConversationMemoryService> logger)
+{
+    // Stored shape of one assistant tool call inside the tool_calls_json array.
+    // ArgumentsJson keeps the model's raw JSON arguments so rehydration rebuilds the
+    // same dictionary the adapter serialized live.
+    private sealed record StoredToolCall
+    {
+        public required string Id { get; init; }
+        public required string Name { get; init; }
+        public required string ArgumentsJson { get; init; }
+    }
+
+    private static readonly JsonSerializerOptions ToolCallsSerializerOptions = new(JsonSerializerDefaults.Web);
+
+    // Loads (or creates) the channel's conversation and builds the replay window for a
+    // new turn. The window walks stored messages newest->oldest summing est_tokens until
+    // WindowTokenBudget, backstopped by WindowMaxMessages — and never splits an assistant
+    // tool-call message from its tool-result rows (a dangling tool_call_id is a provider 400).
+    public async Task<ConversationTurnState> BeginTurnAsync(
+        ulong channelDiscordId, ulong? guildDiscordId, CancellationToken cancellationToken)
+    {
+        var options = conversationOptions.Value;
+        var conversation = await db.Conversations
+            .SingleOrDefaultAsync(c => c.ChannelDiscordId == channelDiscordId, cancellationToken);
+        if (conversation is null)
+        {
+            conversation = new ConversationEntity
+            {
+                ChannelDiscordId = channelDiscordId,
+                GuildDiscordId = guildDiscordId,
+                CreatedAtUtc = DateTime.UtcNow,
+                LastActivityAtUtc = DateTime.UtcNow,
+            };
+            db.Conversations.Add(conversation);
+            await db.SaveChangesAsync(cancellationToken);
+            logger.LogDebug("Started conversation store for channel {ChannelId}", channelDiscordId);
+        }
+
+        var lastTurnIndex = await db.ConversationMessages
+            .Where(m => m.ConversationId == conversation.Id)
+            .MaxAsync(m => (int?)m.TurnIndex, cancellationToken);
+
+        // The uuidv7 PK is insertion order; the newest WindowMaxMessages rows are the
+        // most history the window may ever replay.
+        var rows = await db.ConversationMessages
+            .Where(m => m.ConversationId == conversation.Id)
+            .OrderByDescending(m => m.Id)
+            .Take(options.WindowMaxMessages)
+            .ToListAsync(cancellationToken);
+        rows.Reverse();
+
+        var window = BuildWindow(rows, options.WindowTokenBudget);
+        return new ConversationTurnState(conversation.Id, (lastTurnIndex ?? -1) + 1, window);
+    }
+
+    public async Task PersistUserMessageAsync(
+        ConversationTurnState turn, string text, CancellationToken cancellationToken)
+    {
+        db.ConversationMessages.Add(new ConversationMessageEntity
+        {
+            ConversationId = turn.ConversationId,
+            TurnIndex = turn.TurnIndex,
+            Role = ConversationMessageRole.User,
+            Text = text,
+            EstTokens = EstimateTokens(text),
+            CreatedAtUtc = DateTime.UtcNow,
+        });
+        await TouchAndSaveAsync(turn.ConversationId, cancellationToken);
+    }
+
+    // Persists one round's assembled assistant messages (text + tool calls + reasoning).
+    // The provider-reported round usage lands on the round's first assistant row.
+    public async Task PersistAssistantMessagesAsync(
+        ConversationTurnState turn, IEnumerable<ChatMessage> messages,
+        int? promptTokens, int? completionTokens, CancellationToken cancellationToken)
+    {
+        var usageRecorded = false;
+        foreach (var message in messages)
+        {
+            var text = message.Text;
+            var reasoning = string.Concat(
+                message.Contents.OfType<TextReasoningContent>().Select(content => content.Text));
+            var toolCallsJson = SerializeToolCalls(message.Contents.OfType<FunctionCallContent>().ToList());
+            if (string.IsNullOrEmpty(text) && string.IsNullOrEmpty(reasoning) && toolCallsJson is null)
+                continue;
+
+            db.ConversationMessages.Add(new ConversationMessageEntity
+            {
+                ConversationId = turn.ConversationId,
+                TurnIndex = turn.TurnIndex,
+                Role = ConversationMessageRole.Assistant,
+                Text = string.IsNullOrEmpty(text) ? null : text,
+                ToolCallsJson = toolCallsJson,
+                Reasoning = string.IsNullOrEmpty(reasoning) ? null : reasoning,
+                PromptTokens = usageRecorded ? null : promptTokens,
+                CompletionTokens = usageRecorded ? null : completionTokens,
+                EstTokens = EstimateTokens(text, toolCallsJson, reasoning),
+                CreatedAtUtc = DateTime.UtcNow,
+            });
+            usageRecorded = true;
+        }
+
+        await TouchAndSaveAsync(turn.ConversationId, cancellationToken);
+    }
+
+    public async Task PersistToolResultAsync(
+        ConversationTurnState turn, string toolName, FunctionResultContent result,
+        CancellationToken cancellationToken)
+    {
+        var wireText = ToWireText(result);
+        db.ConversationMessages.Add(new ConversationMessageEntity
+        {
+            ConversationId = turn.ConversationId,
+            TurnIndex = turn.TurnIndex,
+            Role = ConversationMessageRole.Tool,
+            ToolCallId = result.CallId,
+            ToolName = toolName,
+            ToolResult = wireText,
+            EstTokens = EstimateTokens(wireText),
+            CreatedAtUtc = DateTime.UtcNow,
+        });
+        await TouchAndSaveAsync(turn.ConversationId, cancellationToken);
+    }
+
+    public async Task RecordUsageAsync(
+        ConversationTurnState turn, ulong invokerId, ConversationRoundUsage usage,
+        CancellationToken cancellationToken)
+    {
+        db.ConversationUsage.Add(new ConversationUsageEntity
+        {
+            ConversationId = turn.ConversationId,
+            InvokerId = invokerId,
+            TurnIndex = turn.TurnIndex,
+            Round = usage.Round,
+            Attempt = usage.Attempt,
+            Model = usage.Model,
+            PromptTokens = usage.PromptTokens,
+            CompletionTokens = usage.CompletionTokens,
+            CostUsd = usage.CostUsd,
+            UpstreamInferenceCostUsd = usage.UpstreamInferenceCostUsd,
+            WebSearchRequests = usage.WebSearchRequests,
+            LatencyMs = usage.LatencyMs,
+            Failed = usage.Failed,
+            CreatedAtUtc = DateTime.UtcNow,
+        });
+        await db.SaveChangesAsync(cancellationToken);
+    }
+
+    // The exact string MEAI's OpenAI adapter puts on the wire for a tool result: the
+    // `Result as string` fast-path, else the same JSON serialization it falls back to.
+    // Persisting THIS (and rehydrating Result as a string, which re-hits the fast-path)
+    // makes the replayed tool message byte-identical whether the live Result was a raw
+    // string or an AIFunctionFactory JsonElement (research A1/A-OQ1).
+    private static string ToWireText(FunctionResultContent result)
+    {
+        if (result.Result is string text)
+            return text;
+        if (result.Result is null)
+            return string.Empty;
+
+        try
+        {
+            return JsonSerializer.Serialize(
+                result.Result, AIJsonUtilities.DefaultOptions.GetTypeInfo(typeof(object)));
+        }
+        catch (NotSupportedException)
+        {
+            return string.Empty;
+        }
+    }
+
+    private static string? SerializeToolCalls(IReadOnlyList<FunctionCallContent> calls)
+    {
+        if (calls.Count == 0)
+            return null;
+
+        var stored = calls.Select(call => new StoredToolCall
+        {
+            Id = call.CallId,
+            Name = call.Name,
+            ArgumentsJson = JsonSerializer.Serialize(
+                call.Arguments ?? new Dictionary<string, object?>(), AIJsonUtilities.DefaultOptions),
+        });
+        return JsonSerializer.Serialize(stored, ToolCallsSerializerOptions);
+    }
+
+    // chars/4 — OpenRouter normalizes token counts to a GPT tokenizer, so this is a fair
+    // zero-dependency proxy for budgeting; the ledger keeps the real provider numbers.
+    private const int CharsPerEstimatedToken = 4;
+
+    private static int EstimateTokens(params string?[] parts) =>
+        Math.Max(1, parts.Sum(part => part?.Length ?? 0) / CharsPerEstimatedToken);
+
+    // A window "group" is the unsplittable unit: an assistant message carrying tool calls
+    // plus all its tool-result rows, or any other message alone. Incomplete groups (a
+    // crash persisted the calls but not every result, or the backstop cut the head) are
+    // dropped whole rather than replayed dangling.
+    private IReadOnlyList<ChatMessage> BuildWindow(List<ConversationMessageEntity> rows, int tokenBudget)
+    {
+        var groups = GroupRows(rows);
+
+        List<List<ConversationMessageEntity>> included = [];
+        var totalTokens = 0;
+        for (var i = groups.Count - 1; i >= 0; i--)
+        {
+            var groupTokens = groups[i].Sum(row => row.EstTokens);
+            if (totalTokens + groupTokens > tokenBudget)
+                break;
+            totalTokens += groupTokens;
+            included.Add(groups[i]);
+        }
+        included.Reverse();
+
+        return included
+            .SelectMany(group => group)
+            .Select(Rehydrate)
+            .ToList();
+    }
+
+    private List<List<ConversationMessageEntity>> GroupRows(List<ConversationMessageEntity> rows)
+    {
+        List<List<ConversationMessageEntity>> groups = [];
+        List<ConversationMessageEntity>? openGroup = null;
+        HashSet<string>? pendingCallIds = null;
+
+        foreach (var row in rows)
+        {
+            if (row.Role == ConversationMessageRole.Tool)
+            {
+                if (openGroup is not null && row.ToolCallId is not null && pendingCallIds!.Remove(row.ToolCallId))
+                {
+                    openGroup.Add(row);
+                    continue;
+                }
+
+                // Orphan tool row: its assistant head fell outside the loaded rows (or
+                // was never persisted) — replaying it dangling is a provider 400.
+                logger.LogDebug("Dropping orphan tool row {RowId} from the replay window", row.Id);
+                continue;
+            }
+
+            CloseGroup(groups, ref openGroup, ref pendingCallIds);
+
+            if (row.Role == ConversationMessageRole.Assistant && row.ToolCallsJson is not null)
+            {
+                openGroup = [row];
+                pendingCallIds = ParseToolCallIds(row.ToolCallsJson);
+            }
+            else
+            {
+                groups.Add([row]);
+            }
+        }
+
+        CloseGroup(groups, ref openGroup, ref pendingCallIds);
+        return groups;
+    }
+
+    // Seals the open tool-call group: kept only when every call got its result row.
+    private void CloseGroup(
+        List<List<ConversationMessageEntity>> groups,
+        ref List<ConversationMessageEntity>? openGroup,
+        ref HashSet<string>? pendingCallIds)
+    {
+        if (openGroup is null)
+            return;
+
+        if (pendingCallIds!.Count == 0)
+            groups.Add(openGroup);
+        else
+            logger.LogDebug("Dropping incomplete tool-call group ({Missing} unanswered call(s)) from the replay window",
+                pendingCallIds.Count);
+
+        openGroup = null;
+        pendingCallIds = null;
+    }
+
+    private HashSet<string> ParseToolCallIds(string toolCallsJson)
+    {
+        try
+        {
+            var calls = JsonSerializer.Deserialize<List<StoredToolCall>>(toolCallsJson, ToolCallsSerializerOptions) ?? [];
+            return calls.Select(call => call.Id).ToHashSet(StringComparer.Ordinal);
+        }
+        catch (JsonException ex)
+        {
+            logger.LogWarning(ex, "Unparseable tool_calls_json in the conversation store; treating the group as incomplete");
+            return ["__unparseable__"];
+        }
+    }
+
+    private ChatMessage Rehydrate(ConversationMessageEntity row)
+    {
+        switch (row.Role)
+        {
+            case ConversationMessageRole.User:
+                return new ChatMessage(ChatRole.User, row.Text ?? string.Empty);
+
+            case ConversationMessageRole.Tool:
+                // Result MUST be a string so the adapter's fast-path emits the stored
+                // wire text verbatim — see ToWireText.
+                return new ChatMessage(ChatRole.Tool,
+                    [new FunctionResultContent(row.ToolCallId!, row.ToolResult ?? string.Empty)]);
+
+            default:
+                List<AIContent> contents = [];
+                // Reasoning is persisted but deliberately NOT replayed — stale thinking
+                // signatures (research A-OQ2); revisit if reply quality suffers.
+                if (!string.IsNullOrEmpty(row.Text))
+                    contents.Add(new TextContent(row.Text));
+                if (row.ToolCallsJson is not null)
+                    contents.AddRange(RehydrateToolCalls(row.ToolCallsJson));
+                return new ChatMessage(ChatRole.Assistant, contents);
+        }
+    }
+
+    private IEnumerable<FunctionCallContent> RehydrateToolCalls(string toolCallsJson)
+    {
+        var calls = JsonSerializer.Deserialize<List<StoredToolCall>>(toolCallsJson, ToolCallsSerializerOptions) ?? [];
+        foreach (var call in calls)
+        {
+            var arguments = JsonSerializer.Deserialize<Dictionary<string, object?>>(
+                call.ArgumentsJson, AIJsonUtilities.DefaultOptions) ?? [];
+            yield return new FunctionCallContent(call.Id, call.Name, arguments);
+        }
+    }
+
+    private async Task TouchAndSaveAsync(Guid conversationId, CancellationToken cancellationToken)
+    {
+        var conversation = await db.Conversations.FindAsync([conversationId], cancellationToken);
+        if (conversation is not null)
+            conversation.LastActivityAtUtc = DateTime.UtcNow;
+        await db.SaveChangesAsync(cancellationToken);
+    }
+}

--- a/src/DiscordEventService/Services/Conversation/ConversationService.cs
+++ b/src/DiscordEventService/Services/Conversation/ConversationService.cs
@@ -16,6 +16,7 @@ namespace DiscordEventService.Services.Conversation;
 internal sealed class ConversationService(
     IChatClient chatClient,
     ConversationToolRegistry toolRegistry,
+    ConversationMemoryService memory,
     IOptions<ConversationOptions> conversationOptions,
     IOptions<OpenRouterOptions> openRouterOptions,
     ILogger<ConversationService> logger)
@@ -50,9 +51,16 @@ internal sealed class ConversationService(
         var chatOptions = OpenRouterChatOptions.Create(options.ReasoningEffort);
         chatOptions.Tools = toolset.Tools;
 
+        // Durable memory (#267): rehydrate the conversation's stored window, then persist
+        // the incoming user message — awaited, inside the turn, so a crash mid-turn
+        // leaves a consistent prefix. The channel snowflake is the conversation key.
+        var memoryTurn = await memory.BeginTurnAsync(context.ChannelId, context.GuildId, cancellationToken);
+        await memory.PersistUserMessageAsync(memoryTurn, userMessage ?? string.Empty, cancellationToken);
+
         List<ChatMessage> messages =
         [
             new(ChatRole.System, BuildSystemPrompt(options)),
+            .. memoryTurn.Window,
             new(ChatRole.User, userMessage ?? string.Empty),
         ];
 
@@ -82,8 +90,10 @@ internal sealed class ConversationService(
         for (var round = 1; round <= options.MaxToolRounds; round++)
         {
             var sink = new List<ChatResponseUpdate>();
+            var roundStopwatch = Stopwatch.StartNew();
             await foreach (var renderEvent in StreamRoundAsync(chatOptions, sink))
                 yield return renderEvent;
+            roundStopwatch.Stop();
 
             // MEAI assembles the streamed tool-calls for us — act on the assembled response,
             // never reassemble fragments by index. Append the assistant turn (text + any
@@ -92,6 +102,11 @@ internal sealed class ConversationService(
             var response = sink.ToChatResponse();
             messages.AddRange(response.Messages);
             turnCostUsd += RecordRoundCost(sink, round, turn);
+
+            var roundUsage = ExtractRoundUsage(sink, round, options.Model, roundStopwatch.ElapsedMilliseconds);
+            await memory.PersistAssistantMessagesAsync(memoryTurn, response.Messages,
+                roundUsage.PromptTokens, roundUsage.CompletionTokens, cancellationToken);
+            await memory.RecordUsageAsync(memoryTurn, context.InvokerId, roundUsage, cancellationToken);
 
             var toolCalls = response.Messages
                 .SelectMany(message => message.Contents)
@@ -118,6 +133,7 @@ internal sealed class ConversationService(
             {
                 var result = await toolset.InvokeAsync(call, cancellationToken);
                 messages.Add(new ChatMessage(ChatRole.Tool, [result]));
+                await memory.PersistToolResultAsync(memoryTurn, call.Name, result, cancellationToken);
             }
 
             yield return new ConversationUpdate.ToolBatchSummary(SummarizeToolBatch(toolCalls));
@@ -130,9 +146,19 @@ internal sealed class ConversationService(
         turn?.SetTag("conversation.hit_round_cap", true);
 
         var finalSink = new List<ChatResponseUpdate>();
+        var finalStopwatch = Stopwatch.StartNew();
         await foreach (var renderEvent in StreamRoundAsync(OpenRouterChatOptions.Create(options.ReasoningEffort), finalSink))
             yield return renderEvent;
+        finalStopwatch.Stop();
         turnCostUsd += RecordRoundCost(finalSink, options.MaxToolRounds + 1, turn);
+
+        var finalResponse = finalSink.ToChatResponse();
+        var finalUsage = ExtractRoundUsage(
+            finalSink, options.MaxToolRounds + 1, options.Model, finalStopwatch.ElapsedMilliseconds);
+        await memory.PersistAssistantMessagesAsync(memoryTurn, finalResponse.Messages,
+            finalUsage.PromptTokens, finalUsage.CompletionTokens, cancellationToken);
+        await memory.RecordUsageAsync(memoryTurn, context.InvokerId, finalUsage, cancellationToken);
+
         if (!HadText(finalSink))
             yield return new ConversationUpdate.AssistantTextDelta(CapReachedFallback);
         turn?.SetTag("conversation.cost_usd", turnCostUsd);
@@ -179,6 +205,37 @@ internal sealed class ConversationService(
 #pragma warning disable SCME0001 // ChatTokenUsage.Patch (JsonPatch) is experimental.
         return raw.Patch.TryGetValue("$.cost"u8, out double cost) ? cost : null;
 #pragma warning restore SCME0001
+    }
+
+    // Everything one ledger row needs from a round's streamed updates (#267): MEAI's
+    // typed token counts plus the OpenRouter extras recovered from the raw usage patch
+    // (`cost`, and the §5 itemisation fields when the provider reports them). §1 always
+    // records attempt 1 / not-failed; the §2 retry policy widens both.
+    private static ConversationRoundUsage ExtractRoundUsage(
+        List<ChatResponseUpdate> updates, int round, string model, long latencyMs)
+    {
+        var usage = updates
+            .SelectMany(update => update.Contents)
+            .OfType<UsageContent>()
+            .LastOrDefault();
+
+        double? upstreamCostUsd = null;
+        int? webSearchRequests = null;
+        if (usage?.RawRepresentation is ChatTokenUsage raw)
+        {
+#pragma warning disable SCME0001 // ChatTokenUsage.Patch (JsonPatch) is experimental.
+            if (raw.Patch.TryGetValue("$.cost_details.upstream_inference_cost"u8, out double upstream))
+                upstreamCostUsd = upstream;
+            if (raw.Patch.TryGetValue("$.server_tool_use.web_search_requests"u8, out int searches))
+                webSearchRequests = searches;
+#pragma warning restore SCME0001
+        }
+
+        return new ConversationRoundUsage(
+            round, Attempt: 1, model,
+            (int?)usage?.Details.InputTokenCount, (int?)usage?.Details.OutputTokenCount,
+            ExtractCostUsd(updates), upstreamCostUsd, webSearchRequests,
+            latencyMs, Failed: false);
     }
 
     private static string BuildSystemPrompt(ConversationOptions options) =>

--- a/src/DiscordEventService/Services/CoreServiceRegistration.cs
+++ b/src/DiscordEventService/Services/CoreServiceRegistration.cs
@@ -24,6 +24,7 @@ internal static class CoreServiceRegistration
         typeof(GuildStatsService),
         typeof(DatabaseQueryService),
         typeof(ConversationToolRegistry),
+        typeof(ConversationMemoryService),
         typeof(ConversationService),
     ];
 

--- a/tests/DiscordEventService.Tests/ConversationLiveApiTests.cs
+++ b/tests/DiscordEventService.Tests/ConversationLiveApiTests.cs
@@ -87,8 +87,10 @@ public sealed class ConversationLiveApiTests(PostgresFixture fixture)
             new DatabaseSchemaHint("schema hint"),
             conversationOptions,
             NullLogger<ConversationToolRegistry>.Instance);
+        var memory = new ConversationMemoryService(
+            NewContext(), conversationOptions, NullLogger<ConversationMemoryService>.Instance);
         var service = new ConversationService(
-            chatClient, registry, conversationOptions, openRouterOptions, NullLogger<ConversationService>.Instance);
+            chatClient, registry, memory, conversationOptions, openRouterOptions, NullLogger<ConversationService>.Instance);
 
         var context = new ConversationContext(GuildDiscordId, InvokerId: 1UL, "tester", IsAdmin: false, ChannelId: 9UL);
 

--- a/tests/DiscordEventService.Tests/ConversationLoopTests.cs
+++ b/tests/DiscordEventService.Tests/ConversationLoopTests.cs
@@ -41,6 +41,11 @@ public sealed class ConversationLoopTests(PostgresFixture fixture)
         await _db.Channels.ExecuteDeleteAsync();
         await _db.Users.ExecuteDeleteAsync();
         await _db.Guilds.ExecuteDeleteAsync();
+        // #267: the loop now persists into the conversation store; without cleanup a prior
+        // test's history replays into the next test's transcript.
+        await _db.ConversationMessages.ExecuteDeleteAsync();
+        await _db.ConversationUsage.ExecuteDeleteAsync();
+        await _db.Conversations.ExecuteDeleteAsync();
 
         _guild = new GuildEntity { DiscordId = GuildDiscordId, Name = "g" };
         _db.Guilds.Add(_guild);
@@ -190,6 +195,7 @@ public sealed class ConversationLoopTests(PostgresFixture fixture)
         return new ConversationService(
             client,
             registry,
+            new ConversationMemoryService(NewContext(), conversationOptions, NullLogger<ConversationMemoryService>.Instance),
             conversationOptions,
             openRouterOptions,
             NullLogger<ConversationService>.Instance);

--- a/tests/DiscordEventService.Tests/ConversationMemoryTests.cs
+++ b/tests/DiscordEventService.Tests/ConversationMemoryTests.cs
@@ -235,6 +235,26 @@ public sealed class ConversationMemoryTests(PostgresFixture fixture)
         Assert.DoesNotContain(replayed.Contents, c => c is TextReasoningContent);
     }
 
+    [Fact]
+    public async Task ReasoningOnlyAssistantRow_IsNotReplayedAsAnEmptyMessage()
+    {
+        var memory = BuildMemory();
+        var turn = await memory.BeginTurnAsync(ThreadChannelId, GuildDiscordId, CancellationToken.None);
+
+        await memory.PersistUserMessageAsync(turn, "pytanie", CancellationToken.None);
+        // Degenerate round: reasoning but no visible text and no tool call.
+        await memory.PersistAssistantMessagesAsync(turn,
+            [new ChatMessage(ChatRole.Assistant, [new TextReasoningContent("tylko rozumowanie")])],
+            null, null, CancellationToken.None);
+
+        var next = await memory.BeginTurnAsync(ThreadChannelId, GuildDiscordId, CancellationToken.None);
+
+        // The row is persisted for the record but must not replay as an empty message.
+        Assert.Equal(2, await _db.ConversationMessages.CountAsync());
+        var replayed = Assert.Single(next.Window);
+        Assert.Equal("pytanie", replayed.Text);
+    }
+
     private static ConversationContext Context() =>
         new(GuildDiscordId, InvokerId, "tester", IsAdmin: false, ChannelId: ThreadChannelId);
 

--- a/tests/DiscordEventService.Tests/ConversationMemoryTests.cs
+++ b/tests/DiscordEventService.Tests/ConversationMemoryTests.cs
@@ -1,0 +1,488 @@
+using System.ClientModel;
+using System.ClientModel.Primitives;
+using System.Net;
+using System.Runtime.CompilerServices;
+using System.Text;
+using System.Text.Json;
+using DiscordEventService.Configuration;
+using DiscordEventService.Data;
+using DiscordEventService.Data.Entities.Core;
+using DiscordEventService.Services.Conversation;
+using DiscordEventService.Services.MemeIndexing;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.AI;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using OpenAI;
+using Xunit;
+
+namespace DiscordEventService.Tests;
+
+// #267 conversation memory + usage ledger, against a real Postgres (Testcontainers, no
+// DB mocking). The headline test is the byte-fidelity replay (research A-OQ1): a stored
+// tool round must rehydrate into the exact wire bytes the model saw live — through the
+// REAL MEAI OpenAI adapter with the HTTP transport faked, so the `object?` Result trap
+// (a JsonElement replays quote-wrapped) would be caught here, not in production.
+public sealed class ConversationMemoryTests(PostgresFixture fixture)
+    : IClassFixture<PostgresFixture>, IAsyncLifetime
+{
+    private const ulong GuildDiscordId = 21UL;
+    private const ulong ChannelDiscordId = 22UL;
+    private const ulong ThreadChannelId = 23UL;
+    private const ulong InvokerId = 42UL;
+    private const ulong MemeMessageId = 2101UL;
+
+    private DiscordDbContext _db = null!;
+
+    public async Task InitializeAsync()
+    {
+        _db = NewContext();
+        await _db.Database.MigrateAsync();
+
+        await _db.ConversationMessages.ExecuteDeleteAsync();
+        await _db.ConversationUsage.ExecuteDeleteAsync();
+        await _db.Conversations.ExecuteDeleteAsync();
+        await _db.MemeIndex.ExecuteDeleteAsync();
+        await _db.Messages.ExecuteDeleteAsync();
+        await _db.Channels.ExecuteDeleteAsync();
+        await _db.Users.ExecuteDeleteAsync();
+        await _db.Guilds.ExecuteDeleteAsync();
+
+        await SeedTurtleMemeAsync();
+    }
+
+    public Task DisposeAsync() => _db.DisposeAsync().AsTask();
+
+    // Byte-fidelity (the A-OQ1 test): live tool round -> store -> restart -> follow-up.
+    // The tool message and the assistant tool_calls the model sees on the follow-up must
+    // be byte-identical to what it saw live in turn 1.
+    [Fact]
+    public async Task FollowUpAfterRestart_ReplaysToolRound_ByteIdenticalOnTheWire()
+    {
+        var transport = new CaptureTransport(callIndex => callIndex switch
+        {
+            // Turn 1, round 1: the model calls meme_search (unicode args stress the bytes).
+            0 => SseToolCall("call_1", "meme_search", "{\"query\":\"żółw\",\"limit\":5}"),
+            // Turn 1, round 2: final answer + usage frame (exercises the ledger extraction).
+            1 => SseText("Znalazłem mema o żółwiu."),
+            // Turn 2 (after "restart"): plain answer.
+            _ => SseText("Tak, to ten sam żółw."),
+        });
+
+        // Turn 1 — live: real adapter, real tool dispatch against the seeded meme.
+        await CollectAsync(BuildRealAdapterService(transport, out _)
+            .GenerateReplyAsync("znajdź mema o żółwiu", Context(), CancellationToken.None));
+
+        // Turn 2 — fresh service + fresh DbContexts = a process restart; same channel.
+        await CollectAsync(BuildRealAdapterService(transport, out _)
+            .GenerateReplyAsync("a to na pewno żółw?", Context(), CancellationToken.None));
+
+        Assert.Equal(3, transport.RequestBodies.Count);
+
+        // Live wire: turn 1's second call carried the tool round back to the model.
+        var liveToolMessage = FindMessage(transport.RequestBodies[1], "tool");
+        var liveToolCalls = FindToolCallsArray(transport.RequestBodies[1]);
+        // Replayed wire: turn 2's only call rehydrated that round from the store.
+        var replayedToolMessage = FindMessage(transport.RequestBodies[2], "tool");
+        var replayedToolCalls = FindToolCallsArray(transport.RequestBodies[2]);
+
+        // THE assertion: byte-identical wire replay (a JsonElement-typed Result would
+        // come back quote-wrapped/escaped here and fail).
+        Assert.Equal(liveToolMessage, replayedToolMessage);
+        Assert.Equal(liveToolCalls, replayedToolCalls);
+
+        // And the replayed transcript actually carried turn 1 (user + final answer).
+        var turn2Messages = MessagesOf(transport.RequestBodies[2]);
+        Assert.Contains(turn2Messages, m => m.Contains("znajdź mema o żółwiu"));
+        Assert.Contains(turn2Messages, m => m.Contains("Znalazłem mema o żółwiu."));
+    }
+
+    [Fact]
+    public async Task ToolRound_LedgerRowsPerRound_WithCostTokensAndInvoker()
+    {
+        var transport = new CaptureTransport(callIndex => callIndex switch
+        {
+            0 => SseToolCall("call_1", "meme_search", "{\"query\":\"żółw\",\"limit\":5}"),
+            _ => SseText("Gotowe."),
+        });
+
+        await CollectAsync(BuildRealAdapterService(transport, out var conversationOptions)
+            .GenerateReplyAsync("znajdź mema o żółwiu", Context(), CancellationToken.None));
+
+        var rows = await _db.ConversationUsage.OrderBy(u => u.Round).ToListAsync();
+        Assert.Equal(2, rows.Count);
+        Assert.All(rows, row =>
+        {
+            Assert.Equal(InvokerId, row.InvokerId);
+            Assert.Equal(conversationOptions.Value.Model, row.Model);
+            Assert.Equal(1, row.Attempt);
+            Assert.False(row.Failed);
+            Assert.Equal(0, row.TurnIndex);
+            Assert.True(row.LatencyMs >= 0);
+        });
+        Assert.Equal([1, 2], rows.Select(r => r.Round));
+        // The canned usage frame flows through the raw ChatTokenUsage patch into the row.
+        Assert.All(rows, row =>
+        {
+            Assert.Equal(10, row.PromptTokens);
+            Assert.Equal(5, row.CompletionTokens);
+            Assert.Equal(0.01, row.CostUsd);
+            Assert.Equal(0.008, row.UpstreamInferenceCostUsd);
+        });
+
+        // "Cost per user this month" is a single WHERE (#256).
+        var monthlyCost = await _db.ConversationUsage
+            .Where(u => u.InvokerId == InvokerId && u.CreatedAtUtc >= DateTime.UtcNow.AddDays(-30))
+            .SumAsync(u => u.CostUsd ?? 0);
+        Assert.Equal(0.02, monthlyCost, precision: 10);
+    }
+
+    [Fact]
+    public async Task FollowUpTurn_SeesPriorUserAndAssistantMessages()
+    {
+        var client = new RecordingChatClient(_ => Stream("Pierwsza odpowiedź."));
+        var service = BuildScriptedService(client);
+        await CollectAsync(service.GenerateReplyAsync("pierwsze pytanie", Context(), CancellationToken.None));
+
+        var followUpClient = new RecordingChatClient(_ => Stream("Druga odpowiedź."));
+        await CollectAsync(BuildScriptedService(followUpClient)
+            .GenerateReplyAsync("drugie pytanie", Context(), CancellationToken.None));
+
+        var transcript = Assert.Single(followUpClient.Calls);
+        Assert.Equal(ChatRole.System, transcript[0].Role);
+        Assert.Equal(ChatRole.User, transcript[^1].Role);
+        Assert.Equal("drugie pytanie", transcript[^1].Text);
+        Assert.Contains(transcript, m => m.Role == ChatRole.User && m.Text == "pierwsze pytanie");
+        Assert.Contains(transcript, m => m.Role == ChatRole.Assistant && m.Text == "Pierwsza odpowiedź.");
+    }
+
+    [Fact]
+    public async Task Window_TokenBudget_DropsOldestMessagesFirst()
+    {
+        var memory = BuildMemory(windowTokenBudget: 30);
+        var turn = await memory.BeginTurnAsync(ThreadChannelId, GuildDiscordId, CancellationToken.None);
+        // ~25 est tokens each (100 chars / 4) — only one fits a 30-token budget.
+        await memory.PersistUserMessageAsync(turn with { TurnIndex = 0 }, new string('a', 100), CancellationToken.None);
+        await memory.PersistUserMessageAsync(turn with { TurnIndex = 1 }, new string('b', 100), CancellationToken.None);
+
+        var next = await memory.BeginTurnAsync(ThreadChannelId, GuildDiscordId, CancellationToken.None);
+
+        var replayed = Assert.Single(next.Window);
+        Assert.Equal(new string('b', 100), replayed.Text);
+        Assert.Equal(2, next.TurnIndex);
+    }
+
+    [Fact]
+    public async Task Window_NeverSplitsToolCallGroup_DropsItWhole()
+    {
+        var memory = BuildMemory(windowTokenBudget: 40);
+        var turn = await memory.BeginTurnAsync(ThreadChannelId, GuildDiscordId, CancellationToken.None);
+
+        // One tool-call group (~50+ est tokens: assistant row + huge tool result).
+        var assistantWithCall = new ChatMessage(ChatRole.Assistant,
+            [new FunctionCallContent("call_1", "meme_search", new Dictionary<string, object?> { ["query"] = "x" })]);
+        await memory.PersistAssistantMessagesAsync(turn, [assistantWithCall], null, null, CancellationToken.None);
+        await memory.PersistToolResultAsync(turn, "meme_search",
+            new FunctionResultContent("call_1", new string('r', 200)), CancellationToken.None);
+        // A small later answer that fits on its own.
+        await memory.PersistAssistantMessagesAsync(turn,
+            [new ChatMessage(ChatRole.Assistant, "krótka odpowiedź")], null, null, CancellationToken.None);
+
+        var next = await memory.BeginTurnAsync(ThreadChannelId, GuildDiscordId, CancellationToken.None);
+
+        // The over-budget group was dropped WHOLE — no dangling FunctionCallContent or
+        // FunctionResultContent may survive (a dangling tool_call_id is a provider 400).
+        var replayed = Assert.Single(next.Window);
+        Assert.Equal("krótka odpowiedź", replayed.Text);
+        Assert.DoesNotContain(next.Window, m => m.Contents.OfType<FunctionCallContent>().Any());
+        Assert.DoesNotContain(next.Window, m => m.Contents.OfType<FunctionResultContent>().Any());
+    }
+
+    [Fact]
+    public async Task Window_IncompleteToolGroup_CrashBeforeToolResult_IsNotReplayed()
+    {
+        var memory = BuildMemory();
+        var turn = await memory.BeginTurnAsync(ThreadChannelId, GuildDiscordId, CancellationToken.None);
+
+        await memory.PersistUserMessageAsync(turn, "pytanie", CancellationToken.None);
+        // Crash simulation: the assistant's tool call was persisted, its result never was.
+        var assistantWithCall = new ChatMessage(ChatRole.Assistant,
+            [new FunctionCallContent("call_1", "meme_search", new Dictionary<string, object?> { ["query"] = "x" })]);
+        await memory.PersistAssistantMessagesAsync(turn, [assistantWithCall], null, null, CancellationToken.None);
+
+        var next = await memory.BeginTurnAsync(ThreadChannelId, GuildDiscordId, CancellationToken.None);
+
+        var replayed = Assert.Single(next.Window);
+        Assert.Equal("pytanie", replayed.Text);
+    }
+
+    [Fact]
+    public async Task Reasoning_IsPersistedButStrippedFromReplay()
+    {
+        var memory = BuildMemory();
+        var turn = await memory.BeginTurnAsync(ThreadChannelId, GuildDiscordId, CancellationToken.None);
+
+        var withReasoning = new ChatMessage(ChatRole.Assistant,
+            [new TextReasoningContent("tajne rozumowanie"), new TextContent("odpowiedź")]);
+        await memory.PersistAssistantMessagesAsync(turn, [withReasoning], null, null, CancellationToken.None);
+
+        var row = await _db.ConversationMessages.SingleAsync();
+        Assert.Equal("tajne rozumowanie", row.Reasoning);
+
+        var next = await memory.BeginTurnAsync(ThreadChannelId, GuildDiscordId, CancellationToken.None);
+        var replayed = Assert.Single(next.Window);
+        Assert.Equal("odpowiedź", replayed.Text);
+        Assert.DoesNotContain(replayed.Contents, c => c is TextReasoningContent);
+    }
+
+    private static ConversationContext Context() =>
+        new(GuildDiscordId, InvokerId, "tester", IsAdmin: false, ChannelId: ThreadChannelId);
+
+    private ConversationMemoryService BuildMemory(int windowTokenBudget = 12000, int windowMaxMessages = 40)
+    {
+        var options = Options.Create(new ConversationOptions
+        {
+            WindowTokenBudget = windowTokenBudget,
+            WindowMaxMessages = windowMaxMessages,
+        });
+        return new ConversationMemoryService(NewContext(), options, NullLogger<ConversationMemoryService>.Instance);
+    }
+
+    // The full production stack minus the network: real MEAI OpenAI adapter over a
+    // scripted SSE transport, real tool registry, real store.
+    private ConversationService BuildRealAdapterService(
+        CaptureTransport transport, out IOptions<ConversationOptions> conversationOptions)
+    {
+        conversationOptions = Options.Create(new ConversationOptions
+        {
+            ReasoningEffort = "low",
+            PrimaryGuildId = GuildDiscordId,
+            InterimNarration = "-# interim",
+        });
+        var openRouterOptions = Options.Create(new OpenRouterOptions { ApiKey = "test-key" });
+
+        var chatClient = new OpenAIClient(
+                new ApiKeyCredential("test-key"),
+                new OpenAIClientOptions
+                {
+                    Endpoint = new Uri("http://localhost/api/v1"),
+                    Transport = new HttpClientPipelineTransport(new HttpClient(transport)),
+                })
+            .GetChatClient(conversationOptions.Value.Model)
+            .AsIChatClient();
+
+        return new ConversationService(
+            chatClient,
+            BuildRegistry(conversationOptions),
+            new ConversationMemoryService(NewContext(), conversationOptions, NullLogger<ConversationMemoryService>.Instance),
+            conversationOptions,
+            openRouterOptions,
+            NullLogger<ConversationService>.Instance);
+    }
+
+    private ConversationService BuildScriptedService(IChatClient client)
+    {
+        var conversationOptions = Options.Create(new ConversationOptions
+        {
+            ReasoningEffort = "low",
+            PrimaryGuildId = GuildDiscordId,
+        });
+        return new ConversationService(
+            client,
+            BuildRegistry(conversationOptions),
+            new ConversationMemoryService(NewContext(), conversationOptions, NullLogger<ConversationMemoryService>.Instance),
+            conversationOptions,
+            Options.Create(new OpenRouterOptions { ApiKey = "test-key" }),
+            NullLogger<ConversationService>.Instance);
+    }
+
+    private ConversationToolRegistry BuildRegistry(IOptions<ConversationOptions> conversationOptions) =>
+        new(new MemeSearchService(NewContext()),
+            new GuildStatsService(NewContext()),
+            new DatabaseQueryService(NewContext(), conversationOptions, NullLogger<DatabaseQueryService>.Instance),
+            new FakeGuildActionService(),
+            new FakeConfirmationService(),
+            new DatabaseSchemaHint("schema hint"),
+            conversationOptions,
+            NullLogger<ConversationToolRegistry>.Instance);
+
+    private static async Task<List<ConversationUpdate>> CollectAsync(IAsyncEnumerable<ConversationUpdate> stream)
+    {
+        List<ConversationUpdate> events = [];
+        await foreach (var update in stream)
+            events.Add(update);
+        return events;
+    }
+
+    private static List<string> MessagesOf(string requestBody)
+    {
+        using var doc = JsonDocument.Parse(requestBody);
+        return doc.RootElement.GetProperty("messages")
+            .EnumerateArray()
+            .Select(m => m.GetRawText())
+            .ToList();
+    }
+
+    private static string FindMessage(string requestBody, string role)
+    {
+        using var doc = JsonDocument.Parse(requestBody);
+        var match = doc.RootElement.GetProperty("messages")
+            .EnumerateArray()
+            .Single(m => m.GetProperty("role").GetString() == role);
+        return match.GetRawText();
+    }
+
+    private static string FindToolCallsArray(string requestBody)
+    {
+        using var doc = JsonDocument.Parse(requestBody);
+        var match = doc.RootElement.GetProperty("messages")
+            .EnumerateArray()
+            .Single(m => m.TryGetProperty("tool_calls", out _));
+        return match.GetProperty("tool_calls").GetRawText();
+    }
+
+    private const string UsageJson =
+        "\"usage\":{\"prompt_tokens\":10,\"completion_tokens\":5,\"total_tokens\":15," +
+        "\"cost\":0.01,\"cost_details\":{\"upstream_inference_cost\":0.008}}";
+
+    private static string SseChunk(string choicesJson, string? extraJson = null) =>
+        "data: {\"id\":\"chatcmpl-t\",\"object\":\"chat.completion.chunk\",\"created\":1750000000," +
+        $"\"model\":\"anthropic/claude-sonnet-4.6\",\"choices\":{choicesJson}{(extraJson is null ? "" : "," + extraJson)}}}\n\n";
+
+    private static string SseText(string text)
+    {
+        var delta = JsonSerializer.Serialize(text);
+        return SseChunk($"[{{\"index\":0,\"delta\":{{\"role\":\"assistant\",\"content\":{delta}}},\"finish_reason\":null}}]")
+            + SseChunk("[{\"index\":0,\"delta\":{},\"finish_reason\":\"stop\"}]", UsageJson)
+            + "data: [DONE]\n\n";
+    }
+
+    private static string SseToolCall(string callId, string toolName, string argumentsJson)
+    {
+        var escapedArgs = JsonSerializer.Serialize(argumentsJson);
+        return SseChunk(
+                $"[{{\"index\":0,\"delta\":{{\"role\":\"assistant\",\"tool_calls\":[{{\"index\":0,\"id\":\"{callId}\"," +
+                $"\"type\":\"function\",\"function\":{{\"name\":\"{toolName}\",\"arguments\":{escapedArgs}}}}}]}},\"finish_reason\":null}}]")
+            + SseChunk("[{\"index\":0,\"delta\":{},\"finish_reason\":\"tool_calls\"}]", UsageJson)
+            + "data: [DONE]\n\n";
+    }
+
+    // Captures every request body and answers with the scripted SSE stream — the fake
+    // seam sits UNDER the real OpenAI SDK + MEAI adapter, which is the point: the wire
+    // bytes asserted on are the ones the adapter actually produces.
+    private sealed class CaptureTransport(Func<int, string> sseResponder) : HttpMessageHandler
+    {
+        private int _callIndex;
+
+        public List<string> RequestBodies { get; } = [];
+
+        protected override async Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            RequestBodies.Add(await request.Content!.ReadAsStringAsync(cancellationToken));
+
+            var response = new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent(sseResponder(_callIndex++), Encoding.UTF8, "text/event-stream"),
+            };
+            return response;
+        }
+    }
+
+    // A fake IChatClient recording each call's transcript (cheap-path recall tests).
+    private sealed class RecordingChatClient(
+        Func<int, IReadOnlyList<ChatResponseUpdate>> responder) : IChatClient
+    {
+        private int _callIndex;
+
+        public List<IReadOnlyList<ChatMessage>> Calls { get; } = [];
+
+        public async IAsyncEnumerable<ChatResponseUpdate> GetStreamingResponseAsync(
+            IEnumerable<ChatMessage> messages, ChatOptions? options = null,
+            [EnumeratorCancellation] CancellationToken cancellationToken = default)
+        {
+            Calls.Add(messages.ToList());
+            foreach (var update in responder(_callIndex++))
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+                yield return update;
+                await Task.Yield();
+            }
+        }
+
+        public Task<ChatResponse> GetResponseAsync(
+            IEnumerable<ChatMessage> messages, ChatOptions? options = null, CancellationToken cancellationToken = default) =>
+            throw new NotSupportedException("the loop streams");
+
+        public object? GetService(Type serviceType, object? serviceKey = null) => null;
+
+        public void Dispose()
+        {
+        }
+    }
+
+    private static IReadOnlyList<ChatResponseUpdate> Stream(params string[] deltas) =>
+        deltas.Select(delta => new ChatResponseUpdate(ChatRole.Assistant, delta)).ToList();
+
+    private async Task SeedTurtleMemeAsync()
+    {
+        var guild = new GuildEntity { DiscordId = GuildDiscordId, Name = "g" };
+        _db.Guilds.Add(guild);
+        await _db.SaveChangesAsync();
+
+        var channel = new ChannelEntity
+        {
+            DiscordId = ChannelDiscordId,
+            GuildId = guild.Id,
+            Name = "memes",
+            Type = ChannelType.Text
+        };
+        var author = new UserEntity { DiscordId = 3UL, Username = "u" };
+        _db.Channels.Add(channel);
+        _db.Users.Add(author);
+        await _db.SaveChangesAsync();
+
+        var message = new MessageEntity
+        {
+            DiscordId = MemeMessageId,
+            ChannelId = channel.Id,
+            GuildId = guild.Id,
+            AuthorId = author.Id,
+            HasAttachments = true,
+            CreatedAtUtc = DateTime.UtcNow,
+        };
+        _db.Messages.Add(message);
+        await _db.SaveChangesAsync();
+
+        _db.MemeIndex.Add(new MemeIndexEntity
+        {
+            MessageId = message.Id,
+            GuildDiscordId = GuildDiscordId,
+            ChannelDiscordId = ChannelDiscordId,
+            MessageDiscordId = MemeMessageId,
+            AttachmentDiscordId = 61UL,
+            FileName = "zolw.png",
+            FileSizeBytes = 1234,
+            ContentType = "image/png",
+            ContentHash = "hash-61",
+            Status = MemeIndexStatus.Indexed,
+            DescriptionPl = "Żółw na deskorolce",
+            DescriptionEn = "A turtle on a skateboard",
+            OcrText = "",
+            Tags = ["żółw"],
+            ModelId = "google/gemini-3-flash-preview",
+            RawResponseJson = "{}",
+            IndexedAtUtc = DateTime.UtcNow,
+        });
+        await _db.SaveChangesAsync();
+    }
+
+    private DiscordDbContext NewContext()
+    {
+        var options = new DbContextOptionsBuilder<DiscordDbContext>()
+            .UseNpgsql(fixture.Container.GetConnectionString())
+            .UseSnakeCaseNamingConvention()
+            .Options;
+        return new DiscordDbContext(options);
+    }
+}


### PR DESCRIPTION
Closes #267 (epic #266 §1 — the spine).

## What

The loop's per-turn `[system, user]` seed becomes `[system, ...window, user]` backed by a durable store, and `RecordRoundCost` finally gets its sink:

- **Store** — `conversation` (one row per thread/DM channel, snowflake key) + `conversation_message` (one row per `ChatMessage`; assistant rows bundle their tool calls as a `tool_calls_json` array, tool results are **plain text columns**, reasoning persisted but stripped on replay). Append-only, uuidv7 PKs, `Restrict` FKs, role-shape check constraint.
- **Replay window** — newest→oldest sum of `est_tokens` (chars/4) until `WindowTokenBudget` (12000), `WindowMaxMessages` (40) backstop; a tool-call group (assistant calls + all its results) is never split — incomplete/over-budget groups drop whole (a dangling `tool_call_id` is a provider 400).
- **Persistence hooks** — awaited, inside the turn, at the loop's existing append points (user at entry, assistant after each round, each tool result, the round-cap final answer). Crash mid-turn leaves a consistent prefix; restart loses nothing.
- **Usage ledger** — `conversation_usage`, one row per round **attempt** with denormalized `invoker_id` (#256: per-user cost sums are a single WHERE), tokens, `usage.cost`, §5 itemisation columns (`upstream_inference_cost_usd`, `web_search_requests`), latency, `failed` (§2 will write those). Attempt/failed widen in §2.

## The byte-fidelity trap (research A-OQ1) — confirmed and closed

`FunctionResultContent.Result` is `object?`; a JSON round-trip turns it into a `JsonElement` and the OpenAI adapter's `as string` fast-path misses → the replayed tool message goes quote-wrapped on the wire. The store persists the **effective wire text** (the adapter's exact fast-path-else-serialize logic) and rehydrates `Result` as a `string`, so replay is byte-identical whether the live result was a raw string or an AIFunctionFactory `JsonElement`.

Proven by `FollowUpAfterRestart_ReplaysToolRound_ByteIdenticalOnTheWire`: real MEAI OpenAI adapter over a scripted SSE transport, live tool round → store → fresh service ("restart") → follow-up; asserts the tool message and assistant `tool_calls` raw JSON are identical between the live and replayed request bodies.

## Tests

7 new Testcontainers tests (no DB mocking): byte-fidelity, ledger rows (cost/tokens/invoker via the raw `ChatTokenUsage` patch from a canned usage frame), cross-turn recall, window budget, group-never-splits, crash-orphaned group dropped, reasoning stripped. Full suite **212 passed / 1 skipped**.

## Verification

- Dev bot booted clean: migration auto-applied, child DI validation **24 services**, guild connected.
- Live human @mention test in #devtuś pending (the loop skips bot authors, so the Discord MCP can't trigger it) — will be done before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)