### PR TITLE
feat: #268 §2 per-round retry policy + visible failure

### DIFF
--- a/src/DiscordEventService/Configuration/ConversationOptions.cs
+++ b/src/DiscordEventService/Configuration/ConversationOptions.cs
@@ -49,6 +49,17 @@ internal sealed class ConversationOptions
     // Hard ceiling on a single turn's model round-trip.
     public int RequestTimeoutSeconds { get; set; } = 120;
 
+    // §2 per-round model-call retry (#268): attempts per round (1 initial + retries),
+    // exponential backoff with full jitter between transient failures. Worst case
+    // (3 attempts, ≤1s+2s backoff) stays well under RequestTimeoutSeconds.
+    public int RetryMaxAttempts { get; set; } = 3;
+    public int RetryBaseDelayMs { get; set; } = 1000;
+    public int RetryMaxDelayMs { get; set; } = 8000;
+
+    // The visible localized failure line posted when a round's retries exhaust (or the
+    // failure is terminal) — never fail a turn silently (#268).
+    public string FailureMessage { get; set; } = "-# 💥 Coś się wysypało — spróbuj jeszcze raz.";
+
     // Conversation memory replay window (#267). The budget is summed over locally
     // estimated message sizes (chars/4 — OpenRouter normalizes counts to a GPT
     // tokenizer, so it's a fair proxy; the per-request provider usage can't size a

--- a/src/DiscordEventService/Services/Conversation/ConversationRegistration.cs
+++ b/src/DiscordEventService/Services/Conversation/ConversationRegistration.cs
@@ -1,4 +1,5 @@
 using System.ClientModel;
+using System.ClientModel.Primitives;
 using System.Text;
 using DiscordEventService.Configuration;
 using DiscordEventService.Infrastructure;
@@ -91,7 +92,15 @@ internal static class ConversationRegistration
         var apiKey = string.IsNullOrWhiteSpace(openRouter.ApiKey) ? "unconfigured" : openRouter.ApiKey;
         var openAiClient = new OpenAIClient(
             new ApiKeyCredential(apiKey),
-            new OpenAIClientOptions { Endpoint = new Uri(openRouter.BaseUrl) });
+            new OpenAIClientOptions
+            {
+                Endpoint = new Uri(openRouter.BaseUrl),
+                // The §2 per-round policy (#268) is the single owner of retries: it
+                // ledgers every attempt and honors Retry-After itself. The SDK
+                // pipeline's default 3 silent retries would stack under it (3×3
+                // network attempts) and under-count the ledger.
+                RetryPolicy = new ClientRetryPolicy(maxRetries: 0),
+            });
 
         return openAiClient
             .GetChatClient(conversation.Model)

--- a/src/DiscordEventService/Services/Conversation/ConversationRetryPolicy.cs
+++ b/src/DiscordEventService/Services/Conversation/ConversationRetryPolicy.cs
@@ -1,0 +1,91 @@
+using System.ClientModel;
+using System.Globalization;
+using DiscordEventService.Configuration;
+using Microsoft.Extensions.AI;
+using OpenAI.Chat;
+
+namespace DiscordEventService.Services.Conversation;
+
+// OpenRouter delivers a post-header failure as a normal SSE data chunk (top-level
+// `error`, usually with `finish_reason:"error"`) — never as an HTTP failure. Probed
+// against the real SDK (#268, research B-OQ1): a frame carrying finish_reason "error"
+// makes the OpenAI SDK throw ArgumentOutOfRangeException("Unknown ChatFinishReason
+// value") out of the enumeration, while a frame without it passes through silently as
+// an empty update whose raw patch carries `$.error` (which would misfire the
+// empty-answer fallback). Both surfaces normalize to this exception so the per-round
+// retry handles them as one transient failure mode.
+internal sealed class MidStreamErrorException(string message, Exception? innerException = null)
+    : Exception(message, innerException);
+
+// Failure classification + backoff for the §2 per-round retry policy (#268). Pure
+// functions only — the retry loop in ConversationService owns the state, the ledger
+// writes and the actual delay.
+internal static class ConversationRetryPolicy
+{
+    // Transient = worth re-issuing the same round: the meme client's 408/429/≥500
+    // convention (OpenRouterClient), transport faults, and the mid-stream error frame.
+    // TaskCanceledException here is an HTTP-stack timeout — the round loop rethrows the
+    // turn's own cancellation before classifying, so it never reaches this. Status 0 is
+    // a ClientResultException wrapping a transport fault. Everything else (400/401/402/
+    // 403, unexpected bugs) is terminal: retrying cannot help — surface the visible
+    // failure line instead.
+    public static bool IsTransient(Exception failure) => failure switch
+    {
+        MidStreamErrorException => true,
+        ClientResultException clientResult => clientResult.Status is 0 or 408 or 429 or >= 500,
+        HttpRequestException or IOException or TaskCanceledException => true,
+        _ => false,
+    };
+
+    // The silent mid-stream surface: the error frame deserialized as a normal update,
+    // with the unmapped top-level `error` object left on the raw chunk's JSON patch.
+    public static bool IsMidStreamErrorFrame(ChatResponseUpdate update)
+    {
+#pragma warning disable SCME0001 // JsonPatch on the raw chunk is experimental.
+        return update.RawRepresentation is StreamingChatCompletionUpdate raw
+            && raw.Patch.Contains("$.error"u8);
+#pragma warning restore SCME0001
+    }
+
+    // The throwing mid-stream surface: the SDK rejects the frame's nonstandard
+    // finish_reason "error" before the chunk (and its $.error payload) materializes.
+    public static Exception AsRoundFailure(Exception thrown) =>
+        thrown is ArgumentOutOfRangeException
+        && thrown.Message.Contains("ChatFinishReason", StringComparison.Ordinal)
+            ? new MidStreamErrorException("mid-stream error frame (finish_reason \"error\")", thrown)
+            : thrown;
+
+    // Exponential backoff with full jitter: random(0, base·2^(attempt-1)) capped at
+    // RetryMaxDelayMs, per OpenRouter's own guidance. A 429's Retry-After header wins
+    // when it asks for longer — the turn's RequestTimeoutSeconds budget still bounds
+    // the wait (Task.Delay runs under the turn token).
+    public static TimeSpan ComputeDelay(
+        int attempt, Exception failure, ConversationOptions options, Random random)
+    {
+        var ceilingMs = (int)Math.Min(
+            (long)options.RetryBaseDelayMs << (attempt - 1), options.RetryMaxDelayMs);
+        var delay = TimeSpan.FromMilliseconds(random.Next(0, ceilingMs + 1));
+
+        return TryGetRetryAfter(failure, out var retryAfter) && retryAfter > delay
+            ? retryAfter
+            : delay;
+    }
+
+    // OpenRouter sends Retry-After in seconds; ignore unparsable or non-positive values.
+    private static bool TryGetRetryAfter(Exception failure, out TimeSpan retryAfter)
+    {
+        retryAfter = default;
+        if (failure is not ClientResultException clientResult)
+            return false;
+
+        var headers = clientResult.GetRawResponse()?.Headers;
+        if (headers is null || !headers.TryGetValue("Retry-After", out var value))
+            return false;
+
+        if (!double.TryParse(value, CultureInfo.InvariantCulture, out var seconds) || seconds <= 0)
+            return false;
+
+        retryAfter = TimeSpan.FromSeconds(seconds);
+        return true;
+    }
+}

