### PR TITLE
feat: #270 §4 Discord live-state read tools

### DIFF
--- a/src/DiscordEventService/Services/Conversation/ConversationRegistration.cs
+++ b/src/DiscordEventService/Services/Conversation/ConversationRegistration.cs
@@ -41,6 +41,9 @@ internal static class ConversationRegistration
         services.AddSingleton<IGuildActionService, GuildActionService>();
         services.AddSingleton<IConfirmationService, ConfirmationService>();
 
+        // §4 live-state read seam (#270): cache-first Discord reads, same accessor rule.
+        services.AddSingleton<IGuildLiveStateService, GuildLiveStateService>();
+
         // §3 cost-cap alert transport (#269): DMs admins via the accessor, same
         // no-DiscordClient-in-DI rule as the action services.
         services.AddSingleton<IUsageAlertNotifier, DiscordUsageAlertNotifier>();
@@ -83,6 +86,10 @@ internal static class ConversationRegistration
         // container, so they share this single instance.
         services.AddSingleton<IGuildActionService, GuildActionService>();
         services.AddSingleton<IConfirmationService, ConfirmationService>();
+
+        // §4: the scoped ConversationToolRegistry (CoreServiceTypes) resolves the live-state
+        // read seam here.
+        services.AddSingleton<IGuildLiveStateService, GuildLiveStateService>();
 
         // §3: the scoped UsageAlertService (CoreServiceTypes) resolves its notifier here.
         services.AddSingleton<IUsageAlertNotifier, DiscordUsageAlertNotifier>();

