### PR TITLE
feat: #269 §3 soft cost-cap alerting (Discord DM, dedup ledger)

### DIFF
--- a/src/DiscordEventService/Configuration/ConversationOptions.cs
+++ b/src/DiscordEventService/Configuration/ConversationOptions.cs
@@ -94,4 +94,24 @@ internal sealed class ConversationOptions
     // always captures them regardless of this flag; prod opts in explicitly — the
     // Langfuse instance is LAN-only, so payloads never leave the home network.
     public bool EnableSensitiveData { get; set; }
+
+    // §3 soft cost-cap alerting (#269) over the conversation_usage ledger — alert-only,
+    // the loop never refuses a turn.
+    public CostAlertOptions CostAlerts { get; set; } = new();
+}
+
+// Conversation:CostAlerts:* (#269). Windows are calendar-UTC (month / date); sums
+// include failed and retried attempts (they may bill) and cover conversation spend
+// only — meme indexing is a different ledger. A cap set to 0 or null is disabled.
+internal sealed class CostAlertOptions
+{
+    public bool Enabled { get; set; } = true;
+
+    // Monthly caps warn at 80% and 100%; the daily runaway tripwire at 100% only.
+    public double? GlobalMonthlyUsd { get; set; } = 10;
+    public double? PerUserMonthlyUsd { get; set; } = 3;
+    public double? GlobalDailyUsd { get; set; } = 2;
+
+    // How many per-invoker sums a global-cap alert lists as the spend breakdown.
+    public int TopSpendersCount { get; set; } = 5;
 }

--- a/src/DiscordEventService/Data/Configurations/UsageAlertEntityConfiguration.cs
+++ b/src/DiscordEventService/Data/Configurations/UsageAlertEntityConfiguration.cs
@@ -1,0 +1,20 @@
+using DiscordEventService.Data.Entities.Conversations;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
+namespace DiscordEventService.Data.Configurations;
+
+internal sealed class UsageAlertEntityConfiguration : IEntityTypeConfiguration<UsageAlertEntity>
+{
+    public void Configure(EntityTypeBuilder<UsageAlertEntity> builder)
+    {
+        builder.ToTable("usage_alerts");
+
+        // The dedup key (#269): insert-if-absent on this index is what makes each
+        // threshold alert fire once per window. NULLS NOT DISTINCT so the global
+        // caps (user null) dedup too — plain unique would treat every null as new.
+        builder.HasIndex(a => new { a.Cap, a.WindowStartUtc, a.Level, a.UserDiscordId })
+            .IsUnique()
+            .AreNullsDistinct(false);
+    }
+}

--- a/src/DiscordEventService/Data/DiscordDbContext.cs
+++ b/src/DiscordEventService/Data/DiscordDbContext.cs
@@ -85,6 +85,9 @@ public sealed class DiscordDbContext(DbContextOptions<DiscordDbContext> options)
     public DbSet<ConversationMessageEntity> ConversationMessages => Set<ConversationMessageEntity>();
     public DbSet<ConversationUsageEntity> ConversationUsage => Set<ConversationUsageEntity>();
 