--- a/src/DiscordEventService/Services/Conversation/ConversationService.cs
+++ b/src/DiscordEventService/Services/Conversation/ConversationService.cs
@@ -71,30 +71,124 @@ internal sealed class ConversationService(
         turn?.SetTag("conversation.invoker_id", context.InvokerId);
         turn?.SetTag("conversation.guild_id", context.GuildId);
 
-        // Streams one round into the transcript sink and yields its text deltas live.
-        // Captures `messages` (current at call time) and the turn's cancellation token.
+        var turnCostUsd = 0d;
+
+        // Streams one round into the transcript sink under the §2 retry policy (#268):
+        // up to RetryMaxAttempts calls over the same intact `messages` prefix (a failed
+        // attempt appended nothing and dispatched no tools), full-jitter backoff between
+        // transient failures, one ledger row per failed attempt. Mid-stream error frames
+        // are normalized to MidStreamErrorException (see ConversationRetryPolicy for the
+        // two SDK surfaces). Reports through `outcome` — an iterator cannot return.
         async IAsyncEnumerable<ConversationUpdate> StreamRoundAsync(
-            ChatOptions roundOptions, List<ChatResponseUpdate> sink)
+            ChatOptions roundOptions, int round, List<ChatResponseUpdate> sink, RoundOutcome outcome)
         {
-            await foreach (var update in chatClient.GetStreamingResponseAsync(messages, roundOptions, cancellationToken))
+            for (var attempt = 1; ; attempt++)
             {
-                sink.Add(update);
-                // .Text excludes reasoning content, so a live "thinking" display stays out
-                // of scope; tool-call fragments carry no text and yield nothing here.
-                if (!string.IsNullOrEmpty(update.Text))
-                    yield return new ConversationUpdate.AssistantTextDelta(update.Text);
+                sink.Clear();
+                var streamedVisibleText = false;
+                Exception? failure = null;
+                var stopwatch = Stopwatch.StartNew();
+
+                var updates = chatClient
+                    .GetStreamingResponseAsync(messages, roundOptions, cancellationToken)
+                    .GetAsyncEnumerator(cancellationToken);
+                try
+                {
+                    while (failure is null)
+                    {
+                        ChatResponseUpdate update;
+                        try
+                        {
+                            if (!await updates.MoveNextAsync())
+                                break;
+                            update = updates.Current;
+                        }
+                        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+                        {
+                            // The turn's own budget, not a provider fault — never retried;
+                            // the handler's timeout path owns what happens next.
+                            throw;
+                        }
+                        catch (Exception thrown)
+                        {
+                            failure = ConversationRetryPolicy.AsRoundFailure(thrown);
+                            break;
+                        }
+
+                        sink.Add(update);
+                        if (ConversationRetryPolicy.IsMidStreamErrorFrame(update))
+                        {
+                            failure = new MidStreamErrorException("mid-stream error frame ($.error chunk)");
+                            break;
+                        }
+
+                        // .Text excludes reasoning content, so a live "thinking" display stays
+                        // out of scope; tool-call fragments carry no text and yield nothing here.
+                        if (!string.IsNullOrEmpty(update.Text))
+                        {
+                            streamedVisibleText = true;
+                            yield return new ConversationUpdate.AssistantTextDelta(update.Text);
+                        }
+                    }
+                }
+                finally
+                {
+                    await updates.DisposeAsync();
+                }
+                stopwatch.Stop();
+
+                if (failure is null)
+                {
+                    outcome.Succeeded = true;
+                    outcome.Attempt = attempt;
+                    outcome.LatencyMs = stopwatch.ElapsedMilliseconds;
+                    yield break;
+                }
+
+                // A failed attempt may still bill (partial stream): its own ledger row and
+                // its cost summed into the turn — but no conversation_message rows.
+                turnCostUsd += RecordRoundCost(sink, round, turn);
+                await memory.RecordUsageAsync(memoryTurn, context.InvokerId,
+                    ExtractRoundUsage(sink, round, attempt, options.Model,
+                        stopwatch.ElapsedMilliseconds, failed: true),
+                    cancellationToken);
+
+                // Partial deltas already reached the handler's buffer; drop them so the
+                // retried stream (or the failure line) renders exactly once.
+                if (streamedVisibleText)
+                    yield return new ConversationUpdate.RoundReset();
+
+                if (!ConversationRetryPolicy.IsTransient(failure) || attempt >= options.RetryMaxAttempts)
+                {
+                    logger.LogError(failure, "Round {Round} failed after {Attempts} attempt(s)", round, attempt);
+                    outcome.Attempt = attempt;
+                    outcome.Failure = failure;
+                    yield break;
+                }
+
+                var delay = ConversationRetryPolicy.ComputeDelay(attempt, failure, options, Random.Shared);
+                logger.LogWarning(failure,
+                    "Round {Round} attempt {Attempt} failed transiently; retrying in {DelayMs}ms",
+                    round, attempt, (int)delay.TotalMilliseconds);
+                await Task.Delay(delay, cancellationToken);
             }
         }