--- a/src/DiscordEventService/Services/Conversation/ConversationService.cs
+++ b/src/DiscordEventService/Services/Conversation/ConversationService.cs
@@ -374,6 +374,14 @@ internal sealed class ConversationService(
               questions (counts, activity over time, who-did-what) that the curated tools can't
               answer, call query_database with a single read-only SQL SELECT and summarize the rows.
 
+              For RIGHT-NOW questions use the LIVE tools instead of the database — the database is
+              an ingested copy and can lag. voice_occupants tells you who is sitting in which voice
+              channel this moment; member_info gives one member's current presence, activity, voice
+              state, roles and join/boost dates (by id or name fragment — if it returns several
+              candidates, ask the user which one they meant); server_info gives the server's live
+              member count, boosts and channel/role/emoji counts. For historical or aggregate
+              questions (who was in voice yesterday, activity over time), stick to query_database.
+
               Before EVERY tool call, first write one short progress note (in the user's language)
               saying what you are about to check — e.g. "okej, sprawdzam memy…", "daj mi sekundę,
               zajrzę do bazy…". Never skip it, keep it to one brief sentence, and vary the phrasing

--- a/src/DiscordEventService/Services/Conversation/ConversationToolRegistry.cs
+++ b/src/DiscordEventService/Services/Conversation/ConversationToolRegistry.cs
@@ -17,6 +17,7 @@ internal sealed class ConversationToolRegistry(
     MemeSearchService memeSearch,
     GuildStatsService guildStats,
     DatabaseQueryService databaseQuery,
+    IGuildLiveStateService liveState,
     IGuildActionService guildActions,
     IConfirmationService confirmations,
     DatabaseSchemaHint schemaHint,
@@ -58,6 +59,10 @@ internal sealed class ConversationToolRegistry(
                 BuildMemeSearchTool(context),
                 BuildTopPostersTool(context),
                 BuildQueryDatabaseTool(context),
+                // Live-state read tools (#270 §4) — gateway-cache truth for right-now questions.
+                BuildVoiceOccupantsTool(context),
+                BuildMemberInfoTool(context),
+                BuildServerInfoTool(context),
                 // Action tools — admin-only (§6); the irreversible ones stage behind a confirm button.
                 BuildAddReactionTool(context),
                 BuildPinMessageTool(context),
@@ -222,6 +227,103 @@ internal sealed class ConversationToolRegistry(
 
     private static string Truncate(string text, int maxLength) =>
         text.Length <= maxLength ? text : text[..(maxLength - 1)] + "…";
+
+    // ─────────────────────── Live-state read tools (#270 §4) ───────────────────────
+    // Open to everyone incl. DMs (a DM resolves the guild via PrimaryGuildId, like the other
+    // read tools) — restricting them would be theater, the same data is already reachable
+    // through query_database's ingested copies. These answer from the gateway caches, which
+    // DiscordIntents.All keeps warm; the one REST call is the member-by-id cache miss.
+
+    private const string NoLiveGuildMessage =
+        "This conversation isn't tied to a server, so I can't check its live state here.";
+
+    private const string GuildNotVisibleMessage =
+        "I can't see that server right now — I may be disconnected or no longer in it.";
+
+    private AIFunction BuildVoiceOccupantsTool(ConversationContext context) =>
+        AIFunctionFactory.Create(
+            () => VoiceOccupants(context),
+            new AIFunctionFactoryOptions
+            {
+                Name = "voice_occupants",
+                Description =
+                    "LIVE: who is in the server's voice channels RIGHT NOW — every non-empty voice "
+                    + "channel with its occupants and their state (muted/deafened/streaming/camera) plus "
+                    + "a jump link. Prefer this over query_database for right-now voice questions; the "
+                    + "database copy lags behind live state.",
+                JsonSchemaCreateOptions = StrictSchema,
+            });
+
+    private string VoiceOccupants(ConversationContext context)
+    {
+        if (!TryResolveGuild(context, out var guildId))
+            return NoLiveGuildMessage;
+
+        var channels = liveState.GetVoiceOccupants(guildId);
+        if (channels is null)
+            return GuildNotVisibleMessage;
+        return channels.Count == 0
+            ? "Nobody is in any voice channel right now."
+            : LiveStateFormatter.FormatVoiceChannels(channels);
+    }
+
+    private AIFunction BuildMemberInfoTool(ConversationContext context) =>
+        AIFunctionFactory.Create(
+            ([Description("Who to look up: a user id (snowflake string), or a fragment of their "
+                + "username/display name.")] string member,
+                CancellationToken ct) => MemberInfoAsync(context, member, ct),
+            new AIFunctionFactoryOptions
+            {
+                Name = "member_info",
+                Description =
+                    "LIVE: a member's current state RIGHT NOW — presence (online/idle/dnd/offline), "
+                    + "activities, voice channel, roles, join date, boost status. Prefer this over "
+                    + "query_database for right-now questions about a person. Accepts a user id or a "
+                    + "name fragment; an ambiguous fragment returns the matching candidates.",
+                JsonSchemaCreateOptions = StrictSchema,
+            });
+
+    private async Task<string> MemberInfoAsync(
+        ConversationContext context, string member, CancellationToken ct)
+    {
+        if (!TryResolveGuild(context, out var guildId))
+            return NoLiveGuildMessage;
+        if (string.IsNullOrWhiteSpace(member))
+            return "Provide a user id or a fragment of the member's name.";
+
+        var lookup = await liveState.FindMemberAsync(guildId, member, ct);
+        if (lookup is null)
+            return GuildNotVisibleMessage;
+
+        return lookup.Outcome switch
+        {
+            MemberLookupOutcome.Found => LiveStateFormatter.FormatMember(lookup.Member!),
+            MemberLookupOutcome.Ambiguous => LiveStateFormatter.FormatCandidates(member.Trim(), lookup.Candidates),
+            _ => $"No member matching \"{member.Trim()}\" in this server.",
+        };
+    }
+
+    private AIFunction BuildServerInfoTool(ConversationContext context) =>
+        AIFunctionFactory.Create(
+            () => ServerInfo(context),
+            new AIFunctionFactoryOptions
+            {
+                Name = "server_info",
+                Description =
+                    "LIVE: the server's current shape RIGHT NOW — live member count, boost tier and "
+                    + "count, created date, and channel/role/emoji counts. Prefer this over "
+                    + "query_database for right-now questions about the server itself.",
+                JsonSchemaCreateOptions = StrictSchema,
+            });
+
+    private string ServerInfo(ConversationContext context)
+    {
+        if (!TryResolveGuild(context, out var guildId))
+            return NoLiveGuildMessage;
+
+        var server = liveState.GetServerInfo(guildId);
+        return server is null ? GuildNotVisibleMessage : LiveStateFormatter.FormatServerInfo(server);
+    }
 
     // ───────────────────────── Action tools (#238 §6) ─────────────────────────
     // Every action tool first checks context.IsAdmin (the un-promptable gate). Reversible ones

--- a/src/DiscordEventService/Services/Conversation/GuildLiveStateService.cs
+++ b/src/DiscordEventService/Services/Conversation/GuildLiveStateService.cs
@@ -1,0 +1,275 @@
+using DSharpPlus;
+using DSharpPlus.Entities;
+using DSharpPlus.Exceptions;
+
+namespace DiscordEventService.Services.Conversation;
+
+// The Discord-read seam for the §4 live-state tools (#270): projects the gateway caches
+// (kept warm by DiscordIntents.All) into plain records the tool layer formats and tests
+// without DSharpPlus entities. Cache-first by design — the ONLY REST call is the
+// member-by-id cache miss, per the ticket's now-correctness principle. A null return
+// means the guild isn't in the client's cache (not connected / not a member); the tool
+// layer turns that into a clean string. Stateless and singleton over the accessor, same
+// as GuildActionService.
+internal interface IGuildLiveStateService
+{
+    IReadOnlyList<LiveVoiceChannel>? GetVoiceOccupants(ulong guildId);
+    Task<MemberLookupResult?> FindMemberAsync(ulong guildId, string query, CancellationToken cancellationToken);
+    LiveServerInfo? GetServerInfo(ulong guildId);
+}
+
+internal sealed record LiveVoiceOccupant(
+    string DisplayName, bool IsMuted, bool IsDeafened, bool IsStreaming, bool HasVideo);
+
+internal sealed record LiveVoiceChannel(
+    ulong GuildId, ulong ChannelId, string ChannelName, IReadOnlyList<LiveVoiceOccupant> Occupants);
+
+internal sealed record LiveMemberCandidate(ulong Id, string Username, string? GlobalName, string DisplayName);
+
+internal sealed record LiveMemberVoice(
+    string ChannelName, bool IsMuted, bool IsDeafened, bool IsStreaming, bool HasVideo);
+
+internal sealed record LiveMemberInfo(
+    ulong Id,
+    string Username,
+    string? GlobalName,
+    string DisplayName,
+    bool IsBot,
+    DateTimeOffset AccountCreatedAt,
+    DateTimeOffset JoinedAt,
+    DateTimeOffset? BoostingSince,
+    DateTimeOffset? TimedOutUntil,
+    IReadOnlyList<string> Roles,
+    string PresenceStatus,
+    IReadOnlyList<string> Activities,
+    LiveMemberVoice? Voice);
+
+internal sealed record LiveServerInfo(
+    ulong Id,
+    string Name,
+    DateTimeOffset CreatedAt,
+    string? OwnerName,
+    int MemberCount,
+    int BoostTier,
+    int BoostCount,
+    int TextChannelCount,
+    int VoiceChannelCount,
+    int CategoryCount,
+    int RoleCount,
+    int EmojiCount);
+
+internal enum MemberLookupOutcome
+{
+    Found,
+    Ambiguous,
+    NotFound,
+}
+
+internal sealed record MemberLookupResult(
+    MemberLookupOutcome Outcome,
+    LiveMemberInfo? Member,
+    IReadOnlyList<LiveMemberCandidate> Candidates)
+{
+    public static MemberLookupResult Found(LiveMemberInfo member) => new(MemberLookupOutcome.Found, member, []);
+    public static MemberLookupResult Ambiguous(IReadOnlyList<LiveMemberCandidate> candidates) =>
+        new(MemberLookupOutcome.Ambiguous, null, candidates);
+    public static MemberLookupResult NotFound() => new(MemberLookupOutcome.NotFound, null, []);
+}
+
+internal sealed class GuildLiveStateService(DiscordClientAccessor clientAccessor) : IGuildLiveStateService
+{
+    // Resolved from the accessor (never injected directly) so DiscordClient stays out of the
+    // child container's DI graph — see DiscordClientAccessor for why.
+    private DiscordClient Client => clientAccessor.Client;
+
+    public IReadOnlyList<LiveVoiceChannel>? GetVoiceOccupants(ulong guildId)
+    {
+        if (!Client.Guilds.TryGetValue(guildId, out var guild))
+            return null;
+
+        return guild.VoiceStates.Values
+            .Where(state => state.Channel is not null)
+            .GroupBy(state => state.Channel!)
+            .Select(channel => new LiveVoiceChannel(
+                guildId,
+                channel.Key.Id,
+                channel.Key.Name ?? channel.Key.Id.ToString(),
+                [.. channel.Select(ProjectOccupant).OrderBy(o => o.DisplayName, StringComparer.OrdinalIgnoreCase)]))
+            .OrderBy(channel => channel.ChannelName, StringComparer.OrdinalIgnoreCase)
+            .ToList();
+    }
+
+    public async Task<MemberLookupResult?> FindMemberAsync(
+        ulong guildId, string query, CancellationToken cancellationToken)
+    {
+        if (!Client.Guilds.TryGetValue(guildId, out var guild))
+            return null;
+
+        var trimmed = query.Trim();
+        if (ulong.TryParse(trimmed, out var id))
+        {
+            if (guild.Members.TryGetValue(id, out var cached))
+                return MemberLookupResult.Found(ProjectMember(cached));
+
+            // The single sanctioned REST fallback: an id the cache doesn't have (member left,
+            // or the cache is still filling after a reconnect).
+            try
+            {
+                var fetched = await guild.GetMemberAsync(id, updateCache: true);
+                return MemberLookupResult.Found(ProjectMember(fetched));
+            }
+            catch (NotFoundException)
+            {
+                return MemberLookupResult.NotFound();
+            }
+            catch (BadRequestException)
+            {
+                // A numeric string Discord rejects as a snowflake — same answer as unknown.
+                return MemberLookupResult.NotFound();
+            }
+        }
+
+        var match = MemberMatcher.Match(
+            guild.Members.Values.Select(member => new LiveMemberCandidate(
+                member.Id, member.Username, member.GlobalName, member.DisplayName)),
+            trimmed);
+        return match.Outcome == MemberLookupOutcome.Found
+            ? MemberLookupResult.Found(ProjectMember(guild.Members[match.Member!.Value]))
+            : new MemberLookupResult(match.Outcome, null, match.Candidates);
+    }
+
+    public LiveServerInfo? GetServerInfo(ulong guildId)
+    {
+        if (!Client.Guilds.TryGetValue(guildId, out var guild))
+            return null;
+
+        var channels = guild.Channels.Values;
+        return new LiveServerInfo(
+            guild.Id,
+            guild.Name,
+            guild.CreationTimestamp,
+            guild.Members.TryGetValue(guild.OwnerId, out var owner) ? owner.DisplayName : null,
+            guild.MemberCount,
+            guild.PremiumTier switch
+            {
+                DiscordPremiumTier.Tier_1 => 1,
+                DiscordPremiumTier.Tier_2 => 2,
+                DiscordPremiumTier.Tier_3 => 3,
+                _ => 0,
+            },
+            guild.PremiumSubscriptionCount ?? 0,
+            channels.Count(c => c.Type is DiscordChannelType.Text or DiscordChannelType.News),
+            channels.Count(c => c.Type is DiscordChannelType.Voice or DiscordChannelType.Stage),
+            channels.Count(c => c.Type is DiscordChannelType.Category),
+            guild.Roles.Count,
+            guild.Emojis.Count);
+    }
+
+    private static LiveVoiceOccupant ProjectOccupant(DiscordVoiceState state) =>
+        new(
+            state.Member?.DisplayName ?? state.User?.Username ?? "(unknown)",
+            state.IsSelfMuted || state.IsServerMuted,
+            state.IsSelfDeafened || state.IsServerDeafened,
+            state.IsSelfStream,
+            state.IsSelfVideo);
+
+    private static LiveMemberInfo ProjectMember(DiscordMember member)
+    {
+        var presence = member.Presence;
+        var voiceChannel = member.VoiceState?.Channel;
+        return new LiveMemberInfo(
+            member.Id,
+            member.Username,
+            member.GlobalName,
+            member.DisplayName,
+            member.IsBot,
+            member.CreationTimestamp,
+            member.JoinedAt,
+            member.PremiumSince,
+            member.IsTimedOut ? member.CommunicationDisabledUntil : null,
+            [.. member.Roles.OrderByDescending(role => role.Position).Select(role => role.Name)],
+            DescribeStatus(presence),
+            presence is null ? [] : [.. presence.Activities.Select(DescribeActivity)],
+            voiceChannel is null
+                ? null
+                : new LiveMemberVoice(
+                    voiceChannel.Name ?? voiceChannel.Id.ToString(),
+                    member.VoiceState!.IsSelfMuted || member.VoiceState.IsServerMuted,
+                    member.VoiceState.IsSelfDeafened || member.VoiceState.IsServerDeafened,
+                    member.VoiceState.IsSelfStream,
+                    member.VoiceState.IsSelfVideo));
+    }
+
+    private static string DescribeStatus(DiscordPresence? presence) =>
+        presence?.Status switch
+        {
+            DiscordUserStatus.Online => "online",
+            DiscordUserStatus.Idle => "idle",
+            DiscordUserStatus.DoNotDisturb => "do not disturb",
+            // Invisible is indistinguishable from offline on the receiving side; null presence
+            // means the gateway never sent one (offline since boot).
+            _ => "offline",
+        };
+
+    private static string DescribeActivity(DiscordActivity activity) =>
+        activity.ActivityType switch
+        {
+            DiscordActivityType.Custom when activity.CustomStatus is { } custom =>
+                $"Custom status: {custom.Name}",
+            DiscordActivityType.Playing => $"Playing {activity.Name}",
+            DiscordActivityType.Streaming => $"Streaming {activity.Name}",
+            DiscordActivityType.ListeningTo => $"Listening to {activity.Name}",
+            DiscordActivityType.Watching => $"Watching {activity.Name}",
+            DiscordActivityType.Competing => $"Competing in {activity.Name}",
+            _ => activity.Name,
+        };
+}
+
+// Pure name-fragment resolution over the live member cache, kept Discord-free so the
+// ambiguity contract (#270 acceptance) is unit-testable: an exact username/global/display
+// name hit wins outright; otherwise a unique substring hit wins; several hits return the
+// candidates for the model to relay; none is a clean not-found.
+internal static class MemberMatcher
+{
+    // Enough for the model to relay "which one did you mean?" without flooding the context.
+    private const int MaxCandidates = 10;
+
+    public sealed record Result(
+        MemberLookupOutcome Outcome, ulong? Member, IReadOnlyList<LiveMemberCandidate> Candidates);
+
+    public static Result Match(IEnumerable<LiveMemberCandidate> members, string fragment)
+    {
+        List<LiveMemberCandidate> exact = [];
+        List<LiveMemberCandidate> partial = [];
+        foreach (var member in members)
+        {
+            if (MatchesExactly(member, fragment))
+                exact.Add(member);
+            else if (Contains(member, fragment))
+                partial.Add(member);
+        }
+
+        if (exact.Count == 1)
+            return new Result(MemberLookupOutcome.Found, exact[0].Id, []);
+
+        var hits = exact.Count > 1 ? exact : partial;
+        return hits.Count switch
+        {
+            0 => new Result(MemberLookupOutcome.NotFound, null, []),
+            1 => new Result(MemberLookupOutcome.Found, hits[0].Id, []),
+            _ => new Result(
+                MemberLookupOutcome.Ambiguous, null,
+                [.. hits.OrderBy(m => m.DisplayName, StringComparer.OrdinalIgnoreCase).Take(MaxCandidates)]),
+        };
+    }
+
+    private static bool MatchesExactly(LiveMemberCandidate member, string fragment) =>
+        string.Equals(member.Username, fragment, StringComparison.OrdinalIgnoreCase)
+        || string.Equals(member.GlobalName, fragment, StringComparison.OrdinalIgnoreCase)
+        || string.Equals(member.DisplayName, fragment, StringComparison.OrdinalIgnoreCase);
+
+    private static bool Contains(LiveMemberCandidate member, string fragment) =>
+        member.Username.Contains(fragment, StringComparison.OrdinalIgnoreCase)
+        || (member.GlobalName?.Contains(fragment, StringComparison.OrdinalIgnoreCase) ?? false)
+        || member.DisplayName.Contains(fragment, StringComparison.OrdinalIgnoreCase);
+}

--- a/src/DiscordEventService/Services/Conversation/LiveStateFormatter.cs
+++ b/src/DiscordEventService/Services/Conversation/LiveStateFormatter.cs
@@ -1,0 +1,98 @@
+using System.Globalization;
+using System.Text;
+
+namespace DiscordEventService.Services.Conversation;
+
+// Model-facing rendering for the §4 live-state tools (#270): plain records in, one
+// compact string out. Kept pure (no Discord, no clock) so the output shapes are
+// unit-tested — the live projection layer is verified on the dev bot instead.
+internal static class LiveStateFormatter
+{
+    public static string FormatVoiceChannels(IReadOnlyList<LiveVoiceChannel> channels)
+    {
+        var builder = new StringBuilder();
+        builder.Append(CultureInfo.InvariantCulture, $"{channels.Count} voice channel(s) with people in them:");
+        foreach (var channel in channels)
+        {
+            builder.Append(CultureInfo.InvariantCulture,
+                $"\n**{channel.ChannelName}** ({channel.Occupants.Count}) — "
+                + $"https://discord.com/channels/{channel.GuildId}/{channel.ChannelId}");
+            foreach (var occupant in channel.Occupants)
+                builder.Append(CultureInfo.InvariantCulture,
+                    $"\n- {occupant.DisplayName}{DescribeFlags(occupant.IsMuted, occupant.IsDeafened, occupant.IsStreaming, occupant.HasVideo)}");
+        }
+        return builder.ToString();
+    }
+
+    public static string FormatCandidates(string query, IReadOnlyList<LiveMemberCandidate> candidates)
+    {
+        var lines = candidates.Select(candidate =>
+        {
+            var alias = candidate.GlobalName is { } global && global != candidate.DisplayName
+                ? $" / {global}"
+                : string.Empty;
+            return $"- {candidate.DisplayName}{alias} (username {candidate.Username}, id {candidate.Id})";
+        });
+        return $"Several members match \"{query}\" — ask which one they mean:\n{string.Join("\n", lines)}";
+    }
+
+    public static string FormatMember(LiveMemberInfo member)
+    {
+        var builder = new StringBuilder();
+        builder.Append(CultureInfo.InvariantCulture,
+            $"**{member.DisplayName}** (username {member.Username}, id {member.Id})");
+        if (member.GlobalName is { } global && global != member.DisplayName)
+            builder.Append(CultureInfo.InvariantCulture, $", global name {global}");
+        if (member.IsBot)
+            builder.Append(" — BOT");
+
+        builder.Append(CultureInfo.InvariantCulture, $"\nStatus: {member.PresenceStatus}");
+        foreach (var activity in member.Activities)
+            builder.Append(CultureInfo.InvariantCulture, $"\n- {activity}");
+
+        builder.Append(member.Voice is { } voice
+            ? $"\nVoice: in **{voice.ChannelName}**{DescribeFlags(voice.IsMuted, voice.IsDeafened, voice.IsStreaming, voice.HasVideo)}"
+            : "\nVoice: not in a voice channel");
+
+        builder.Append(CultureInfo.InvariantCulture,
+            $"\nRoles: {(member.Roles.Count > 0 ? string.Join(", ", member.Roles) : "(none)")}");
+        builder.Append(CultureInfo.InvariantCulture,
+            $"\nJoined this server: {FormatDate(member.JoinedAt)} | Account created: {FormatDate(member.AccountCreatedAt)}");
+        if (member.BoostingSince is { } boosting)
+            builder.Append(CultureInfo.InvariantCulture, $"\nBoosting the server since {FormatDate(boosting)}");
+        if (member.TimedOutUntil is { } timedOut)
+            builder.Append(CultureInfo.InvariantCulture,
+                $"\nTimed out until {timedOut.UtcDateTime.ToString("yyyy-MM-dd HH:mm 'UTC'", CultureInfo.InvariantCulture)}");
+        return builder.ToString();
+    }
+
+    public static string FormatServerInfo(LiveServerInfo server)
+    {
+        var owner = server.OwnerName is { } name ? $"\nOwner: {name}" : string.Empty;
+        return $"""
+            **{server.Name}** (id {server.Id}), created {FormatDate(server.CreatedAt)}{owner}
+            Members: {server.MemberCount}
+            Boosts: level {server.BoostTier}, {server.BoostCount} boost(s)
+            Channels: {server.TextChannelCount} text, {server.VoiceChannelCount} voice, {server.CategoryCount} categories
+            Roles: {server.RoleCount} | Emojis: {server.EmojiCount}
+            """;
+    }
+
+    private static string DescribeFlags(bool isMuted, bool isDeafened, bool isStreaming, bool hasVideo)
+    {
+        List<string> flags = [];
+        // Deafening implies muting on Discord, so "deafened" alone tells the whole story.
+        if (isDeafened)
+            flags.Add("deafened");
+        else if (isMuted)
+            flags.Add("muted");
+        if (isStreaming)
+            flags.Add("streaming");
+        if (hasVideo)
+            flags.Add("camera on");
+        return flags.Count > 0 ? $" ({string.Join(", ", flags)})" : string.Empty;
+    }
+
+    private static string FormatDate(DateTimeOffset timestamp) =>
+        timestamp.UtcDateTime.ToString("yyyy-MM-dd", CultureInfo.InvariantCulture);
+}

--- a/tests/DiscordEventService.Tests/ConversationActionToolTests.cs
+++ b/tests/DiscordEventService.Tests/ConversationActionToolTests.cs
@@ -155,6 +155,7 @@ public sealed class ConversationActionToolTests
             memeSearch: null!,
             guildStats: null!,
             databaseQuery: null!,
+            new FakeGuildLiveStateService(),
             actions,
             confirmations,
             new DatabaseSchemaHint("schema"),

--- a/tests/DiscordEventService.Tests/ConversationLiveApiTests.cs
+++ b/tests/DiscordEventService.Tests/ConversationLiveApiTests.cs
@@ -82,6 +82,7 @@ public sealed class ConversationLiveApiTests(PostgresFixture fixture)
             new MemeSearchService(NewContext()),
             new GuildStatsService(NewContext()),
             new DatabaseQueryService(NewContext(), conversationOptions, NullLogger<DatabaseQueryService>.Instance),
+            new FakeGuildLiveStateService(),
             new FakeGuildActionService(),
             new FakeConfirmationService(),
             new DatabaseSchemaHint("schema hint"),

--- a/tests/DiscordEventService.Tests/ConversationLiveStateToolTests.cs
+++ b/tests/DiscordEventService.Tests/ConversationLiveStateToolTests.cs
@@ -1,0 +1,320 @@
+using DiscordEventService.Configuration;
+using DiscordEventService.Services.Conversation;
+using Microsoft.Extensions.AI;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using Xunit;
+
+namespace DiscordEventService.Tests;
+
+// The §4 live tools' testable contracts (#270): the guild-resolution guardrails, the
+// member-lookup decision tree (id vs fragment, ambiguity, not-found), and the exact
+// model-facing output shapes. The projection off real DSharpPlus caches is deliberately
+// NOT faked here — that layer is live-verified on the dev bot.
+public sealed class ConversationLiveStateToolTests
+{
+    private const ulong GuildId = 100UL;
+    private const ulong ChannelId = 7UL;
+
+    // ─────────────────────────── tool-level contracts ───────────────────────────
+
+    [Fact]
+    public async Task VoiceOccupants_InDmWithoutPrimaryGuild_ReportsNoServer()
+    {
+        var live = new FakeGuildLiveStateService();
+        var toolset = BuildToolset(DmContext(), live, primaryGuildId: null);
+
+        var result = await InvokeAsync(toolset, "voice_occupants", []);
+
+        Assert.Contains("server", result, StringComparison.OrdinalIgnoreCase);
+        Assert.Null(live.VoiceGuildId);
+    }
+
+    [Fact]
+    public async Task VoiceOccupants_InDm_FallsBackToPrimaryGuild()
+    {
+        var live = new FakeGuildLiveStateService { VoiceChannels = [] };
+        var toolset = BuildToolset(DmContext(), live, primaryGuildId: GuildId);
+
+        var result = await InvokeAsync(toolset, "voice_occupants", []);
+
+        Assert.Equal(GuildId, live.VoiceGuildId);
+        Assert.Contains("Nobody", result, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public async Task VoiceOccupants_FormatsChannelsOccupantsAndJumpLinks()
+    {
+        var live = new FakeGuildLiveStateService
+        {
+            VoiceChannels =
+            [
+                new LiveVoiceChannel(GuildId, 555UL, "Nora", [
+                    new LiveVoiceOccupant("Alice", IsMuted: true, IsDeafened: false, IsStreaming: false, HasVideo: false),
+                    new LiveVoiceOccupant("Bob", IsMuted: false, IsDeafened: false, IsStreaming: true, HasVideo: true),
+                    new LiveVoiceOccupant("Carol", IsMuted: false, IsDeafened: false, IsStreaming: false, HasVideo: false),
+                ]),
+            ],
+        };
+        var toolset = BuildToolset(GuildContext(), live);
+
+        var result = await InvokeAsync(toolset, "voice_occupants", []);
+
+        Assert.Contains("**Nora** (3)", result);
+        Assert.Contains($"https://discord.com/channels/{GuildId}/555", result);
+        Assert.Contains("Alice (muted)", result);
+        Assert.Contains("Bob (streaming, camera on)", result);
+        Assert.Contains("- Carol", result);
+    }
+
+    [Fact]
+    public async Task VoiceOccupants_GuildNotInCache_ReportsCleanly()
+    {
+        var live = new FakeGuildLiveStateService { VoiceChannels = null };
+        var toolset = BuildToolset(GuildContext(), live);
+
+        var result = await InvokeAsync(toolset, "voice_occupants", []);
+
+        Assert.Contains("can't see", result, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public async Task MemberInfo_Ambiguous_ReturnsCandidateList()
+    {
+        var live = new FakeGuildLiveStateService
+        {
+            MemberLookup = MemberLookupResult.Ambiguous(
+            [
+                new LiveMemberCandidate(1UL, "anna_a", "Anna A", "Ania"),
+                new LiveMemberCandidate(2UL, "anna_b", null, "Anka"),
+            ]),
+        };
+        var toolset = BuildToolset(GuildContext(), live);
+
+        var result = await InvokeAsync(toolset, "member_info", new() { ["member"] = "an" });
+
+        Assert.Equal("an", live.MemberQuery);
+        Assert.Contains("Several members match", result);
+        Assert.Contains("Ania / Anna A (username anna_a, id 1)", result);
+        Assert.Contains("Anka (username anna_b, id 2)", result);
+    }
+
+    [Fact]
+    public async Task MemberInfo_Unknown_ReturnsCleanNotFound()
+    {
+        var live = new FakeGuildLiveStateService { MemberLookup = MemberLookupResult.NotFound() };
+        var toolset = BuildToolset(GuildContext(), live);
+
+        var result = await InvokeAsync(toolset, "member_info", new() { ["member"] = "999" });
+
+        Assert.Contains("No member matching \"999\"", result);
+    }
+
+    [Fact]
+    public async Task MemberInfo_BlankQuery_AsksForAValue()
+    {
+        var live = new FakeGuildLiveStateService();
+        var toolset = BuildToolset(GuildContext(), live);
+
+        var result = await InvokeAsync(toolset, "member_info", new() { ["member"] = "  " });
+
+        Assert.Null(live.MemberQuery);
+        Assert.Contains("Provide", result);
+    }
+
+    [Fact]
+    public async Task MemberInfo_Found_RendersTheFullSnapshot()
+    {
+        var live = new FakeGuildLiveStateService
+        {
+            MemberLookup = MemberLookupResult.Found(new LiveMemberInfo(
+                Id: 42UL,
+                Username: "wiktor",
+                GlobalName: "Wiktor",
+                DisplayName: "Wikuś",
+                IsBot: false,
+                AccountCreatedAt: new DateTimeOffset(2016, 5, 1, 0, 0, 0, TimeSpan.Zero),
+                JoinedAt: new DateTimeOffset(2020, 1, 2, 0, 0, 0, TimeSpan.Zero),
+                BoostingSince: new DateTimeOffset(2024, 3, 4, 0, 0, 0, TimeSpan.Zero),
+                TimedOutUntil: null,
+                Roles: ["Admin", "Gracz"],
+                PresenceStatus: "online",
+                Activities: ["Playing Factorio", "Custom status: grinduję"],
+                Voice: new LiveMemberVoice("Nora", IsMuted: false, IsDeafened: true, IsStreaming: false, HasVideo: false))),
+        };
+        var toolset = BuildToolset(GuildContext(), live);
+
+        var result = await InvokeAsync(toolset, "member_info", new() { ["member"] = "42" });
+
+        Assert.Contains("**Wikuś** (username wiktor, id 42)", result);
+        Assert.Contains("Status: online", result);
+        Assert.Contains("Playing Factorio", result);
+        Assert.Contains("Custom status: grinduję", result);
+        Assert.Contains("Voice: in **Nora** (deafened)", result);
+        Assert.Contains("Roles: Admin, Gracz", result);
+        Assert.Contains("Joined this server: 2020-01-02", result);
+        Assert.Contains("Account created: 2016-05-01", result);
+        Assert.Contains("Boosting the server since 2024-03-04", result);
+        Assert.DoesNotContain("Timed out", result);
+    }
+
+    [Fact]
+    public async Task ServerInfo_RendersTheLiveSnapshot()
+    {
+        var live = new FakeGuildLiveStateService
+        {
+            ServerInfo = new LiveServerInfo(
+                Id: GuildId,
+                Name: "Wojtusiowo",
+                CreatedAt: new DateTimeOffset(2017, 8, 9, 0, 0, 0, TimeSpan.Zero),
+                OwnerName: "Wikuś",
+                MemberCount: 123,
+                BoostTier: 2,
+                BoostCount: 7,
+                TextChannelCount: 20,
+                VoiceChannelCount: 5,
+                CategoryCount: 4,
+                RoleCount: 15,
+                EmojiCount: 60),
+        };
+        var toolset = BuildToolset(GuildContext(), live);
+
+        var result = await InvokeAsync(toolset, "server_info", []);
+
+        Assert.Contains("**Wojtusiowo** (id 100), created 2017-08-09", result);
+        Assert.Contains("Owner: Wikuś", result);
+        Assert.Contains("Members: 123", result);
+        Assert.Contains("Boosts: level 2, 7 boost(s)", result);
+        Assert.Contains("Channels: 20 text, 5 voice, 4 categories", result);
+        Assert.Contains("Roles: 15 | Emojis: 60", result);
+    }
+
+    // ─────────────────────────── MemberMatcher contract ───────────────────────────
+
+    private static readonly LiveMemberCandidate[] Members =
+    [
+        new(1UL, "anna_gaming", "Anna G", "Ania"),
+        new(2UL, "annabelle", null, "Bella"),
+        new(3UL, "marek", "Marek", "Marek"),
+        new(4UL, "ann", null, "Przemek"),
+    ];
+
+    [Fact]
+    public void Match_UniqueFragment_Finds()
+    {
+        var result = MemberMatcher.Match(Members, "marek");
+
+        Assert.Equal(MemberLookupOutcome.Found, result.Outcome);
+        Assert.Equal(3UL, result.Member);
+    }
+
+    [Fact]
+    public void Match_ExactNameBeatsSubstringHits()
+    {
+        // "ann" is a substring of three members but the exact username of one — the exact
+        // hit must win instead of reporting ambiguity.
+        var result = MemberMatcher.Match(Members, "ann");
+
+        Assert.Equal(MemberLookupOutcome.Found, result.Outcome);
+        Assert.Equal(4UL, result.Member);
+    }
+
+    [Fact]
+    public void Match_AmbiguousFragment_ReturnsCandidates()
+    {
+        var result = MemberMatcher.Match(Members, "anna");
+
+        Assert.Equal(MemberLookupOutcome.Ambiguous, result.Outcome);
+        Assert.Equal(new[] { 1UL, 2UL }, result.Candidates.Select(c => c.Id).Order().ToArray());
+    }
+
+    [Fact]
+    public void Match_IsCaseInsensitive()
+    {
+        var result = MemberMatcher.Match(Members, "MAREK");
+
+        Assert.Equal(MemberLookupOutcome.Found, result.Outcome);
+        Assert.Equal(3UL, result.Member);
+    }
+
+    [Fact]
+    public void Match_NoHit_IsNotFound()
+    {
+        var result = MemberMatcher.Match(Members, "zzz");
+
+        Assert.Equal(MemberLookupOutcome.NotFound, result.Outcome);
+        Assert.Empty(result.Candidates);
+    }
+
+    [Fact]
+    public void Match_CapsTheCandidateList()
+    {
+        var crowd = Enumerable.Range(1, 30)
+            .Select(i => new LiveMemberCandidate((ulong)i, $"user{i}", null, $"User {i}"))
+            .ToArray();
+
+        var result = MemberMatcher.Match(crowd, "user");
+
+        Assert.Equal(MemberLookupOutcome.Ambiguous, result.Outcome);
+        Assert.Equal(10, result.Candidates.Count);
+    }
+
+    // ─────────────────────────── helpers ───────────────────────────
+
+    private static ConversationToolset BuildToolset(
+        ConversationContext context, FakeGuildLiveStateService live, ulong? primaryGuildId = GuildId)
+    {
+        var options = Options.Create(new ConversationOptions { PrimaryGuildId = primaryGuildId });
+        var registry = new ConversationToolRegistry(
+            memeSearch: null!,
+            guildStats: null!,
+            databaseQuery: null!,
+            live,
+            new FakeGuildActionService(),
+            new FakeConfirmationService(),
+            new DatabaseSchemaHint("schema"),
+            options,
+            NullLogger<ConversationToolRegistry>.Instance);
+        return registry.BuildToolset(context);
+    }
+
+    private static ConversationContext GuildContext() =>
+        new(GuildId, InvokerId: 42UL, "tester", IsAdmin: false, ChannelId);
+
+    private static ConversationContext DmContext() =>
+        new(GuildId: null, InvokerId: 42UL, "tester", IsAdmin: false, ChannelId);
+
+    private static async Task<string> InvokeAsync(
+        ConversationToolset toolset, string tool, Dictionary<string, object?> arguments)
+    {
+        var result = await toolset.InvokeAsync(
+            new FunctionCallContent("call_1", tool, arguments), CancellationToken.None);
+        return result.Result?.ToString() ?? string.Empty;
+    }
+}
+
+// Canned live-state answers; also used by the other conversation test suites wherever the
+// registry needs its full dependency set but the live tools are never invoked.
+internal sealed class FakeGuildLiveStateService : IGuildLiveStateService
+{
+    public IReadOnlyList<LiveVoiceChannel>? VoiceChannels { get; set; } = [];
+    public MemberLookupResult? MemberLookup { get; set; } = MemberLookupResult.NotFound();
+    public LiveServerInfo? ServerInfo { get; set; }
+
+    public ulong? VoiceGuildId { get; private set; }
+    public string? MemberQuery { get; private set; }
+
+    public IReadOnlyList<LiveVoiceChannel>? GetVoiceOccupants(ulong guildId)
+    {
+        VoiceGuildId = guildId;
+        return VoiceChannels;
+    }
+
+    public Task<MemberLookupResult?> FindMemberAsync(ulong guildId, string query, CancellationToken cancellationToken)
+    {
+        MemberQuery = query;
+        return Task.FromResult(MemberLookup);
+    }
+
+    public LiveServerInfo? GetServerInfo(ulong guildId) => ServerInfo;
+}

--- a/tests/DiscordEventService.Tests/ConversationLoopTests.cs
+++ b/tests/DiscordEventService.Tests/ConversationLoopTests.cs
@@ -183,6 +183,7 @@ public sealed class ConversationLoopTests(PostgresFixture fixture)
             new MemeSearchService(NewContext()),
             new GuildStatsService(NewContext()),
             new DatabaseQueryService(NewContext(), conversationOptions, NullLogger<DatabaseQueryService>.Instance),
+            new FakeGuildLiveStateService(),
             new FakeGuildActionService(),
             new FakeConfirmationService(),
             new DatabaseSchemaHint("schema hint"),

--- a/tests/DiscordEventService.Tests/ConversationMemoryTests.cs
+++ b/tests/DiscordEventService.Tests/ConversationMemoryTests.cs
@@ -319,6 +319,7 @@ public sealed class ConversationMemoryTests(PostgresFixture fixture)
         new(new MemeSearchService(NewContext()),
             new GuildStatsService(NewContext()),
             new DatabaseQueryService(NewContext(), conversationOptions, NullLogger<DatabaseQueryService>.Instance),
+            new FakeGuildLiveStateService(),
             new FakeGuildActionService(),
             new FakeConfirmationService(),
             new DatabaseSchemaHint("schema hint"),

--- a/tests/DiscordEventService.Tests/ConversationRetryTests.cs
+++ b/tests/DiscordEventService.Tests/ConversationRetryTests.cs
@@ -240,6 +240,7 @@ public sealed class ConversationRetryTests(PostgresFixture fixture)
         new(new MemeSearchService(NewContext()),
             new GuildStatsService(NewContext()),
             new DatabaseQueryService(NewContext(), conversationOptions, NullLogger<DatabaseQueryService>.Instance),
+            new FakeGuildLiveStateService(),
             new FakeGuildActionService(),
             new FakeConfirmationService(),
             new DatabaseSchemaHint("schema hint"),


### PR DESCRIPTION
Closes #270 (epic #266 §4).

## What

Three **LIVE** read tools in `ConversationToolRegistry`, per the now-correctness principle (live tool only where the DB copy is derived/laggy):

- **`voice_occupants`** — zero-arg; every non-empty voice channel with occupants + their state (muted/deafened/streaming/camera) + jump links.
- **`member_info`** — one `member` param (id or name fragment). Full cached member snapshot: presence, activities, voice state, roles, join date, account created, boost status, timeout. Ambiguous fragment returns the candidate list; unknown id returns a clean not-found string.
- **`server_info`** — zero-arg; live member count, boost tier + count, created date, channel/role/emoji counts.

All three are open to everyone incl. DMs (guild via the `PrimaryGuildId` fallback); descriptions start with `LIVE` and steer the model away from `query_database` for right-now questions (plus a routing paragraph in the system prompt).

## How

- **`IGuildLiveStateService` / `GuildLiveStateService`** — new Discord-read seam, singleton in BOTH containers, client via `DiscordClientAccessor` only (the §6 boot-deadlock rule). Cache-first: the ONLY REST call is the member-by-id cache miss (`GetMemberAsync(id, updateCache: true)`), with `NotFoundException`/`BadRequestException` caught into a not-found result per the `GuildActionService` attempt-and-catch convention.
- **`MemberMatcher`** — pure name-fragment resolution: exact username/global/display hit wins outright, unique substring hit wins, several hits return ≤10 candidates, none is not-found.
- **`LiveStateFormatter`** — pure record→string rendering, so output shapes are unit-testable without faking DSharpPlus entities.

## Tests

15 new tests in `ConversationLiveStateToolTests`: tool-level guardrails (DM without primary guild, guild not in cache, blank query), the member-lookup decision tree, exact output shapes, and the `MemberMatcher` contract. Full suite: 254 passed. The projection off real DSharpPlus caches is live-verified on the dev bot (voice session driven via Discord MCP).

🤖 Generated with [Claude Code](https://claude.com/claude-code)