+    // Sent cost-cap alerts (#269) — the soft-cap dedup ledger + audit trail.
+    public DbSet<UsageAlertEntity> UsageAlerts => Set<UsageAlertEntity>();
+
     protected override void OnModelCreating(ModelBuilder modelBuilder)
     {
         base.OnModelCreating(modelBuilder);

--- a/src/DiscordEventService/Data/Entities/Conversations/UsageAlertEntity.cs
+++ b/src/DiscordEventService/Data/Entities/Conversations/UsageAlertEntity.cs
@@ -1,0 +1,36 @@
+namespace DiscordEventService.Data.Entities.Conversations;
+
+// Persisted enum — never renumber (follow MemeIndexStatus).
+public enum UsageAlertCap
+{
+    GlobalMonthly = 0,
+    PerUserMonthly = 1,
+    GlobalDaily = 2
+}
+
+// One sent cost-cap alert (#269): the dedup ledger for soft cost alerting. A row per
+// (cap, window, level[, user]) means each threshold crossing DMs the admins exactly
+// once per window — restart- and redeploy-proof — and the table doubles as an audit
+// trail of when spend crossed which line.
+public class UsageAlertEntity
+{
+    public Guid Id { get; set; }
+
+    public UsageAlertCap Cap { get; set; }
+
+    // Calendar-UTC window this alert belongs to: first day of the month for the
+    // monthly caps, the UTC date for the daily tripwire.
+    public DateTime WindowStartUtc { get; set; }
+
+    // Warn level in percent: 80 or 100 for monthly caps, 100 for the daily tripwire.
+    public int Level { get; set; }
+
+    // The over-cap user for PerUserMonthly; null for the global caps.
+    public ulong? UserDiscordId { get; set; }
+
+    // Audit trail: what the window's spend and the configured cap were at send time.
+    public double SpentUsd { get; set; }
+    public double LimitUsd { get; set; }
+
+    public DateTime CreatedAtUtc { get; set; }
+}

--- a/src/DiscordEventService/Data/Migrations/20260717232641_AddUsageAlerts.Designer.cs
+++ b/src/DiscordEventService/Data/Migrations/20260717232641_AddUsageAlerts.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using DiscordEventService.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using NpgsqlTypes;
@@ -12,9 +13,11 @@ using NpgsqlTypes;
 namespace DiscordEventService.Data.Migrations
 {
     [DbContext(typeof(DiscordDbContext))]
-    partial class DiscordDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260717232641_AddUsageAlerts")]
+    partial class AddUsageAlerts
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/DiscordEventService/Data/Migrations/20260717232641_AddUsageAlerts.cs
+++ b/src/DiscordEventService/Data/Migrations/20260717232641_AddUsageAlerts.cs
@@ -1,0 +1,47 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace DiscordEventService.Data.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddUsageAlerts : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "usage_alerts",
+                columns: table => new
+                {
+                    id = table.Column<Guid>(type: "uuid", nullable: false, defaultValueSql: "uuidv7()"),
+                    cap = table.Column<int>(type: "integer", nullable: false),
+                    window_start_utc = table.Column<DateTime>(type: "timestamp with time zone", nullable: false),
+                    level = table.Column<int>(type: "integer", nullable: false),
+                    user_discord_id = table.Column<long>(type: "bigint", nullable: true),
+                    spent_usd = table.Column<double>(type: "double precision", nullable: false),
+                    limit_usd = table.Column<double>(type: "double precision", nullable: false),
+                    created_at_utc = table.Column<DateTime>(type: "timestamp with time zone", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("pk_usage_alerts", x => x.id);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "ix_usage_alerts_cap_window_start_utc_level_user_discord_id",
+                table: "usage_alerts",
+                columns: new[] { "cap", "window_start_utc", "level", "user_discord_id" },
+                unique: true)
+                .Annotation("Npgsql:NullsDistinct", false);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "usage_alerts");
+        }
+    }
+}

--- a/src/DiscordEventService/Services/Conversation/ConversationRegistration.cs
+++ b/src/DiscordEventService/Services/Conversation/ConversationRegistration.cs
@@ -41,6 +41,10 @@ internal static class ConversationRegistration
         services.AddSingleton<IGuildActionService, GuildActionService>();
         services.AddSingleton<IConfirmationService, ConfirmationService>();
 
+        // §3 cost-cap alert transport (#269): DMs admins via the accessor, same
+        // no-DiscordClient-in-DI rule as the action services.
+        services.AddSingleton<IUsageAlertNotifier, DiscordUsageAlertNotifier>();
+
         AddLangfuseTracing(services, configuration);
         return services;
     }
@@ -79,6 +83,9 @@ internal static class ConversationRegistration
         // container, so they share this single instance.
         services.AddSingleton<IGuildActionService, GuildActionService>();
         services.AddSingleton<IConfirmationService, ConfirmationService>();
+
+        // §3: the scoped UsageAlertService (CoreServiceTypes) resolves its notifier here.
+        services.AddSingleton<IUsageAlertNotifier, DiscordUsageAlertNotifier>();
     }
 
     private static IChatClient CreateChatClient(IServiceProvider sp)

