### PR TITLE
feat: #271 §5 openrouter:web_search server tool + citations

### DIFF
--- a/src/DiscordEventService/Configuration/ConversationOptions.cs
+++ b/src/DiscordEventService/Configuration/ConversationOptions.cs
@@ -98,6 +98,24 @@ internal sealed class ConversationOptions
     // §3 soft cost-cap alerting (#269) over the conversation_usage ledger — alert-only,
     // the loop never refuses a turn.
     public CostAlertOptions CostAlerts { get; set; } = new();
+
+    // §5 OpenRouter `openrouter:web_search` server tool (#271). Attached to every loop
+    // round when enabled — safe because a search bills only when the model invokes one
+    // ($0.005 Exa per search), never per attached request.
+    public WebSearchOptions WebSearch { get; set; } = new();
+}
+
+// Conversation:WebSearch:* (#271). Engine pinned to Exa for the predictable flat
+// per-search rate (unset would fall through to native provider passthrough pricing);
+// MaxResults bounds results per search, not searches per request — the model controls
+// how many searches it runs, and #269's soft caps cover the tail.
+internal sealed class WebSearchOptions
+{
+    public bool Enabled { get; set; } = true;
+
+    public string Engine { get; set; } = "exa";
+
+    public int MaxResults { get; set; } = 3;
 }
 
 // Conversation:CostAlerts:* (#269). Windows are calendar-UTC (month / date); sums