-
-        var turnCostUsd = 0d;
 
         for (var round = 1; round <= options.MaxToolRounds; round++)
         {
             var sink = new List<ChatResponseUpdate>();
-            var roundStopwatch = Stopwatch.StartNew();
-            await foreach (var renderEvent in StreamRoundAsync(chatOptions, sink))
+            var outcome = new RoundOutcome();
+            await foreach (var renderEvent in StreamRoundAsync(chatOptions, round, sink, outcome))
                 yield return renderEvent;
-            roundStopwatch.Stop();
+
+            if (!outcome.Succeeded)
+            {
+                yield return new ConversationUpdate.AssistantTextDelta(options.FailureMessage);
+                turn?.SetTag("conversation.failed", true);
+                turn?.SetTag("conversation.rounds", round);
+                turn?.SetTag("conversation.cost_usd", turnCostUsd);
+                yield break;
+            }
 
             // MEAI assembles the streamed tool-calls for us — act on the assembled response,
             // never reassemble fragments by index. Append the assistant turn (text + any
@@ -104,7 +198,8 @@ internal sealed class ConversationService(
             messages.AddRange(response.Messages);
             turnCostUsd += RecordRoundCost(sink, round, turn);
 
-            var roundUsage = ExtractRoundUsage(sink, round, options.Model, roundStopwatch.ElapsedMilliseconds);
+            var roundUsage = ExtractRoundUsage(
+                sink, round, outcome.Attempt, options.Model, outcome.LatencyMs, failed: false);
             await memory.PersistAssistantMessagesAsync(memoryTurn, response.Messages,
                 roundUsage.PromptTokens, roundUsage.CompletionTokens, cancellationToken);
             await memory.RecordUsageAsync(memoryTurn, context.InvokerId, roundUsage, cancellationToken);
@@ -146,15 +241,25 @@ internal sealed class ConversationService(
         turn?.SetTag("conversation.hit_round_cap", true);
 
         var finalSink = new List<ChatResponseUpdate>();
-        var finalStopwatch = Stopwatch.StartNew();
-        await foreach (var renderEvent in StreamRoundAsync(OpenRouterChatOptions.Create(options.ReasoningEffort), finalSink))
+        var finalOutcome = new RoundOutcome();
+        await foreach (var renderEvent in StreamRoundAsync(
+            OpenRouterChatOptions.Create(options.ReasoningEffort), options.MaxToolRounds + 1, finalSink, finalOutcome))
             yield return renderEvent;
-        finalStopwatch.Stop();
+
+        if (!finalOutcome.Succeeded)
+        {
+            yield return new ConversationUpdate.AssistantTextDelta(options.FailureMessage);
+            turn?.SetTag("conversation.failed", true);
+            turn?.SetTag("conversation.cost_usd", turnCostUsd);
+            yield break;
+        }
+
         turnCostUsd += RecordRoundCost(finalSink, options.MaxToolRounds + 1, turn);
 
         var finalResponse = finalSink.ToChatResponse();
         var finalUsage = ExtractRoundUsage(
-            finalSink, options.MaxToolRounds + 1, options.Model, finalStopwatch.ElapsedMilliseconds);
+            finalSink, options.MaxToolRounds + 1, finalOutcome.Attempt, options.Model,
+            finalOutcome.LatencyMs, failed: false);
         await memory.PersistAssistantMessagesAsync(memoryTurn, finalResponse.Messages,
             finalUsage.PromptTokens, finalUsage.CompletionTokens, cancellationToken);
         await memory.RecordUsageAsync(memoryTurn, context.InvokerId, finalUsage, cancellationToken);
@@ -207,12 +312,23 @@ internal sealed class ConversationService(
 #pragma warning restore SCME0001
     }
 
+    // Out-channel for StreamRoundAsync (an iterator cannot return a value): whether the
+    // round ultimately succeeded, on which attempt, and the winning attempt's latency.
+    private sealed class RoundOutcome
+    {
+        public bool Succeeded { get; set; }
+        public int Attempt { get; set; }
+        public long LatencyMs { get; set; }
+        public Exception? Failure { get; set; }
+    }
+
     // Everything one ledger row needs from a round's streamed updates (#267): MEAI's
     // typed token counts plus the OpenRouter extras recovered from the raw usage patch
-    // (`cost`, and the §5 itemisation fields when the provider reports them). §1 always
-    // records attempt 1 / not-failed; the §2 retry policy widens both.
+    // (`cost`, and the §5 itemisation fields when the provider reports them). The §2
+    // retry policy (#268) writes one row per attempt — failed rows keep whatever
+    // partial usage the stream reported before dying (mid-stream failures still bill).
     private static ConversationRoundUsage ExtractRoundUsage(
-        List<ChatResponseUpdate> updates, int round, string model, long latencyMs)
+        List<ChatResponseUpdate> updates, int round, int attempt, string model, long latencyMs, bool failed)
     {
         var usage = updates
             .SelectMany(update => update.Contents)
@@ -232,10 +348,10 @@ internal sealed class ConversationService(
         }
 
         return new ConversationRoundUsage(
-            round, Attempt: 1, model,
+            round, attempt, model,
             (int?)usage?.Details.InputTokenCount, (int?)usage?.Details.OutputTokenCount,
             ExtractCostUsd(updates), upstreamCostUsd, webSearchRequests,
-            latencyMs, Failed: false);
+            latencyMs, failed);
     }
 
     private static string BuildSystemPrompt(ConversationOptions options) =>