--- a/src/DiscordEventService/Services/Conversation/UsageAlertNotifier.cs
+++ b/src/DiscordEventService/Services/Conversation/UsageAlertNotifier.cs
@@ -1,0 +1,48 @@
+using DiscordEventService.Configuration;
+using Microsoft.Extensions.Options;
+
+namespace DiscordEventService.Services.Conversation;
+
+// Delivery seam for §3 cost-cap alerts (#269): UsageAlertService decides WHAT to say,
+// this decides WHERE it goes. An interface so the threshold/dedup logic tests against
+// a recording fake — the Discord impl is live-verified only, like the renderer.
+internal interface IUsageAlertNotifier
+{
+    Task NotifyAdminsAsync(string message, CancellationToken cancellationToken);
+}
+
+// DMs every configured admin (#269 transport decision: Discord DM, not ntfy/Grafana —
+// no homelab coupling to survive the Hetzner move). Per-admin failures are logged and
+// swallowed: one refused DM must not stop the remaining admins, and an alert-path
+// failure must never break the conversation turn.
+internal sealed class DiscordUsageAlertNotifier(
+    DiscordClientAccessor clientAccessor,
+    IOptions<ConversationOptions> conversationOptions,
+    ILogger<DiscordUsageAlertNotifier> logger) : IUsageAlertNotifier
+{
+    public async Task NotifyAdminsAsync(string message, CancellationToken cancellationToken)
+    {
+        var adminIds = conversationOptions.Value.AdminUserIds;
+        if (adminIds.Length == 0)
+        {
+            logger.LogWarning("Cost alert had no AdminUserIds to DM; dropping: {Message}", message);
+            return;
+        }
+
+        foreach (var adminId in adminIds)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            try
+            {
+                var user = await clientAccessor.Client.GetUserAsync(adminId);
+                var dm = await user.CreateDmChannelAsync();
+                await dm.SendMessageAsync(message);
+                logger.LogInformation("Cost alert DM sent to admin {AdminId}", adminId);
+            }
+            catch (Exception ex)
+            {
+                logger.LogWarning(ex, "Failed to DM cost alert to admin {AdminId}", adminId);
+            }
+        }
+    }
+}