--- a/src/DiscordEventService/Services/Conversation/ConversationService.cs
+++ b/src/DiscordEventService/Services/Conversation/ConversationService.cs
@@ -47,9 +47,10 @@ internal sealed class ConversationService(
         var options = conversationOptions.Value;
         var toolset = toolRegistry.BuildToolset(context);
 
-        // Reuse the §1 helper for the provider pin + reasoning/usage patch, then hang the
-        // turn's tools off it; the OpenAI adapter merges Tools onto the patched body.
-        var chatOptions = OpenRouterChatOptions.Create(options.ReasoningEffort);
+        // Reuse the §1 helper for the provider pin + reasoning/usage/web-search patch,
+        // then hang the turn's tools off it; the OpenAI adapter merges Tools onto the
+        // patched body (the appended server tool lands after them).
+        var chatOptions = OpenRouterChatOptions.Create(options.ReasoningEffort, options.WebSearch);
         chatOptions.Tools = toolset.Tools;
 
         // Durable memory (#267): rehydrate the conversation's stored window, then persist
@@ -72,6 +73,11 @@ internal sealed class ConversationService(
         turn?.SetTag("conversation.guild_id", context.GuildId);
 
         var turnCostUsd = 0d;
+
+        // The turn's web-search citations (#271), accumulated across every successful
+        // round (a mixed tool round may also search) and rendered once under the answer.
+        // Failed attempts drop out naturally — the sink is cleared per attempt.
+        var citations = new List<WebSearchCitations.Citation>();
 
         // Streams one round into the transcript sink under the §2 retry policy (#268):
         // up to RetryMaxAttempts calls over the same intact `messages` prefix (a failed
@@ -197,9 +203,11 @@ internal sealed class ConversationService(
             var response = sink.ToChatResponse();
             messages.AddRange(response.Messages);
             turnCostUsd += RecordRoundCost(sink, round, turn, outcome);
+            WebSearchCitations.AccumulateRound(sink, citations);
 
             var roundUsage = ExtractRoundUsage(
                 sink, round, outcome.Attempt, options.Model, outcome.LatencyMs, failed: false);
+            RecordWebSearches(roundUsage, round, turn);
             await memory.PersistAssistantMessagesAsync(memoryTurn, response.Messages,
                 roundUsage.PromptTokens, roundUsage.CompletionTokens, cancellationToken);
             await memory.RecordUsageAsync(memoryTurn, context.InvokerId, roundUsage, cancellationToken);
@@ -213,6 +221,8 @@ internal sealed class ConversationService(
             {
                 if (!HadText(sink))
                     yield return new ConversationUpdate.AssistantTextDelta(EmptyAnswerFallback);
+                if (WebSearchCitations.FormatSourceList(citations) is { } sources)
+                    yield return new ConversationUpdate.AssistantTextDelta($"\n{sources}");
                 logger.LogDebug("Conversation answered in {Rounds} round(s) for {Author}",
                     round, context.InvokerDisplayName);
                 turn?.SetTag("conversation.rounds", round);
@@ -243,7 +253,8 @@ internal sealed class ConversationService(
         var finalSink = new List<ChatResponseUpdate>();
         var finalOutcome = new RoundOutcome();
         await foreach (var renderEvent in StreamRoundAsync(
-            OpenRouterChatOptions.Create(options.ReasoningEffort), options.MaxToolRounds + 1, finalSink, finalOutcome))
+            OpenRouterChatOptions.Create(options.ReasoningEffort, options.WebSearch),
+            options.MaxToolRounds + 1, finalSink, finalOutcome))
             yield return renderEvent;
 
         if (!finalOutcome.Succeeded)
@@ -255,17 +266,21 @@ internal sealed class ConversationService(
         }
 
         turnCostUsd += RecordRoundCost(finalSink, options.MaxToolRounds + 1, turn, finalOutcome);
+        WebSearchCitations.AccumulateRound(finalSink, citations);
 
         var finalResponse = finalSink.ToChatResponse();
         var finalUsage = ExtractRoundUsage(
             finalSink, options.MaxToolRounds + 1, finalOutcome.Attempt, options.Model,
             finalOutcome.LatencyMs, failed: false);
+        RecordWebSearches(finalUsage, options.MaxToolRounds + 1, turn);
         await memory.PersistAssistantMessagesAsync(memoryTurn, finalResponse.Messages,
             finalUsage.PromptTokens, finalUsage.CompletionTokens, cancellationToken);
         await memory.RecordUsageAsync(memoryTurn, context.InvokerId, finalUsage, cancellationToken);
 
         if (!HadText(finalSink))
             yield return new ConversationUpdate.AssistantTextDelta(CapReachedFallback);
+        if (WebSearchCitations.FormatSourceList(citations) is { } finalSources)
+            yield return new ConversationUpdate.AssistantTextDelta($"\n{finalSources}");
         turn?.SetTag("conversation.cost_usd", turnCostUsd);
     }
 
@@ -300,6 +315,19 @@ internal sealed class ConversationService(
         turn?.SetTag($"conversation.round{round}.cost_usd", outcome.CostUsd);
         logger.LogDebug("Round {Round} model cost ${Cost}", round, cost.Value);
         return cost.Value;
+    }
+
+    // Search spend itemisation (#271): the ledger row already carries the counts; the
+    // trace tag + log line make a searchy round visible without a DB query.
+    // `cost − upstream_inference_cost` is the round's search spend.
+    private void RecordWebSearches(ConversationRoundUsage usage, int round, Activity? turn)
+    {
+        if (usage.WebSearchRequests is not > 0)
+            return;
+
+        turn?.SetTag($"conversation.round{round}.web_search_requests", usage.WebSearchRequests);
+        logger.LogDebug("Round {Round} ran {Searches} web search(es), upstream model cost ${Upstream}",
+            round, usage.WebSearchRequests, usage.UpstreamInferenceCostUsd);
     }
 
     private static double? ExtractCostUsd(IEnumerable<ChatResponseUpdate> updates)
@@ -347,7 +375,9 @@ internal sealed class ConversationService(
 #pragma warning disable SCME0001 // ChatTokenUsage.Patch (JsonPatch) is experimental.
             if (raw.Patch.TryGetValue("$.cost_details.upstream_inference_cost"u8, out double upstream))
                 upstreamCostUsd = upstream;
-            if (raw.Patch.TryGetValue("$.server_tool_use.web_search_requests"u8, out int searches))
+            // `server_tool_use_details` is the field the #261 live spike observed on this
+            // exact stack (not Anthropic's native `server_tool_use` name).
+            if (raw.Patch.TryGetValue("$.server_tool_use_details.web_search_requests"u8, out int searches))
                 webSearchRequests = searches;
 #pragma warning restore SCME0001
         }
@@ -373,6 +403,11 @@ internal sealed class ConversationService(
               "who posts the most" ranking, call top_posters. For other analytical or statistical
               questions (counts, activity over time, who-did-what) that the curated tools can't
               answer, call query_database with a single read-only SQL SELECT and summarize the rows.
+
+              For questions about the world OUTSIDE this server — news, current events, facts
+              that may have changed recently — you can search the web (it runs automatically
+              when you use your web search tool); prefer searching over guessing when freshness
+              matters, and cite your sources.
 
               For RIGHT-NOW questions use the LIVE tools instead of the database — the database is
               an ingested copy and can lag. voice_occupants tells you who is sitting in which voice

--- a/src/DiscordEventService/Services/Conversation/OpenRouterChatOptions.cs
+++ b/src/DiscordEventService/Services/Conversation/OpenRouterChatOptions.cs
@@ -1,21 +1,24 @@
+using DiscordEventService.Configuration;
 using Microsoft.Extensions.AI;
 using OpenAI.Chat;
 
 namespace DiscordEventService.Services.Conversation;
 
 // Builds the per-request ChatOptions for the OpenRouter chat model, injecting the
-// Claude/OpenRouter body fields (`provider`, `reasoning`, `usage`) through a JsonPatch on
-// a fresh ChatCompletionOptions. ChatOptions.AdditionalProperties is NOT the mechanism —
-// the OpenAI adapter silently drops that dictionary (except the reserved `strict` key).
-// Reused unchanged by every round of the agentic loop (§2+).
+// Claude/OpenRouter body fields (`provider`, `reasoning`, `usage`, the web-search
+// server tool) through a JsonPatch on a fresh ChatCompletionOptions.
+// ChatOptions.AdditionalProperties is NOT the mechanism — the OpenAI adapter silently
+// drops that dictionary (except the reserved `strict` key). Reused unchanged by every
+// round of the agentic loop (§2+).
 internal static class OpenRouterChatOptions
 {
-    public static ChatOptions Create(string reasoningEffort) => new()
+    public static ChatOptions Create(string reasoningEffort, WebSearchOptions webSearch) => new()
     {
-        RawRepresentationFactory = _ => BuildRawRepresentation(reasoningEffort),
+        RawRepresentationFactory = _ => BuildRawRepresentation(reasoningEffort, webSearch),
     };
 
-    private static ChatCompletionOptions BuildRawRepresentation(string reasoningEffort)
+    private static ChatCompletionOptions BuildRawRepresentation(
+        string reasoningEffort, WebSearchOptions webSearch)
     {
 #pragma warning disable SCME0001 // ChatCompletionOptions.Patch (JsonPatch) is experimental.
         var options = new ChatCompletionOptions();
@@ -32,6 +35,19 @@ internal static class OpenRouterChatOptions
         // chunk — it is not in MEAI's typed UsageDetails and is recovered from the raw
         // ChatTokenUsage patch (#241). Captured per round for the §5 usage ledger.
         options.Patch.Set("$.usage"u8, BinaryData.FromObjectAsJson(new { include = true }));
+
+        // The `openrouter:web_search` server tool (#271): executed entirely server-side —
+        // no tool call ever surfaces to the loop, the model decides when to search. It is
+        // not a `function` tool, so it cannot ride ChatOptions.Tools; `Append` merges it
+        // AFTER the adapter-serialized app tools (`Set` would clobber them).
+        if (webSearch.Enabled)
+        {
+            options.Patch.Append("$.tools"u8, BinaryData.FromObjectAsJson(new
+            {
+                type = "openrouter:web_search",
+                parameters = new { engine = webSearch.Engine, max_results = webSearch.MaxResults },
+            }));
+        }
 
         return options;
 #pragma warning restore SCME0001

--- a/src/DiscordEventService/Services/Conversation/WebSearchCitations.cs
+++ b/src/DiscordEventService/Services/Conversation/WebSearchCitations.cs
@@ -1,0 +1,92 @@
+using System.ClientModel.Primitives;
+using System.Text;
+using System.Text.Json;
+using Microsoft.Extensions.AI;
+using OpenAI.Chat;
+
+namespace DiscordEventService.Services.Conversation;
+
+// Recovers `url_citation` annotations from a round's raw streamed chunks and renders the
+// turn's compact source list (#271). OpenRouter spreads the annotations across mid-stream
+// delta chunks (one per citation as the model writes, `start_index`/`end_index` always 0)
+// at `choices[0].delta.annotations`. The OpenAI SDK has no typed annotation surface on
+// streamed deltas, and the chunk root's JsonPatch can't reach them either (they are
+// retained inside the NESTED delta model's patch — the root patch stays empty), so the
+// recovery round-trips each chunk through ModelReaderWriter and reads the JSON.
+internal static class WebSearchCitations
+{
+    internal sealed record Citation(string Url, string Title);
+
+    // Collects the round's citations into `citations`, deduplicating by URL across the
+    // whole turn (a later round may re-search what an earlier round already cited).
+    public static void AccumulateRound(IEnumerable<ChatResponseUpdate> updates, List<Citation> citations)
+    {
+        foreach (var update in updates)
+        {
+            if (update.RawRepresentation is not StreamingChatCompletionUpdate raw)
+                continue;
+
+            using var chunk = JsonDocument.Parse(ModelReaderWriter.Write(raw));
+            if (!chunk.RootElement.TryGetProperty("choices", out var choices)
+                || choices.ValueKind is not JsonValueKind.Array)
+                continue;
+
+            foreach (var choice in choices.EnumerateArray())
+            {
+                if (!choice.TryGetProperty("delta", out var delta)
+                    || !delta.TryGetProperty("annotations", out var annotations)
+                    || annotations.ValueKind is not JsonValueKind.Array)
+                    continue;
+
+                foreach (var annotation in annotations.EnumerateArray())
+                {
+                    if (!annotation.TryGetProperty("url_citation", out var citation)
+                        || !citation.TryGetProperty("url", out var url)
+                        || url.GetString() is not { Length: > 0 } urlValue)
+                        continue;
+
+                    if (!citations.Any(existing => existing.Url.Equals(urlValue, StringComparison.Ordinal)))
+                    {
+                        citations.Add(new Citation(urlValue,
+                            citation.TryGetProperty("title", out var title) ? title.GetString() ?? "" : ""));
+                    }
+                }
+            }
+        }
+    }
+
+    // One subtext line of domain-named markdown links (the model already inlines
+    // domain-named links in its own text; this is the structured source list under the
+    // reply). Repeated domains get an ordinal so two articles stay distinguishable.
+    public static string? FormatSourceList(IReadOnlyList<Citation> citations)
+    {
+        if (citations.Count == 0)
+            return null;
+
+        var line = new StringBuilder("-# 🔗 ");
+        var domainCounts = new Dictionary<string, int>(StringComparer.OrdinalIgnoreCase);
+        for (var i = 0; i < citations.Count; i++)
+        {
+            var domain = DomainOf(citations[i].Url);
+            var count = domainCounts[domain] = domainCounts.GetValueOrDefault(domain) + 1;
+            if (i > 0)
+                line.Append(" · ");
+            line.Append('[').Append(domain);
+            if (count > 1)
+                line.Append(" (").Append(count).Append(')');
+            line.Append("](").Append(citations[i].Url).Append(')');
+        }
+
+        return line.ToString();
+    }
+
+    private static string DomainOf(string url)
+    {
+        if (!Uri.TryCreate(url, UriKind.Absolute, out var uri) || uri.Host.Length == 0)
+            return url;
+
+        return uri.Host.StartsWith("www.", StringComparison.OrdinalIgnoreCase)
+            ? uri.Host[4..]
+            : uri.Host;
+    }
+}

--- a/src/DiscordEventService/Services/Conversation/WebSearchCitations.cs
+++ b/src/DiscordEventService/Services/Conversation/WebSearchCitations.cs
@@ -15,7 +15,7 @@ namespace DiscordEventService.Services.Conversation;
 // recovery round-trips each chunk through ModelReaderWriter and reads the JSON.
 internal static class WebSearchCitations
 {
-    internal sealed record Citation(string Url, string Title);
+    internal sealed record Citation(string Url);
 
     // Collects the round's citations into `citations`, deduplicating by URL across the
     // whole turn (a later round may re-search what an earlier round already cited).
@@ -46,10 +46,7 @@ internal static class WebSearchCitations
                         continue;
 
                     if (!citations.Any(existing => existing.Url.Equals(urlValue, StringComparison.Ordinal)))
-                    {
-                        citations.Add(new Citation(urlValue,
-                            citation.TryGetProperty("title", out var title) ? title.GetString() ?? "" : ""));
-                    }
+                        citations.Add(new Citation(urlValue));
                 }
             }
         }

--- a/tests/DiscordEventService.Tests/ConversationWebSearchTests.cs
+++ b/tests/DiscordEventService.Tests/ConversationWebSearchTests.cs
@@ -1,0 +1,269 @@
+using System.ClientModel;
+using System.Globalization;
+using System.ClientModel.Primitives;
+using System.Net;
+using System.Text;
+using System.Text.Json;
+using DiscordEventService.Configuration;
+using DiscordEventService.Data;
+using DiscordEventService.Services.Conversation;
+using DiscordEventService.Services.MemeIndexing;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.AI;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using OpenAI;
+using Xunit;
+
+namespace DiscordEventService.Tests;
+
+// The §5 web-search server tool end-to-end (#271): a recording transport UNDER the real
+// OpenAI SDK + MEAI adapter proves the wire body (the `openrouter:web_search` entry must
+// merge AFTER the adapter-serialized app tools — `Set` would clobber them, and a
+// disabled config must leave the body clean), and scripted SSE streams prove citation
+// recovery — annotations arrive spread across mid-stream delta chunks at
+// `$.choices[0].delta.annotations` — plus the ledger itemisation of search spend.
+public sealed class ConversationWebSearchTests(PostgresFixture fixture)
+    : IClassFixture<PostgresFixture>, IAsyncLifetime
+{
+    private const ulong GuildDiscordId = 51UL;
+    private const ulong ThreadChannelId = 53UL;
+    private const ulong InvokerId = 54UL;
+
+    private DiscordDbContext _db = null!;
+
+    public async Task InitializeAsync()
+    {
+        _db = NewContext();
+        await _db.Database.MigrateAsync();
+
+        await _db.ConversationMessages.ExecuteDeleteAsync();
+        await _db.ConversationUsage.ExecuteDeleteAsync();
+        await _db.Conversations.ExecuteDeleteAsync();
+    }
+
+    public Task DisposeAsync() => _db.DisposeAsync().AsTask();
+
+    [Fact]
+    public async Task RequestBody_WebSearchEnabled_ServerToolAppendedAfterAppTools()
+    {
+        var transport = new RecordingTransport(_ => SseResponse(SseText("Cześć.")));
+
+        await CollectAsync(BuildService(transport, webSearchEnabled: true)
+            .GenerateReplyAsync("pytanie", Context(), CancellationToken.None));
+
+        var tools = Assert.Single(transport.RequestBodies).GetProperty("tools");
+        var entries = tools.EnumerateArray().ToList();
+        // The app's function tools survive the patch, and the appended server tool
+        // lands after them.
+        Assert.Contains(entries, tool => tool.GetProperty("type").GetString() == "function");
+        var serverTool = Assert.Single(entries,
+            tool => tool.GetProperty("type").GetString() == "openrouter:web_search");
+        Assert.Equal("exa", serverTool.GetProperty("parameters").GetProperty("engine").GetString());
+        Assert.Equal(3, serverTool.GetProperty("parameters").GetProperty("max_results").GetInt32());
+        Assert.Equal("openrouter:web_search", entries[^1].GetProperty("type").GetString());
+    }
+
+    [Fact]
+    public async Task RequestBody_WebSearchDisabled_NoServerToolOnTheWire()
+    {
+        var transport = new RecordingTransport(_ => SseResponse(SseText("Cześć.")));
+
+        await CollectAsync(BuildService(transport, webSearchEnabled: false)
+            .GenerateReplyAsync("pytanie", Context(), CancellationToken.None));
+
+        var tools = Assert.Single(transport.RequestBodies).GetProperty("tools");
+        Assert.Contains(tools.EnumerateArray(),
+            tool => tool.GetProperty("type").GetString() == "function");
+        Assert.DoesNotContain(tools.EnumerateArray(),
+            tool => tool.GetProperty("type").GetString() == "openrouter:web_search");
+    }
+
+    [Fact]
+    public async Task AnnotatedMixedTurn_AccumulatesCitationsAcrossRounds_RendersSourceListOnce()
+    {
+        // Round 0 is the mixed shape the #261 spike observed: narration text, a citation,
+        // AND an app tool call in one round. Round 1 answers with a second citation plus
+        // a duplicate of the first URL (a later round may re-search) — the source list
+        // must dedupe it.
+        var transport = new RecordingTransport(call => call switch
+        {
+            0 => SseResponse(
+                AnnotatedTextChunk("Sprawdzam w sieci. ",
+                    Annotation("https://example.com/article", "Article"))
+                + ToolCallChunk("call_1", "meme_search", """{"query":"zolw","limit":5}""")
+                + FinishChunk("tool_calls", UsageJson(cost: 0.02, upstreamCost: 0.012, webSearches: 1))
+                + "data: [DONE]\n\n"),
+            _ => SseResponse(
+                AnnotatedTextChunk("Oto co znalazłem.",
+                    Annotation("https://news.example.org/story", "Story"),
+                    Annotation("https://example.com/article", "Article"))
+                + FinishChunk("stop", UsageJson(cost: 0.015, upstreamCost: 0.01, webSearches: 1))
+                + "data: [DONE]\n\n"),
+        });
+
+        var events = await CollectAsync(BuildService(transport, webSearchEnabled: true)
+            .GenerateReplyAsync("co się dzieje w świecie?", Context(), CancellationToken.None));
+
+        var answer = FinalAnswer(events);
+        Assert.StartsWith("Oto co znalazłem.", answer);
+        Assert.EndsWith("-# 🔗 [example.com](https://example.com/article) · " +
+            "[news.example.org](https://news.example.org/story)", answer);
+
+        // Search spend itemised per round in the ledger: upstream model cost and the
+        // search counter recovered from `cost_details` / `server_tool_use_details`.
+        var rows = await _db.ConversationUsage.OrderBy(u => u.Round).ToListAsync();
+        Assert.Equal(2, rows.Count);
+        Assert.Equal(0.012, rows[0].UpstreamInferenceCostUsd!.Value, precision: 6);
+        Assert.Equal(1, rows[0].WebSearchRequests);
+        Assert.Equal(0.01, rows[1].UpstreamInferenceCostUsd!.Value, precision: 6);
+        Assert.Equal(1, rows[1].WebSearchRequests);
+    }
+
+    [Fact]
+    public async Task NoAnnotations_NoSourceLineAndNoCrash()
+    {
+        var transport = new RecordingTransport(_ => SseResponse(SseText("Zwykła odpowiedź.")));
+
+        var events = await CollectAsync(BuildService(transport, webSearchEnabled: true)
+            .GenerateReplyAsync("pytanie", Context(), CancellationToken.None));
+
+        Assert.Equal("Zwykła odpowiedź.", FinalAnswer(events));
+        Assert.DoesNotContain("🔗", FinalAnswer(events));
+    }
+
+    private static ConversationContext Context() =>
+        new(GuildDiscordId, InvokerId, "tester", IsAdmin: false, ChannelId: ThreadChannelId);
+
+    // What the discrete renderer (#274) posts after the last tool round: buffered deltas,
+    // dropped on RoundReset, reset at each tool-batch boundary.
+    private static string FinalAnswer(IReadOnlyList<ConversationUpdate> events)
+    {
+        var text = new StringBuilder();
+        foreach (var update in events)
+        {
+            switch (update)
+            {
+                case ConversationUpdate.AssistantTextDelta delta:
+                    text.Append(delta.Text);
+                    break;
+                case ConversationUpdate.ToolBatchSummary or ConversationUpdate.RoundReset:
+                    text.Clear();
+                    break;
+            }
+        }
+        return text.ToString();
+    }
+
+    private ConversationService BuildService(RecordingTransport transport, bool webSearchEnabled)
+    {
+        var conversationOptions = Options.Create(new ConversationOptions
+        {
+            ReasoningEffort = "low",
+            PrimaryGuildId = GuildDiscordId,
+            WebSearch = new WebSearchOptions { Enabled = webSearchEnabled },
+        });
+
+        var chatClient = new OpenAIClient(
+                new ApiKeyCredential("test-key"),
+                new OpenAIClientOptions
+                {
+                    Endpoint = new Uri("http://localhost/api/v1"),
+                    Transport = new HttpClientPipelineTransport(new HttpClient(transport)),
+                    RetryPolicy = new ClientRetryPolicy(maxRetries: 0),
+                })
+            .GetChatClient(conversationOptions.Value.Model)
+            .AsIChatClient();
+
+        var registry = new ConversationToolRegistry(
+            new MemeSearchService(NewContext()),
+            new GuildStatsService(NewContext()),
+            new DatabaseQueryService(NewContext(), conversationOptions, NullLogger<DatabaseQueryService>.Instance),
+            new FakeGuildLiveStateService(),
+            new FakeGuildActionService(),
+            new FakeConfirmationService(),
+            new DatabaseSchemaHint("schema hint"),
+            conversationOptions,
+            NullLogger<ConversationToolRegistry>.Instance);
+
+        return new ConversationService(
+            chatClient,
+            registry,
+            new ConversationMemoryService(NewContext(), conversationOptions, NullLogger<ConversationMemoryService>.Instance),
+            conversationOptions,
+            Options.Create(new OpenRouterOptions { ApiKey = "test-key" }),
+            NullLogger<ConversationService>.Instance);
+    }
+
+    private static async Task<List<ConversationUpdate>> CollectAsync(IAsyncEnumerable<ConversationUpdate> stream)
+    {
+        List<ConversationUpdate> events = [];
+        await foreach (var update in stream)
+            events.Add(update);
+        return events;
+    }
+
+    private static string SseChunk(string choicesJson, string? extraJson = null) =>
+        "data: {\"id\":\"chatcmpl-t\",\"object\":\"chat.completion.chunk\",\"created\":1750000000," +
+        $"\"model\":\"anthropic/claude-sonnet-5\",\"choices\":{choicesJson}{(extraJson is null ? "" : "," + extraJson)}}}\n\n";
+
+    private static string SseText(string text) =>
+        SseChunk($"[{{\"index\":0,\"delta\":{{\"role\":\"assistant\",\"content\":{JsonSerializer.Serialize(text)}}},\"finish_reason\":null}}]")
+        + FinishChunk("stop", UsageJson(cost: 0.01, upstreamCost: null, webSearches: null))
+        + "data: [DONE]\n\n";
+
+    // The annotation shape OpenRouter streams: one `url_citation` per mid-stream delta
+    // chunk, offsets always 0.
+    private static string Annotation(string url, string title) =>
+        $$$"""{"type":"url_citation","url_citation":{"url":"{{{url}}}","title":"{{{title}}}","content":"excerpt","start_index":0,"end_index":0}}""";
+
+    private static string AnnotatedTextChunk(string text, params string[] annotations) =>
+        SseChunk($"[{{\"index\":0,\"delta\":{{\"role\":\"assistant\",\"content\":{JsonSerializer.Serialize(text)}," +
+            $"\"annotations\":[{string.Join(",", annotations)}]}},\"finish_reason\":null}}]");
+
+    private static string ToolCallChunk(string callId, string name, string argumentsJson) =>
+        SseChunk($"[{{\"index\":0,\"delta\":{{\"tool_calls\":[{{\"index\":0,\"id\":\"{callId}\",\"type\":\"function\"," +
+            $"\"function\":{{\"name\":\"{name}\",\"arguments\":{JsonSerializer.Serialize(argumentsJson)}}}}}]}},\"finish_reason\":null}}]");
+
+    private static string FinishChunk(string finishReason, string usageJson) =>
+        SseChunk($"[{{\"index\":0,\"delta\":{{}},\"finish_reason\":\"{finishReason}\"}}]", usageJson);
+
+    private static string UsageJson(double cost, double? upstreamCost, int? webSearches)
+    {
+        var extras = new StringBuilder();
+        if (upstreamCost is not null)
+            extras.Append($",\"cost_details\":{{\"upstream_inference_cost\":{upstreamCost.Value.ToString(CultureInfo.InvariantCulture)}}}");
+        if (webSearches is not null)
+            extras.Append($",\"server_tool_use_details\":{{\"web_search_requests\":{webSearches},\"tool_calls_requested\":{webSearches},\"tool_calls_executed\":{webSearches}}}");
+        return "\"usage\":{\"prompt_tokens\":100,\"completion_tokens\":20,\"total_tokens\":120," +
+            $"\"cost\":{cost.ToString(CultureInfo.InvariantCulture)}{extras}}}";
+    }
+
+    private static HttpResponseMessage SseResponse(string sse) =>
+        new(HttpStatusCode.OK) { Content = new StringContent(sse, Encoding.UTF8, "text/event-stream") };
+
+    // Records every request body (for wire assertions) and returns scripted SSE responses.
+    private sealed class RecordingTransport(Func<int, HttpResponseMessage> responder) : HttpMessageHandler
+    {
+        private int _callCount;
+
+        public List<JsonElement> RequestBodies { get; } = [];
+
+        protected override async Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            var body = await request.Content!.ReadAsStringAsync(cancellationToken);
+            RequestBodies.Add(JsonDocument.Parse(body).RootElement.Clone());
+            return responder(_callCount++);
+        }
+    }
+
+    private DiscordDbContext NewContext()
+    {
+        var options = new DbContextOptionsBuilder<DiscordDbContext>()
+            .UseNpgsql(fixture.Container.GetConnectionString())
+            .UseSnakeCaseNamingConvention()
+            .Options;
+        return new DiscordDbContext(options);
+    }
+}

--- a/tests/DiscordEventService.Tests/OpenRouterChatOptionsTests.cs
+++ b/tests/DiscordEventService.Tests/OpenRouterChatOptionsTests.cs
@@ -1,5 +1,6 @@
 using System.ClientModel.Primitives;
 using System.Text.Json;
+using DiscordEventService.Configuration;
 using DiscordEventService.Services.Conversation;
 using OpenAI.Chat;
 using Xunit;
@@ -11,9 +12,10 @@ namespace DiscordEventService.Tests;
 // silently dropped if routed through ChatOptions.AdditionalProperties instead.
 public sealed class OpenRouterChatOptionsTests
 {
-    private static JsonElement SerializeRequestBody(string reasoningEffort)
+    private static JsonElement SerializeRequestBody(
+        string reasoningEffort, WebSearchOptions? webSearch = null)
     {
-        var chatOptions = OpenRouterChatOptions.Create(reasoningEffort);
+        var chatOptions = OpenRouterChatOptions.Create(reasoningEffort, webSearch ?? new WebSearchOptions());
         Assert.NotNull(chatOptions.RawRepresentationFactory);
 
         var raw = chatOptions.RawRepresentationFactory!(null!);
@@ -41,5 +43,27 @@ public sealed class OpenRouterChatOptionsTests
         var reasoning = SerializeRequestBody(effort).GetProperty("reasoning");
 
         Assert.Equal(effort, reasoning.GetProperty("effort").GetString());
+    }
+
+    // The server tool must land even when ChatOptions.Tools is empty (the round-cap
+    // fallback withholds app tools) — Append has to create the array, not require one.
+    [Fact]
+    public void Create_WebSearchEnabled_AppendsServerToolWithConfiguredParameters()
+    {
+        var body = SerializeRequestBody("medium",
+            new WebSearchOptions { Enabled = true, Engine = "exa", MaxResults = 3 });
+
+        var tool = Assert.Single(body.GetProperty("tools").EnumerateArray());
+        Assert.Equal("openrouter:web_search", tool.GetProperty("type").GetString());
+        Assert.Equal("exa", tool.GetProperty("parameters").GetProperty("engine").GetString());
+        Assert.Equal(3, tool.GetProperty("parameters").GetProperty("max_results").GetInt32());
+    }
+
+    [Fact]
+    public void Create_WebSearchDisabled_BodyCarriesNoServerTool()
+    {
+        var body = SerializeRequestBody("medium", new WebSearchOptions { Enabled = false });
+
+        Assert.False(body.TryGetProperty("tools", out _));
     }
 }


### PR DESCRIPTION
Closes #271. Last child of epic #266. Spec: `docs/research/web-search-over-openrouter.md` #261 addendum.

## What

- **Server tool attached every round**, config-gated (`Conversation:WebSearch:*` — `Enabled` default true, `Engine` exa, `MaxResults` 3): `Patch.Append("$.tools")` in `OpenRouterChatOptions.BuildRawRepresentation` — Append merges after the adapter-serialized app tools; a search bills only when the model invokes one, so every-round attachment is safe. Also attached on the round-cap fallback (Append creates the array when app tools are withheld — unit-proven).
- **Citations**: `url_citation` annotations arrive spread across mid-stream delta chunks. The chunk root's JsonPatch canNOT reach them (they're retained in the nested delta model's patch — the root patch is empty; probed against the pinned SDK), so `WebSearchCitations` round-trips each raw chunk through `ModelReaderWriter` and reads `choices[*].delta.annotations`. Deduped by URL across rounds, rendered as one `-# 🔗` subtext line of domain-named links under the final answer; no line when a turn has none.
- **Ledger fix**: the counter path was `$.server_tool_use.web_search_requests`; the #261 live spike observed `server_tool_use_details` on this exact stack — switched. `cost_details.upstream_inference_cost` path was already right. Per-round trace tag + debug log for search counts (`cost − upstream = search spend`).
- One system-prompt sentence routing outside-world/current-events questions to web search.

## Tests

- `OpenRouterChatOptionsTests`: server tool present with configured params when enabled (including empty-Tools case), absent when disabled.
- `ConversationWebSearchTests` (new, recording transport under the real OpenAI SDK + MEAI adapter): wire body carries function tools + appended server tool (order proven) / clean body when disabled; mixed round (narration + citation + app tool call) accumulates citations across rounds, dedupes, renders the source list once; ledger rows itemise upstream cost + search counts; no-annotation turn renders no source line.
- Full suite: 264 passed, 1 skipped (live-API test).

Live dev-bot verification (cited answer + mixed round + Langfuse trace + `Enabled=false` wire check) to follow on this PR before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)