--- a/src/DiscordEventService/Services/Conversation/ConversationService.cs
+++ b/src/DiscordEventService/Services/Conversation/ConversationService.cs
@@ -147,7 +147,7 @@ internal sealed class ConversationService(
 
                 // A failed attempt may still bill (partial stream): its own ledger row and
                 // its cost summed into the turn — but no conversation_message rows.
-                turnCostUsd += RecordRoundCost(sink, round, turn);
+                turnCostUsd += RecordRoundCost(sink, round, turn, outcome);
                 await memory.RecordUsageAsync(memoryTurn, context.InvokerId,
                     ExtractRoundUsage(sink, round, attempt, options.Model,
                         stopwatch.ElapsedMilliseconds, failed: true),
@@ -196,7 +196,7 @@ internal sealed class ConversationService(
             // well-formed for the next round.
             var response = sink.ToChatResponse();
             messages.AddRange(response.Messages);
-            turnCostUsd += RecordRoundCost(sink, round, turn);
+            turnCostUsd += RecordRoundCost(sink, round, turn, outcome);
 
             var roundUsage = ExtractRoundUsage(
                 sink, round, outcome.Attempt, options.Model, outcome.LatencyMs, failed: false);
@@ -254,7 +254,7 @@ internal sealed class ConversationService(
             yield break;
         }
 
-        turnCostUsd += RecordRoundCost(finalSink, options.MaxToolRounds + 1, turn);
+        turnCostUsd += RecordRoundCost(finalSink, options.MaxToolRounds + 1, turn, finalOutcome);
 
         var finalResponse = finalSink.ToChatResponse();
         var finalUsage = ExtractRoundUsage(
@@ -287,13 +287,17 @@ internal sealed class ConversationService(
     // The real OpenRouter `usage.cost` (USD) isn't in MEAI's typed UsageDetails — recover
     // it from the raw OpenAI ChatTokenUsage's JSON patch. Logged + traced per round here;
     // the §5 usage ledger persists it. Returns 0 when the provider didn't report a cost.
-    private double RecordRoundCost(List<ChatResponseUpdate> updates, int round, Activity? turn)
+    private double RecordRoundCost(
+        List<ChatResponseUpdate> updates, int round, Activity? turn, RoundOutcome outcome)
     {
         var cost = ExtractCostUsd(updates);
         if (cost is null)
             return 0;
 
-        turn?.SetTag($"conversation.round{round}.cost_usd", cost.Value);
+        // The round span tag carries the round's total over ALL attempts — a retried
+        // round's failed attempts may still bill; the ledger itemizes per attempt.
+        outcome.CostUsd += cost.Value;
+        turn?.SetTag($"conversation.round{round}.cost_usd", outcome.CostUsd);
         logger.LogDebug("Round {Round} model cost ${Cost}", round, cost.Value);
         return cost.Value;
     }
@@ -319,6 +323,7 @@ internal sealed class ConversationService(
         public bool Succeeded { get; set; }
         public int Attempt { get; set; }
         public long LatencyMs { get; set; }
+        public double CostUsd { get; set; }
         public Exception? Failure { get; set; }
     }
 

--- a/src/DiscordEventService/Services/Conversation/ConversationUpdate.cs
+++ b/src/DiscordEventService/Services/Conversation/ConversationUpdate.cs
@@ -20,4 +20,9 @@ internal abstract record ConversationUpdate
     // that closes the round — the handler posts the buffered narration plus this line as
     // one message, and the next AssistantTextDelta starts the next round's buffer.
     public sealed record ToolBatchSummary(string Text) : ConversationUpdate;
+
+    // A round attempt failed after streaming partial text (#268): the handler drops the
+    // current round's buffered deltas so the retried stream (or the failure line)
+    // renders exactly once — never appended after the discarded partial.
+    public sealed record RoundReset : ConversationUpdate;
 }

--- a/src/DiscordEventService/Services/EventHandlers/ConversationEventHandler.cs
+++ b/src/DiscordEventService/Services/EventHandlers/ConversationEventHandler.cs
@@ -98,6 +98,10 @@ internal sealed class ConversationEventHandler(
                     case ConversationUpdate.ToolBatchSummary summary:
                         await renderer.CompleteRoundAsync(summary.Text);
                         break;
+
+                    case ConversationUpdate.RoundReset:
+                        renderer.ResetRound();
+                        break;
                 }
             }
 

--- a/src/DiscordEventService/Services/EventHandlers/DiscordTurnRenderer.cs
+++ b/src/DiscordEventService/Services/EventHandlers/DiscordTurnRenderer.cs
@@ -44,6 +44,11 @@ internal sealed class DiscordTurnRenderer(DiscordChannel channel)
     // posted complete (chunked past the message cap).
     public Task CompleteTurnAsync() => PostAsync(TakeBuffer());
 
+    // A round attempt failed after streaming partial deltas (#268): drop them so the
+    // retried stream (or the failure line) renders exactly once. The buffer only ever
+    // holds the current round — every round boundary already flushes it.
+    public void ResetRound() => _text.Clear();
+
     public Task TriggerTypingAsync() => TriggerTypingAsync(force: true);
 
     // The round message: narration first, summary as the closing subtext line. A round

--- a/tests/DiscordEventService.Tests/ConversationRetryPolicyTests.cs
+++ b/tests/DiscordEventService.Tests/ConversationRetryPolicyTests.cs
@@ -1,0 +1,77 @@
+using DiscordEventService.Configuration;
+using DiscordEventService.Services.Conversation;
+using Xunit;
+
+namespace DiscordEventService.Tests;
+
+// The pure seams of the §2 retry policy (#268): transient classification, the
+// unknown-finish-reason normalization (B-OQ1's throwing surface), and backoff shape.
+// The end-to-end paths — both mid-stream surfaces, Retry-After honoring, ledger rows —
+// run through the real SDK adapter in ConversationRetryTests.
+public sealed class ConversationRetryPolicyTests
+{
+    [Fact]
+    public void IsTransient_MidStreamAndTransportFaults_AreRetryable()
+    {
+        Assert.True(ConversationRetryPolicy.IsTransient(new MidStreamErrorException("frame")));
+        Assert.True(ConversationRetryPolicy.IsTransient(new HttpRequestException("reset")));
+        Assert.True(ConversationRetryPolicy.IsTransient(new IOException("broken pipe")));
+        // An HTTP-stack timeout, not the turn's own token — the round loop rethrows the
+        // turn cancellation before classification ever sees it.
+        Assert.True(ConversationRetryPolicy.IsTransient(new TaskCanceledException("timeout")));
+    }
+
+    [Fact]
+    public void IsTransient_UnexpectedExceptions_AreTerminal()
+    {
+        Assert.False(ConversationRetryPolicy.IsTransient(new InvalidOperationException("bug")));
+        // Un-normalized: only AsRoundFailure's wrapping makes the finish-reason surface transient.
+        Assert.False(ConversationRetryPolicy.IsTransient(
+            new ArgumentOutOfRangeException("value", "error", "Unknown ChatFinishReason value.")));
+    }
+
+    [Fact]
+    public void AsRoundFailure_UnknownChatFinishReason_NormalizesToMidStreamError()
+    {
+        // The SDK's actual surface for OpenRouter's finish_reason:"error" frame (probed, B-OQ1).
+        var thrown = new ArgumentOutOfRangeException("value", "error", "Unknown ChatFinishReason value.");
+
+        var normalized = ConversationRetryPolicy.AsRoundFailure(thrown);
+
+        var midStream = Assert.IsType<MidStreamErrorException>(normalized);
+        Assert.Same(thrown, midStream.InnerException);
+        Assert.True(ConversationRetryPolicy.IsTransient(normalized));
+    }
+
+    [Fact]
+    public void AsRoundFailure_OtherExceptions_PassThroughUnchanged()
+    {
+        var thrown = new InvalidOperationException("bug");
+        Assert.Same(thrown, ConversationRetryPolicy.AsRoundFailure(thrown));
+
+        var unrelatedRange = new ArgumentOutOfRangeException("count", 5, "out of range");
+        Assert.Same(unrelatedRange, ConversationRetryPolicy.AsRoundFailure(unrelatedRange));
+    }
+
+    [Fact]
+    public void ComputeDelay_FullJitter_StaysWithinExponentialCeiling()
+    {
+        var options = new ConversationOptions { RetryBaseDelayMs = 1000, RetryMaxDelayMs = 8000 };
+        var failure = new HttpRequestException("reset");
+
+        for (var seed = 0; seed < 50; seed++)
+        {
+            var random = new Random(seed);
+            AssertWithin(ConversationRetryPolicy.ComputeDelay(1, failure, options, random), 1000);
+            AssertWithin(ConversationRetryPolicy.ComputeDelay(2, failure, options, random), 2000);
+            AssertWithin(ConversationRetryPolicy.ComputeDelay(3, failure, options, random), 4000);
+            // Past the exponential curve the cap wins.
+            AssertWithin(ConversationRetryPolicy.ComputeDelay(10, failure, options, random), 8000);
+        }
+    }
+
+    private static void AssertWithin(TimeSpan delay, int ceilingMs)
+    {
+        Assert.InRange(delay.TotalMilliseconds, 0, ceilingMs);
+    }
+}

--- a/tests/DiscordEventService.Tests/ConversationRetryTests.cs
+++ b/tests/DiscordEventService.Tests/ConversationRetryTests.cs
@@ -1,0 +1,319 @@
+using System.ClientModel;
+using System.ClientModel.Primitives;
+using System.Diagnostics;
+using System.Net;
+using System.Text;
+using System.Text.Json;
+using DiscordEventService.Configuration;
+using DiscordEventService.Data;
+using DiscordEventService.Services.Conversation;
+using DiscordEventService.Services.MemeIndexing;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.AI;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using OpenAI;
+using Xunit;
+
+namespace DiscordEventService.Tests;
+
+// The §2 per-round retry policy end-to-end (#268): fault-injecting transport UNDER the
+// real OpenAI SDK + MEAI adapter — the same seam as the byte-fidelity tests — so both
+// empirically probed mid-stream surfaces (B-OQ1) are exercised as the SDK actually
+// produces them: the finish_reason:"error" frame throws an unknown-finish-reason
+// ArgumentOutOfRangeException; a frame without it passes through silently with `$.error`
+// on the raw patch. Ledger rows per attempt land in a real Postgres.
+public sealed class ConversationRetryTests(PostgresFixture fixture)
+    : IClassFixture<PostgresFixture>, IAsyncLifetime
+{
+    private const ulong GuildDiscordId = 31UL;
+    private const ulong ThreadChannelId = 33UL;
+    private const ulong InvokerId = 44UL;
+
+    private DiscordDbContext _db = null!;
+
+    public async Task InitializeAsync()
+    {
+        _db = NewContext();
+        await _db.Database.MigrateAsync();
+
+        await _db.ConversationMessages.ExecuteDeleteAsync();
+        await _db.ConversationUsage.ExecuteDeleteAsync();
+        await _db.Conversations.ExecuteDeleteAsync();
+    }
+
+    public Task DisposeAsync() => _db.DisposeAsync().AsTask();
+
+    [Fact]
+    public async Task PreStream500_RetriesWithBackoff_AnswersAndLedgersFailedAttempt()
+    {
+        var transport = new ScriptedTransport(call => call switch
+        {
+            0 => ErrorResponse(HttpStatusCode.InternalServerError),
+            _ => SseResponse(SseText("Odpowiedź.")),
+        });
+
+        var events = await CollectAsync(BuildService(transport, out _)
+            .GenerateReplyAsync("pytanie", Context(), CancellationToken.None));
+
+        Assert.Equal(2, transport.CallCount);
+        Assert.Equal("Odpowiedź.", RenderedText(events));
+
+        var rows = await _db.ConversationUsage.OrderBy(u => u.Attempt).ToListAsync();
+        Assert.Equal(2, rows.Count);
+        Assert.All(rows, row => Assert.Equal(1, row.Round));
+        Assert.True(rows[0].Failed);
+        Assert.Equal(1, rows[0].Attempt);
+        Assert.False(rows[1].Failed);
+        Assert.Equal(2, rows[1].Attempt);
+
+        // The failed attempt persisted NO transcript rows — only the ledger row.
+        Assert.Equal(2, await _db.ConversationMessages.CountAsync()); // user + winning answer
+    }
+
+    [Fact]
+    public async Task MidStreamErrorFrame_FinishReasonError_RetriesAndRendersAnswerExactlyOnce()
+    {
+        var transport = new ScriptedTransport(call => call switch
+        {
+            // Partial text, then OpenRouter's documented error frame — the SDK throws an
+            // unknown-finish-reason ArgumentOutOfRangeException on this surface.
+            0 => SseResponse(SsePartialTextThenErrorFrame("Czę", finishReasonError: true)),
+            _ => SseResponse(SseText("Cześć!")),
+        });
+
+        var events = await CollectAsync(BuildService(transport, out _)
+            .GenerateReplyAsync("hej", Context(), CancellationToken.None));
+
+        Assert.Equal(2, transport.CallCount);
+        // The partial delta reached the renderer, so a RoundReset must discard it.
+        Assert.Contains(events, e => e is ConversationUpdate.RoundReset);
+        Assert.Equal("Cześć!", RenderedText(events));
+
+        var rows = await _db.ConversationUsage.OrderBy(u => u.Attempt).ToListAsync();
+        Assert.Equal(2, rows.Count);
+        Assert.True(rows[0].Failed);
+        Assert.False(rows[1].Failed);
+    }
+
+    [Fact]
+    public async Task MidStreamErrorFrame_Silent_DetectedInsteadOfEmptyAnswerFallback()
+    {
+        var transport = new ScriptedTransport(call => call switch
+        {
+            // The silent surface: top-level `error`, finish_reason null — deserializes as
+            // an empty update; without detection this misfires the empty-answer fallback.
+            0 => SseResponse(SsePartialTextThenErrorFrame("", finishReasonError: false)),
+            _ => SseResponse(SseText("Działa.")),
+        });
+
+        var events = await CollectAsync(BuildService(transport, out _)
+            .GenerateReplyAsync("hej", Context(), CancellationToken.None));
+
+        Assert.Equal(2, transport.CallCount);
+        Assert.Equal("Działa.", RenderedText(events));
+
+        var rows = await _db.ConversationUsage.OrderBy(u => u.Attempt).ToListAsync();
+        Assert.Equal(2, rows.Count);
+        Assert.True(rows[0].Failed);
+        Assert.False(rows[1].Failed);
+    }
+
+    [Fact]
+    public async Task RetriesExhausted_PostsVisibleFailureLine_PersistsNoAssistantRows()
+    {
+        var transport = new ScriptedTransport(_ => ErrorResponse(HttpStatusCode.BadGateway));
+
+        var events = await CollectAsync(BuildService(transport, out var options)
+            .GenerateReplyAsync("pytanie", Context(), CancellationToken.None));
+
+        Assert.Equal(options.Value.RetryMaxAttempts, transport.CallCount);
+        Assert.Equal(options.Value.FailureMessage, RenderedText(events));
+
+        var rows = await _db.ConversationUsage.OrderBy(u => u.Attempt).ToListAsync();
+        Assert.Equal(3, rows.Count);
+        Assert.All(rows, row => Assert.True(row.Failed));
+        Assert.Equal([1, 2, 3], rows.Select(r => r.Attempt));
+
+        // Only the user message reached the transcript — a failed turn appends nothing else.
+        var message = await _db.ConversationMessages.SingleAsync();
+        Assert.Equal("pytanie", message.Text);
+    }
+
+    [Fact]
+    public async Task TerminalStatus401_DoesNotRetry_SurfacesFailureLine()
+    {
+        var transport = new ScriptedTransport(_ => ErrorResponse(HttpStatusCode.Unauthorized));
+
+        var events = await CollectAsync(BuildService(transport, out var options)
+            .GenerateReplyAsync("pytanie", Context(), CancellationToken.None));
+
+        Assert.Equal(1, transport.CallCount);
+        Assert.Equal(options.Value.FailureMessage, RenderedText(events));
+
+        var row = await _db.ConversationUsage.SingleAsync();
+        Assert.True(row.Failed);
+        Assert.Equal(1, row.Attempt);
+    }
+
+    [Fact]
+    public async Task RateLimited_RetryAfterHeader_OutweighsJitterBackoff()
+    {
+        var transport = new ScriptedTransport(call => call switch
+        {
+            0 => ErrorResponse(HttpStatusCode.TooManyRequests, retryAfterSeconds: 1),
+            _ => SseResponse(SseText("Po przerwie.")),
+        });
+
+        // RetryBaseDelayMs=1 in BuildService: any wait ≥ the header value proves the
+        // header won over the (sub-hundred-ms) jitter.
+        var stopwatch = Stopwatch.StartNew();
+        var events = await CollectAsync(BuildService(transport, out _)
+            .GenerateReplyAsync("pytanie", Context(), CancellationToken.None));
+        stopwatch.Stop();
+
+        Assert.Equal(2, transport.CallCount);
+        Assert.Equal("Po przerwie.", RenderedText(events));
+        Assert.True(stopwatch.ElapsedMilliseconds >= 950,
+            $"expected the 1s Retry-After to be honored, waited only {stopwatch.ElapsedMilliseconds}ms");
+    }
+
+    private static ConversationContext Context() =>
+        new(GuildDiscordId, InvokerId, "tester", IsAdmin: false, ChannelId: ThreadChannelId);
+
+    // What the discrete renderer (#274) would post: deltas buffered, RoundReset drops
+    // the current round's buffer, the remainder is the answer.
+    private static string RenderedText(IReadOnlyList<ConversationUpdate> events)
+    {
+        var text = new StringBuilder();
+        foreach (var update in events)
+        {
+            switch (update)
+            {
+                case ConversationUpdate.AssistantTextDelta delta:
+                    text.Append(delta.Text);
+                    break;
+                case ConversationUpdate.RoundReset:
+                    text.Clear();
+                    break;
+            }
+        }
+        return text.ToString();
+    }
+
+    private ConversationService BuildService(
+        ScriptedTransport transport, out IOptions<ConversationOptions> conversationOptions)
+    {
+        conversationOptions = Options.Create(new ConversationOptions
+        {
+            ReasoningEffort = "low",
+            PrimaryGuildId = GuildDiscordId,
+            // Keep the exponential backoff sub-hundred-ms in tests; the Retry-After test
+            // proves the header outweighs it.
+            RetryBaseDelayMs = 1,
+            RetryMaxDelayMs = 2,
+        });
+
+        var chatClient = new OpenAIClient(
+                new ApiKeyCredential("test-key"),
+                new OpenAIClientOptions
+                {
+                    Endpoint = new Uri("http://localhost/api/v1"),
+                    Transport = new HttpClientPipelineTransport(new HttpClient(transport)),
+                    // Mirror prod (ConversationRegistration): the app-level §2 policy is
+                    // the single owner of retries.
+                    RetryPolicy = new ClientRetryPolicy(maxRetries: 0),
+                })
+            .GetChatClient(conversationOptions.Value.Model)
+            .AsIChatClient();
+
+        return new ConversationService(
+            chatClient,
+            BuildRegistry(conversationOptions),
+            new ConversationMemoryService(NewContext(), conversationOptions, NullLogger<ConversationMemoryService>.Instance),
+            conversationOptions,
+            Options.Create(new OpenRouterOptions { ApiKey = "test-key" }),
+            NullLogger<ConversationService>.Instance);
+    }
+
+    private ConversationToolRegistry BuildRegistry(IOptions<ConversationOptions> conversationOptions) =>
+        new(new MemeSearchService(NewContext()),
+            new GuildStatsService(NewContext()),
+            new DatabaseQueryService(NewContext(), conversationOptions, NullLogger<DatabaseQueryService>.Instance),
+            new FakeGuildActionService(),
+            new FakeConfirmationService(),
+            new DatabaseSchemaHint("schema hint"),
+            conversationOptions,
+            NullLogger<ConversationToolRegistry>.Instance);
+
+    private static async Task<List<ConversationUpdate>> CollectAsync(IAsyncEnumerable<ConversationUpdate> stream)
+    {
+        List<ConversationUpdate> events = [];
+        await foreach (var update in stream)
+            events.Add(update);
+        return events;
+    }
+
+    private const string UsageJson =
+        "\"usage\":{\"prompt_tokens\":10,\"completion_tokens\":5,\"total_tokens\":15,\"cost\":0.01}";
+
+    private static string SseChunk(string choicesJson, string? extraJson = null) =>
+        "data: {\"id\":\"chatcmpl-t\",\"object\":\"chat.completion.chunk\",\"created\":1750000000," +
+        $"\"model\":\"anthropic/claude-sonnet-5\",\"choices\":{choicesJson}{(extraJson is null ? "" : "," + extraJson)}}}\n\n";
+
+    private static string SseText(string text)
+    {
+        var delta = JsonSerializer.Serialize(text);
+        return SseChunk($"[{{\"index\":0,\"delta\":{{\"role\":\"assistant\",\"content\":{delta}}},\"finish_reason\":null}}]")
+            + SseChunk("[{\"index\":0,\"delta\":{},\"finish_reason\":\"stop\"}]", UsageJson)
+            + "data: [DONE]\n\n";
+    }
+
+    // OpenRouter's documented mid-stream error delivery: optional partial text, then a
+    // normal data chunk with top-level `error`; the stream ends after it (no [DONE]).
+    // finishReasonError toggles the two SDK surfaces probed for B-OQ1.
+    private static string SsePartialTextThenErrorFrame(string partialText, bool finishReasonError)
+    {
+        var text = partialText.Length == 0
+            ? string.Empty
+            : SseChunk($"[{{\"index\":0,\"delta\":{{\"role\":\"assistant\",\"content\":{JsonSerializer.Serialize(partialText)}}},\"finish_reason\":null}}]");
+        var finishReason = finishReasonError ? "\"error\"" : "null";
+        return text + SseChunk(
+            $"[{{\"index\":0,\"delta\":{{\"content\":\"\"}},\"finish_reason\":{finishReason}}}]",
+            "\"error\":{\"code\":502,\"message\":\"Provider returned error\",\"metadata\":{\"provider_name\":\"Anthropic\"}}");
+    }
+
+    private static HttpResponseMessage SseResponse(string sse) =>
+        new(HttpStatusCode.OK) { Content = new StringContent(sse, Encoding.UTF8, "text/event-stream") };
+
+    private static HttpResponseMessage ErrorResponse(HttpStatusCode status, int? retryAfterSeconds = null)
+    {
+        var response = new HttpResponseMessage(status)
+        {
+            Content = new StringContent(
+                $"{{\"error\":{{\"code\":{(int)status},\"message\":\"scripted failure\"}}}}",
+                Encoding.UTF8, "application/json"),
+        };
+        if (retryAfterSeconds is not null)
+            response.Headers.Add("Retry-After", retryAfterSeconds.Value.ToString());
+        return response;
+    }
+
+    private sealed class ScriptedTransport(Func<int, HttpResponseMessage> responder) : HttpMessageHandler
+    {
+        public int CallCount { get; private set; }
+
+        protected override Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request, CancellationToken cancellationToken) =>
+            Task.FromResult(responder(CallCount++));
+    }
+
+    private DiscordDbContext NewContext()
+    {
+        var options = new DbContextOptionsBuilder<DiscordDbContext>()
+            .UseNpgsql(fixture.Container.GetConnectionString())
+            .UseSnakeCaseNamingConvention()
+            .Options;
+        return new DiscordDbContext(options);
+    }
+}


### PR DESCRIPTION
Closes #268 (epic #266 §2).

## What

Per-round retry wrapper around the streamed model call in `ConversationService` — never around the turn (tools dispatch only after a round completes, so a retried round re-runs no tools and re-issues the same intact `messages` prefix).

- **Transient predicate** (`ConversationRetryPolicy`): reuses the meme client's 408/429/≥500 convention + transport faults, extended with the mid-stream error frame. Terminal: 400/401/402/403 and the turn's own timeout (user budget, not provider fault).
- **Mid-stream error frame (research B-OQ1, answered empirically)**: probed OpenRouter's documented frame through the real OpenAI SDK + MEAI adapter. Two surfaces exist:
  - `finish_reason:"error"` → the SDK **throws** `ArgumentOutOfRangeException` ("Unknown ChatFinishReason value") from the enumeration;
  - top-level `error` with `finish_reason:null` → passes through **silently** as an empty update with `$.error` on the raw chunk patch (this was the `EmptyAnswerFallback` misfire path).
  Both normalize to a synthetic `MidStreamErrorException` so one wrapper handles all surfaces.
- **Backoff**: exponential, full jitter, base 1s ×2 capped 8s, max 3 attempts, `Retry-After` honored on 429 when larger. Knobs on `ConversationOptions` (`RetryMaxAttempts`, `RetryBaseDelayMs`, `RetryMaxDelayMs`). Hand-rolled loop, no Polly.
- **Visible failure**: on exhaustion or terminal failure the turn posts a localized failure line (`FailureMessage` option) instead of failing silently. Under #274's discrete rendering the old B4 bubble-rewind is moot — a failed round posted nothing; the new `RoundReset` event just drops the renderer's buffered partial deltas so a retried round renders exactly once.
- **Ledger**: one `conversation_usage` row per attempt; `failed=true` rows keep whatever partial usage the stream reported (failed attempts still bill). A failed attempt persists no `conversation_message` rows.
- **SDK pipeline retries disabled** (`ClientRetryPolicy(maxRetries: 0)`): the app-level policy is the single owner of retries — the SDK's default 3 silent retries would stack under it (3×3 network attempts), under-count the ledger, and double-honor `Retry-After`.

## Tests

- `ConversationRetryTests` (Testcontainers + fault-injecting transport under the real SDK adapter): pre-stream 500 retry + ledger rows, both mid-stream surfaces (incl. exactly-once rendering after partial text), exhaustion → visible failure + no transcript rows, terminal 401 no-retry, Retry-After outweighing jitter.
- `ConversationRetryPolicyTests`: classification matrix, finish-reason normalization, full-jitter bounds.
- Full suite: 227 passed, 1 skipped (live-API).

🤖 Generated with [Claude Code](https://claude.com/claude-code)