--- a/src/DiscordEventService/Services/Conversation/UsageAlertService.cs
+++ b/src/DiscordEventService/Services/Conversation/UsageAlertService.cs
@@ -1,0 +1,168 @@
+using System.Globalization;
+using DiscordEventService.Configuration;
+using DiscordEventService.Data;
+using DiscordEventService.Data.Entities.Conversations;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Options;
+
+namespace DiscordEventService.Services.Conversation;
+
+// §3 soft cost-cap alerting (#269) over the conversation_usage ledger: after every
+// turn, sum the calendar-UTC windows and DM the admins when a cap's warn level is
+// crossed — once per (cap, window, level), deduped through the usage_alerts table.
+// Sums deliberately include failed/retried attempts (they may bill, #268) — no
+// Failed filter. Alert-only by design: the loop never refuses a turn, and every
+// failure in here is logged and swallowed so the alert path can never break the
+// reply. Scoped over the request DbContext; dual-registered via CoreServiceTypes.
+internal sealed class UsageAlertService(
+    DiscordDbContext db,
+    IOptions<ConversationOptions> conversationOptions,
+    IUsageAlertNotifier notifier,
+    ILogger<UsageAlertService> logger)
+{
+    // The monthly caps warn twice, the daily runaway tripwire once (#269 design).
+    private static readonly int[] MonthlyLevels = [80, 100];
+    private static readonly int[] DailyLevels = [100];
+
+    // The check runs post-turn outside the turn's (possibly already-cancelled)
+    // timeout token, so it carries its own ceiling against a hung DB or Discord call.
+    private static readonly TimeSpan CheckTimeout = TimeSpan.FromSeconds(30);
+
+    public async Task CheckAndAlertAsync(ulong invokerId)
+    {
+        try
+        {
+            using var cts = new CancellationTokenSource(CheckTimeout);
+            await CheckCapsAsync(invokerId, cts.Token);
+        }
+        catch (Exception ex)
+        {
+            logger.LogWarning(ex, "Cost-cap alert check failed; the turn's reply is unaffected");
+        }
+    }
+
+    private async Task CheckCapsAsync(ulong invokerId, CancellationToken cancellationToken)
+    {
+        var caps = conversationOptions.Value.CostAlerts;
+        if (!caps.Enabled)
+            return;
+
+        var now = DateTime.UtcNow;
+        var monthStart = new DateTime(now.Year, now.Month, 1, 0, 0, 0, DateTimeKind.Utc);
+        var dayStart = now.Date;
+
+        // A cap of 0/null is disabled — the pattern's > 0 covers both.
+        if (caps.GlobalMonthlyUsd is > 0 and double globalMonthly)
+        {
+            await CheckCapAsync(UsageAlertCap.GlobalMonthly, monthStart, MonthlyLevels,
+                await SumSpendAsync(monthStart, null, cancellationToken),
+                globalMonthly, null, cancellationToken);
+        }
+
+        if (caps.PerUserMonthlyUsd is > 0 and double perUserMonthly)
+        {
+            await CheckCapAsync(UsageAlertCap.PerUserMonthly, monthStart, MonthlyLevels,
+                await SumSpendAsync(monthStart, invokerId, cancellationToken),
+                perUserMonthly, invokerId, cancellationToken);
+        }
+
+        if (caps.GlobalDailyUsd is > 0 and double globalDaily)
+        {
+            await CheckCapAsync(UsageAlertCap.GlobalDaily, dayStart, DailyLevels,
+                await SumSpendAsync(dayStart, null, cancellationToken),
+                globalDaily, null, cancellationToken);
+        }
+    }
+
+    private async Task CheckCapAsync(
+        UsageAlertCap cap, DateTime windowStartUtc, int[] levels, double spentUsd,
+        double limitUsd, ulong? userDiscordId, CancellationToken cancellationToken)
+    {
+        foreach (var level in levels)
+        {
+            if (spentUsd < limitUsd * level / 100)
+                continue;
+
+            // Insert-if-absent on the (cap, window, level, user) unique index is the
+            // dedup: only the writer that actually created the row sends the DM, so
+            // each crossing alerts exactly once per window — restart-proof.
+            var (_, inserted) = await db.UsageAlerts.GetOrInsertAsync(
+                a => a.Cap == cap && a.WindowStartUtc == windowStartUtc
+                    && a.Level == level && a.UserDiscordId == userDiscordId,
+                () => new UsageAlertEntity
+                {
+                    Cap = cap,
+                    WindowStartUtc = windowStartUtc,
+                    Level = level,
+                    UserDiscordId = userDiscordId,
+                    SpentUsd = spentUsd,
+                    LimitUsd = limitUsd,
+                    CreatedAtUtc = DateTime.UtcNow,
+                },
+                cancellationToken);
+            if (!inserted)
+                continue;
+
+            logger.LogInformation(
+                "Cost cap {Cap} crossed {Level}% ({Spent:0.00}/{Limit:0.00} USD) for window {WindowStart:yyyy-MM-dd}",
+                cap, level, spentUsd, limitUsd, windowStartUtc);
+
+            var message = await BuildMessageAsync(
+                cap, level, spentUsd, limitUsd, windowStartUtc, userDiscordId, cancellationToken);
+            await notifier.NotifyAdminsAsync(message, cancellationToken);
+        }
+    }
+
+    private Task<double> SumSpendAsync(
+        DateTime windowStartUtc, ulong? invokerId, CancellationToken cancellationToken)
+    {
+        var rows = db.ConversationUsage.Where(u => u.CreatedAtUtc >= windowStartUtc);
+        if (invokerId is not null)
+            rows = rows.Where(u => u.InvokerId == invokerId);
+        return rows.SumAsync(u => u.CostUsd ?? 0, cancellationToken);
+    }
+
+    private async Task<string> BuildMessageAsync(
+        UsageAlertCap cap, int level, double spentUsd, double limitUsd,
+        DateTime windowStartUtc, ulong? userDiscordId, CancellationToken cancellationToken)
+    {
+        var emoji = level >= 100 ? "🚨" : "⚠️";
+        var spend = $"{Usd(spentUsd)} z {Usd(limitUsd)}";
+
+        switch (cap)
+        {
+            case UsageAlertCap.PerUserMonthly:
+                return $"{emoji} Koszt rozmów: <@{userDiscordId}> przekroczył {level}% " +
+                    $"miesięcznego limitu ({spend}, okno {windowStartUtc:yyyy-MM}).";
+
+            case UsageAlertCap.GlobalDaily:
+                return $"{emoji} Koszt rozmów: dzienny limit awaryjny przekroczył {level}% " +
+                    $"({spend}, {windowStartUtc:yyyy-MM-dd}).\n" +
+                    $"Najwięksi: {await TopSpendersAsync(windowStartUtc, cancellationToken)}";
+
+            default:
+                return $"{emoji} Koszt rozmów: globalny limit miesięczny przekroczył {level}% " +
+                    $"({spend}, okno {windowStartUtc:yyyy-MM}).\n" +
+                    $"Najwięksi: {await TopSpendersAsync(windowStartUtc, cancellationToken)}";
+        }
+    }
+
+    // Per-invoker sums over the cap's window, biggest first — the reason the ledger
+    // carries invoker_id (#256): a global-cap alert should say who is spending.
+    private async Task<string> TopSpendersAsync(
+        DateTime windowStartUtc, CancellationToken cancellationToken)
+    {
+        var top = await db.ConversationUsage
+            .Where(u => u.CreatedAtUtc >= windowStartUtc)
+            .GroupBy(u => u.InvokerId)
+            .Select(g => new { InvokerId = g.Key, SpentUsd = g.Sum(u => u.CostUsd ?? 0) })
+            .OrderByDescending(x => x.SpentUsd)
+            .Take(conversationOptions.Value.CostAlerts.TopSpendersCount)
+            .ToListAsync(cancellationToken);
+
+        return string.Join(", ", top.Select(t => $"<@{t.InvokerId}> {Usd(t.SpentUsd)}"));
+    }
+
+    private static string Usd(double value) =>
+        string.Create(CultureInfo.InvariantCulture, $"${value:0.00}");
+}

--- a/src/DiscordEventService/Services/CoreServiceRegistration.cs
+++ b/src/DiscordEventService/Services/CoreServiceRegistration.cs
@@ -26,6 +26,7 @@ internal static class CoreServiceRegistration
         typeof(ConversationToolRegistry),
         typeof(ConversationMemoryService),
         typeof(ConversationService),
+        typeof(UsageAlertService),
     ];
 
     public static IServiceCollection AddCoreServices(this IServiceCollection services)

--- a/src/DiscordEventService/Services/EventHandlers/ConversationEventHandler.cs
+++ b/src/DiscordEventService/Services/EventHandlers/ConversationEventHandler.cs
@@ -13,6 +13,7 @@ namespace DiscordEventService.Services.EventHandlers;
 // turn is not an ingested event (no raw_event row) and a DM has no guild id.
 internal sealed class ConversationEventHandler(
     ConversationService conversation,
+    UsageAlertService usageAlerts,
     IOptions<ConversationOptions> options,
     ILogger<ConversationEventHandler> logger) : IEventHandler<MessageCreatedEventArgs>
 {
@@ -119,6 +120,14 @@ internal sealed class ConversationEventHandler(
             // Best-effort: post whatever the model had streamed so the user isn't left with
             // silence after the wait (the buffer holds it; posting doesn't need the token).
             await renderer.CompleteTurnAsync();
+        }
+        finally
+        {
+            // §3 post-turn cost-cap check (#269): the ledger rows exist on every exit
+            // path of GenerateReplyAsync (answer, round cap, retry exhaustion, timeout),
+            // so this finally covers them all. Never throws, and runs on its own
+            // timeout — the turn token may already be cancelled here.
+            await usageAlerts.CheckAndAlertAsync(context.InvokerId);
         }
     }
 

--- a/tests/DiscordEventService.Tests/UsageAlertTests.cs
+++ b/tests/DiscordEventService.Tests/UsageAlertTests.cs
@@ -1,0 +1,331 @@
+using DiscordEventService.Configuration;
+using DiscordEventService.Data;
+using DiscordEventService.Data.Entities.Conversations;
+using DiscordEventService.Services.Conversation;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using Xunit;
+
+namespace DiscordEventService.Tests;
+
+// #269 soft cost-cap alerting, against a real Postgres (Testcontainers, no DB mocking).
+// The seeded conversation_usage ledger is the input; the recording notifier is the
+// output — thresholds, 80/100 dedup, window rollover, disabled caps and top-spenders
+// are all proven here, the Discord DM transport itself is live-verified on the dev bot.
+public sealed class UsageAlertTests(PostgresFixture fixture)
+    : IClassFixture<PostgresFixture>, IAsyncLifetime
+{
+    private const ulong InvokerId = 42UL;
+    private const ulong OtherInvokerId = 43UL;
+
+    private DiscordDbContext _db = null!;
+    private Guid _conversationId;
+
+    public async Task InitializeAsync()
+    {
+        _db = NewContext();
+        await _db.Database.MigrateAsync();
+
+        await _db.UsageAlerts.ExecuteDeleteAsync();
+        await _db.ConversationUsage.ExecuteDeleteAsync();
+        await _db.ConversationMessages.ExecuteDeleteAsync();
+        await _db.Conversations.ExecuteDeleteAsync();
+
+        var conversation = new ConversationEntity
+        {
+            ChannelDiscordId = 1001UL,
+            CreatedAtUtc = DateTime.UtcNow,
+            LastActivityAtUtc = DateTime.UtcNow,
+        };
+        _db.Conversations.Add(conversation);
+        await _db.SaveChangesAsync();
+        _conversationId = conversation.Id;
+    }
+
+    public Task DisposeAsync() => _db.DisposeAsync().AsTask();
+
+    [Fact]
+    public async Task BelowAllThresholds_StaysSilent()
+    {
+        await SeedSpendAsync(InvokerId, 1.00);
+
+        var notifier = await RunCheckAsync();
+
+        Assert.Empty(notifier.Messages);
+        Assert.Empty(await _db.UsageAlerts.ToListAsync());
+    }
+
+    [Fact]
+    public async Task GlobalMonthly_Crossing80_AlertsOnce_ThenDedups()
+    {
+        // $8.50 of $10 = 85% — over the 80% warn level, under 100%.
+        await SeedSpendAsync(InvokerId, 8.50);
+
+        var first = await RunCheckAsync(GlobalMonthlyOnly);
+        var second = await RunCheckAsync(GlobalMonthlyOnly);
+
+        var message = Assert.Single(first.Messages);
+        Assert.Contains("80%", message);
+        Assert.Empty(second.Messages);
+
+        var alert = Assert.Single(await _db.UsageAlerts.ToListAsync());
+        Assert.Equal(UsageAlertCap.GlobalMonthly, alert.Cap);
+        Assert.Equal(80, alert.Level);
+        Assert.Null(alert.UserDiscordId);
+        Assert.Equal(MonthStart(), alert.WindowStartUtc);
+        Assert.Equal(8.50, alert.SpentUsd, precision: 6);
+        Assert.Equal(10, alert.LimitUsd, precision: 6);
+    }
+
+    [Fact]
+    public async Task GlobalMonthly_Crossing100AfterAn80Alert_AlertsOnceMore()
+    {
+        await SeedSpendAsync(InvokerId, 8.50);
+        await RunCheckAsync(GlobalMonthlyOnly);
+
+        await SeedSpendAsync(InvokerId, 2.00); // total $10.50 — past 100%
+        var notifier = await RunCheckAsync(GlobalMonthlyOnly);
+
+        var message = Assert.Single(notifier.Messages);
+        Assert.Contains("100%", message);
+        Assert.Equal([80, 100], (await _db.UsageAlerts.OrderBy(a => a.Level).Select(a => a.Level).ToListAsync()));
+    }
+
+    [Fact]
+    public async Task SingleJumpPastBothLevels_AlertsBothOnce()
+    {
+        await SeedSpendAsync(InvokerId, 11.00);
+
+        var notifier = await RunCheckAsync(GlobalMonthlyOnly);
+
+        Assert.Equal(2, notifier.Messages.Count);
+        Assert.Equal([80, 100], (await _db.UsageAlerts.OrderBy(a => a.Level).Select(a => a.Level).ToListAsync()));
+    }
+
+    [Fact]
+    public async Task DailyTripwire_SilentAt80_FiresAt100Only()
+    {
+        var notifierAt85 = await RunCheckAsync(MonthlyCapsOff, seedBefore: 1.70); // 85% of $2
+        Assert.Empty(notifierAt85.Messages);
+
+        await SeedSpendAsync(InvokerId, 0.40); // total $2.10 — over
+        var notifierOver = await RunCheckAsync(MonthlyCapsOff);
+
+        var message = Assert.Single(notifierOver.Messages);
+        Assert.Contains("100%", message);
+        var alert = Assert.Single(await _db.UsageAlerts.ToListAsync());
+        Assert.Equal(UsageAlertCap.GlobalDaily, alert.Cap);
+        Assert.Equal(100, alert.Level);
+        Assert.Equal(DayStart(), alert.WindowStartUtc);
+    }
+
+    [Fact]
+    public async Task PerUserMonthly_AlertsTheCrossingInvokerOnly()
+    {
+        // Invoker 42 at $2.50 of $3 = 83%; invoker 43 far below.
+        await SeedSpendAsync(InvokerId, 2.50);
+        await SeedSpendAsync(OtherInvokerId, 0.10);
+
+        var notifier = await RunCheckAsync(options =>
+        {
+            options.CostAlerts.GlobalMonthlyUsd = null; // isolate the per-user cap
+            options.CostAlerts.GlobalDailyUsd = null;
+        });
+
+        var message = Assert.Single(notifier.Messages);
+        Assert.Contains($"<@{InvokerId}>", message);
+        var alert = Assert.Single(await _db.UsageAlerts.ToListAsync());
+        Assert.Equal(UsageAlertCap.PerUserMonthly, alert.Cap);
+        Assert.Equal(InvokerId, alert.UserDiscordId);
+
+        // The other invoker's own post-turn check is below threshold — no new alert.
+        var otherNotifier = await RunCheckAsync(options =>
+        {
+            options.CostAlerts.GlobalMonthlyUsd = null;
+            options.CostAlerts.GlobalDailyUsd = null;
+        }, invokerId: OtherInvokerId);
+        Assert.Empty(otherNotifier.Messages);
+    }
+
+    [Fact]
+    public async Task WindowRollover_LastMonthsAlertDoesNotSuppressThisMonth()
+    {
+        // Last month crossed and alerted; this month crosses again.
+        _db.UsageAlerts.Add(new UsageAlertEntity
+        {
+            Cap = UsageAlertCap.GlobalMonthly,
+            WindowStartUtc = MonthStart().AddMonths(-1),
+            Level = 80,
+            SpentUsd = 9.00,
+            LimitUsd = 10,
+            CreatedAtUtc = DateTime.UtcNow.AddMonths(-1),
+        });
+        await _db.SaveChangesAsync();
+        await SeedSpendAsync(InvokerId, 8.50);
+
+        var notifier = await RunCheckAsync(GlobalMonthlyOnly);
+
+        Assert.Single(notifier.Messages);
+        Assert.Equal(2, await _db.UsageAlerts.CountAsync());
+    }
+
+    [Fact]
+    public async Task LastMonthsSpend_DoesNotCountTowardThisWindow()
+    {
+        await SeedSpendAsync(InvokerId, 9.00, LastMonth());
+        await SeedSpendAsync(InvokerId, 1.00);
+
+        var notifier = await RunCheckAsync(GlobalMonthlyOnly);
+
+        Assert.Empty(notifier.Messages);
+    }
+
+    [Fact]
+    public async Task DisabledCapsAndMasterSwitch_AreInert()
+    {
+        await SeedSpendAsync(InvokerId, 999.0);
+
+        var capsOff = await RunCheckAsync(options =>
+        {
+            options.CostAlerts.GlobalMonthlyUsd = 0;
+            options.CostAlerts.PerUserMonthlyUsd = null;
+            options.CostAlerts.GlobalDailyUsd = 0;
+        });
+        Assert.Empty(capsOff.Messages);
+
+        var masterOff = await RunCheckAsync(options => options.CostAlerts.Enabled = false);
+        Assert.Empty(masterOff.Messages);
+
+        Assert.Empty(await _db.UsageAlerts.ToListAsync());
+    }
+
+    [Fact]
+    public async Task GlobalAlert_ListsTopSpenders()
+    {
+        await SeedSpendAsync(InvokerId, 6.00);
+        await SeedSpendAsync(OtherInvokerId, 3.00);
+
+        var notifier = await RunCheckAsync(GlobalMonthlyOnly);
+
+        var message = Assert.Single(notifier.Messages);
+        Assert.Contains($"<@{InvokerId}>", message);
+        Assert.Contains($"<@{OtherInvokerId}>", message);
+        // Ordered by spend: the bigger spender is listed first.
+        Assert.True(message.IndexOf($"<@{InvokerId}>", StringComparison.Ordinal)
+            < message.IndexOf($"<@{OtherInvokerId}>", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public async Task FailedAttemptRows_CountTowardTheSums()
+    {
+        // Failed/retried attempts may still bill (#268) — sums must include them.
+        await SeedSpendAsync(InvokerId, 4.30);
+        await SeedSpendAsync(InvokerId, 4.30, failed: true);
+
+        var notifier = await RunCheckAsync(GlobalMonthlyOnly);
+
+        var message = Assert.Single(notifier.Messages);
+        Assert.Contains("80%", message);
+    }
+
+    [Fact]
+    public async Task NotifierFailure_IsSwallowed_AndTheAlertStaysRecorded()
+    {
+        await SeedSpendAsync(InvokerId, 8.50);
+
+        var service = BuildService(new ThrowingNotifier(), BuildOptions(GlobalMonthlyOnly));
+        await service.CheckAndAlertAsync(InvokerId); // must not throw
+
+        Assert.Single(await _db.UsageAlerts.ToListAsync());
+    }
+
+    private static void MonthlyCapsOff(ConversationOptions options)
+    {
+        options.CostAlerts.GlobalMonthlyUsd = null;
+        options.CostAlerts.PerUserMonthlyUsd = null;
+    }
+
+    private static void GlobalMonthlyOnly(ConversationOptions options)
+    {
+        options.CostAlerts.PerUserMonthlyUsd = null;
+        options.CostAlerts.GlobalDailyUsd = null;
+    }
+
+    private async Task<RecordingNotifier> RunCheckAsync(
+        Action<ConversationOptions>? configure = null, double? seedBefore = null, ulong invokerId = InvokerId)
+    {
+        if (seedBefore is not null)
+            await SeedSpendAsync(invokerId, seedBefore.Value);
+
+        var notifier = new RecordingNotifier();
+        await BuildService(notifier, BuildOptions(configure)).CheckAndAlertAsync(invokerId);
+        return notifier;
+    }
+
+    private UsageAlertService BuildService(IUsageAlertNotifier notifier, IOptions<ConversationOptions> options) =>
+        new(NewContext(), options, notifier, NullLogger<UsageAlertService>.Instance);
+
+    private static IOptions<ConversationOptions> BuildOptions(Action<ConversationOptions>? configure)
+    {
+        var options = new ConversationOptions();
+        configure?.Invoke(options);
+        return Options.Create(options);
+    }
+
+    private async Task SeedSpendAsync(
+        ulong invokerId, double costUsd, DateTime? createdAtUtc = null, bool failed = false)
+    {
+        _db.ConversationUsage.Add(new ConversationUsageEntity
+        {
+            ConversationId = _conversationId,
+            InvokerId = invokerId,
+            TurnIndex = 0,
+            Round = 1,
+            Attempt = failed ? 2 : 1,
+            Model = "test-model",
+            CostUsd = costUsd,
+            LatencyMs = 10,
+            Failed = failed,
+            CreatedAtUtc = createdAtUtc ?? DateTime.UtcNow,
+        });
+        await _db.SaveChangesAsync();
+    }
+
+    private static DateTime MonthStart()
+    {
+        var now = DateTime.UtcNow;
+        return new DateTime(now.Year, now.Month, 1, 0, 0, 0, DateTimeKind.Utc);
+    }
+
+    private static DateTime DayStart() => DateTime.UtcNow.Date;
+
+    // Squarely inside last month's window regardless of today's date.
+    private static DateTime LastMonth() => MonthStart().AddDays(-15);
+
+    private DiscordDbContext NewContext()
+    {
+        var options = new DbContextOptionsBuilder<DiscordDbContext>()
+            .UseNpgsql(fixture.Container.GetConnectionString())
+            .UseSnakeCaseNamingConvention()
+            .Options;
+        return new DiscordDbContext(options);
+    }
+
+    private sealed class RecordingNotifier : IUsageAlertNotifier
+    {
+        public List<string> Messages { get; } = [];
+
+        public Task NotifyAdminsAsync(string message, CancellationToken cancellationToken)
+        {
+            Messages.Add(message);
+            return Task.CompletedTask;
+        }
+    }
+
+    private sealed class ThrowingNotifier : IUsageAlertNotifier
+    {
+        public Task NotifyAdminsAsync(string message, CancellationToken cancellationToken) =>
+            throw new InvalidOperationException("DM refused");
+    }
+}


### PR DESCRIPTION
Closes #269 (epic #266 §3).

## What

Soft (alert-only, never refuse) cost caps over the #267 `conversation_usage` ledger:

- **Caps** — global $10/month, per-user $3/month, global $2/day runaway tripwire; calendar-UTC windows; sums include failed/retried attempts (#268 rows bill too — no `failed` filter); conversation spend only.
- **Config** — `Conversation:CostAlerts:*`: master `Enabled` (default true), `GlobalMonthlyUsd`/`PerUserMonthlyUsd`/`GlobalDailyUsd` (0/null disables), `TopSpendersCount`. Monthly caps warn at 80% + 100%; the daily tripwire at 100% only.
- **Transport** — Discord DM to each `AdminUserIds` entry via `DiscordClientAccessor` (never DiscordClient in the child container); per-admin failures logged, never thrown. Global-cap alerts carry a top-spenders per-`invoker_id` breakdown.
- **Dedup** — new `usage_alerts` table (UUIDv7, snake_case), insert-if-absent on the `(cap, window_start, level, user)` NULLS NOT DISTINCT unique index — one DM per crossing per window, restart/redeploy-proof, doubles as an audit trail.
- **Placement** — post-turn in `ConversationEventHandler.RespondAsync`'s `finally`, so ledger rows from every exit path (normal answer, round cap, retry exhaustion, turn timeout) are covered; the check runs on its own 30s timeout and swallows every failure — an alert-path error can never break the reply.

## Tests

12 Testcontainers integration tests over a seeded ledger (no DB mocking): thresholds, 80/100 dedup + single-jump-both-levels, daily-fires-at-100-only, per-user isolation, window rollover both directions, disabled caps + master-off, top-spenders ordering, failed-attempt inclusion, notifier-throw safety. Full suite: 239 passed, 1 skipped (live-API).

Live DM verification on the dev bot (tiny caps) to follow in-PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)