### PR TITLE
fix: #257 Langfuse trace nesting + full identity mapping

### DIFF
--- a/src/DiscordEventService/Program.cs
+++ b/src/DiscordEventService/Program.cs
@@ -156,7 +156,7 @@ builder.Services.AddScoped<MemeIndexSweepJob>();
 // Langfuse OTel export. Registers the singleton chat client in the root container; the
 // DSharpPlus child container forwards to it (ConversationRegistration). ConversationService
 // is a shared scoped service (CoreServiceTypes); the handler lives in DiscordClientRegistration.
-builder.Services.AddConversationFeature(builder.Configuration);
+builder.Services.AddConversationFeature(builder.Configuration, builder.Environment);
 
 // Hangfire. With a fixed InvisibilityTimeout a job outliving it gets presumed
 // dead, re-queued, and the original execution cancelled — observed live on the

--- a/src/DiscordEventService/Services/Conversation/ConversationRegistration.cs
+++ b/src/DiscordEventService/Services/Conversation/ConversationRegistration.cs
@@ -8,6 +8,7 @@ using Microsoft.Extensions.Options;
 using OpenAI;
 using OpenTelemetry;
 using OpenTelemetry.Exporter;
+using OpenTelemetry.Resources;
 using OpenTelemetry.Trace;
 
 namespace DiscordEventService.Services.Conversation;
@@ -20,7 +21,7 @@ internal static class ConversationRegistration
 {
     // Root container: bind options, build the singleton IChatClient, wire Langfuse.
     public static IServiceCollection AddConversationFeature(
-        this IServiceCollection services, IConfiguration configuration)
+        this IServiceCollection services, IConfiguration configuration, IHostEnvironment environment)
     {
         services.AddOptions<ConversationOptions>()
             .Bind(configuration.GetSection(ConversationOptions.SectionName));
@@ -48,7 +49,7 @@ internal static class ConversationRegistration
         // no-DiscordClient-in-DI rule as the action services.
         services.AddSingleton<IUsageAlertNotifier, DiscordUsageAlertNotifier>();
 
-        AddLangfuseTracing(services, configuration);
+        AddLangfuseTracing(services, configuration, environment);
         return services;
     }
 
@@ -127,7 +128,8 @@ internal static class ConversationRegistration
             .Build();
     }
 
-    private static void AddLangfuseTracing(IServiceCollection services, IConfiguration configuration)
+    private static void AddLangfuseTracing(
+        IServiceCollection services, IConfiguration configuration, IHostEnvironment environment)
     {
         var options = configuration.GetSection(ConversationOptions.SectionName).Get<ConversationOptions>()
             ?? new ConversationOptions();
@@ -139,7 +141,15 @@ internal static class ConversationRegistration
             Encoding.UTF8.GetBytes($"{options.LangfusePublicKey}:{options.LangfuseSecretKey}"));
 
         // HttpProtobuf, not gRPC — Langfuse's OTLP endpoint silently no-ops on gRPC.
+        // langfuse.environment separates dev and prod traces inside the one shared
+        // Langfuse project (both export with the same keys).
         services.AddOpenTelemetry().WithTracing(tracing => tracing
+            .ConfigureResource(resource => resource
+                .AddService("discord-event-service")
+                .AddAttributes(new Dictionary<string, object>
+                {
+                    ["langfuse.environment"] = environment.EnvironmentName.ToLowerInvariant(),
+                }))
             .AddSource(ConversationTelemetry.SourceName)
             .AddOtlpExporter(exporter =>
             {

--- a/src/DiscordEventService/Services/Conversation/ConversationService.cs
+++ b/src/DiscordEventService/Services/Conversation/ConversationService.cs
@@ -20,6 +20,7 @@ internal sealed class ConversationService(
     ConversationMemoryService memory,
     IOptions<ConversationOptions> conversationOptions,
     IOptions<OpenRouterOptions> openRouterOptions,
+    IHostEnvironment environment,
     ILogger<ConversationService> logger)
 {
     // The model sometimes answers a final round with no text (degenerate) or runs out of
@@ -72,6 +73,34 @@ internal sealed class ConversationService(
         turn?.SetTag("conversation.invoker_id", context.InvokerId);
         turn?.SetTag("conversation.guild_id", context.GuildId);
 
+        // Langfuse identity mapping: `user.id`/`session.id` on the root span become the
+        // trace's userId/sessionId (users + sessions views, filterable); the
+        // `langfuse.trace.metadata.*` keys become top-level filterable metadata, unlike
+        // our conversation.* tags which land in the unfilterable attribute bag.
+        turn?.SetTag("user.id", context.InvokerId.ToString());
+        turn?.SetTag("session.id", context.ChannelId.ToString());
+        turn?.SetTag("langfuse.trace.metadata.invoker_name", context.InvokerDisplayName);
+        turn?.SetTag("langfuse.trace.metadata.channel_id", context.ChannelId.ToString());
+        if (context.GuildId is { } guildId)
+            turn?.SetTag("langfuse.trace.metadata.guild_id", guildId.ToString());
+
+        // Mirrors the chat client's sensitive-data gate (ConversationRegistration): the
+        // turn's question/answer become the trace-level input/output only when prompt
+        // capture is on anyway.
+        var captureSensitiveData = options.EnableSensitiveData || environment.IsDevelopment();
+        if (captureSensitiveData)
+            turn?.SetTag("langfuse.trace.input", userMessage);
+
+        // This method and StreamRoundAsync are async iterators: after every `yield return`
+        // they resume on the consumer's execution context, where Activity.Current is no
+        // longer the turn span — anything started there (tool spans, round 2+ generations)
+        // would begin a fresh root trace. Re-anchor before starting any child span.
+        void ReanchorTurnSpan()
+        {
+            if (turn is not null && !ReferenceEquals(Activity.Current, turn))
+                Activity.Current = turn;
+        }
+
         var turnCostUsd = 0d;
 
         // The turn's web-search citations (#271), accumulated across every successful
@@ -95,6 +124,7 @@ internal sealed class ConversationService(
                 Exception? failure = null;
                 var stopwatch = Stopwatch.StartNew();
 
+                ReanchorTurnSpan();
                 var updates = chatClient
                     .GetStreamingResponseAsync(messages, roundOptions, cancellationToken)
                     .GetAsyncEnumerator(cancellationToken);
@@ -193,6 +223,8 @@ internal sealed class ConversationService(
                 turn?.SetTag("conversation.failed", true);
                 turn?.SetTag("conversation.rounds", round);
                 turn?.SetTag("conversation.cost_usd", turnCostUsd);
+                if (captureSensitiveData)
+                    turn?.SetTag("langfuse.trace.output", options.FailureMessage);
                 yield break;
             }
 
@@ -227,6 +259,9 @@ internal sealed class ConversationService(
                     round, context.InvokerDisplayName);
                 turn?.SetTag("conversation.rounds", round);
                 turn?.SetTag("conversation.cost_usd", turnCostUsd);
+                if (captureSensitiveData)
+                    turn?.SetTag("langfuse.trace.output",
+                        HadText(sink) ? response.Text : EmptyAnswerFallback);
                 yield break;
             }
 
@@ -234,6 +269,7 @@ internal sealed class ConversationService(
             // progress note is the model's own (the system prompt demands one before every
             // tool call), and a silent round still renders its tool-batch summary message.
             logger.LogDebug("Round {Round}: model requested {Count} tool call(s)", round, toolCalls.Count);
+            ReanchorTurnSpan();
             foreach (var call in toolCalls)
             {
                 var result = await toolset.InvokeAsync(call, cancellationToken);
@@ -262,6 +298,8 @@ internal sealed class ConversationService(
             yield return new ConversationUpdate.AssistantTextDelta(options.FailureMessage);
             turn?.SetTag("conversation.failed", true);
             turn?.SetTag("conversation.cost_usd", turnCostUsd);
+            if (captureSensitiveData)
+                turn?.SetTag("langfuse.trace.output", options.FailureMessage);
             yield break;
         }
 
@@ -282,6 +320,9 @@ internal sealed class ConversationService(
         if (WebSearchCitations.FormatSourceList(citations) is { } finalSources)
             yield return new ConversationUpdate.AssistantTextDelta($"\n{finalSources}");
         turn?.SetTag("conversation.cost_usd", turnCostUsd);
+        if (captureSensitiveData)
+            turn?.SetTag("langfuse.trace.output",
+                HadText(finalSink) ? finalResponse.Text : CapReachedFallback);
     }
 
     // Whitespace-only counts as no visible text — stays consistent with the handler's

--- a/tests/DiscordEventService.Tests/ConversationLiveApiTests.cs
+++ b/tests/DiscordEventService.Tests/ConversationLiveApiTests.cs
@@ -91,7 +91,8 @@ public sealed class ConversationLiveApiTests(PostgresFixture fixture)
         var memory = new ConversationMemoryService(
             NewContext(), conversationOptions, NullLogger<ConversationMemoryService>.Instance);
         var service = new ConversationService(
-            chatClient, registry, memory, conversationOptions, openRouterOptions, NullLogger<ConversationService>.Instance);
+            chatClient, registry, memory, conversationOptions, openRouterOptions,
+            new TestHostEnvironment(), NullLogger<ConversationService>.Instance);
 
         var context = new ConversationContext(GuildDiscordId, InvokerId: 1UL, "tester", IsAdmin: false, ChannelId: 9UL);
 

--- a/tests/DiscordEventService.Tests/ConversationLoopTests.cs
+++ b/tests/DiscordEventService.Tests/ConversationLoopTests.cs
@@ -196,6 +196,7 @@ public sealed class ConversationLoopTests(PostgresFixture fixture)
             new ConversationMemoryService(NewContext(), conversationOptions, NullLogger<ConversationMemoryService>.Instance),
             conversationOptions,
             openRouterOptions,
+            new TestHostEnvironment(),
             NullLogger<ConversationService>.Instance);
     }
 

--- a/tests/DiscordEventService.Tests/ConversationMemoryTests.cs
+++ b/tests/DiscordEventService.Tests/ConversationMemoryTests.cs
@@ -296,6 +296,7 @@ public sealed class ConversationMemoryTests(PostgresFixture fixture)
             new ConversationMemoryService(NewContext(), conversationOptions, NullLogger<ConversationMemoryService>.Instance),
             conversationOptions,
             openRouterOptions,
+            new TestHostEnvironment(),
             NullLogger<ConversationService>.Instance);
     }
 
@@ -312,6 +313,7 @@ public sealed class ConversationMemoryTests(PostgresFixture fixture)
             new ConversationMemoryService(NewContext(), conversationOptions, NullLogger<ConversationMemoryService>.Instance),
             conversationOptions,
             Options.Create(new OpenRouterOptions { ApiKey = "test-key" }),
+            new TestHostEnvironment(),
             NullLogger<ConversationService>.Instance);
     }
 

--- a/tests/DiscordEventService.Tests/ConversationRetryTests.cs
+++ b/tests/DiscordEventService.Tests/ConversationRetryTests.cs
@@ -233,6 +233,7 @@ public sealed class ConversationRetryTests(PostgresFixture fixture)
             new ConversationMemoryService(NewContext(), conversationOptions, NullLogger<ConversationMemoryService>.Instance),
             conversationOptions,
             Options.Create(new OpenRouterOptions { ApiKey = "test-key" }),
+            new TestHostEnvironment(),
             NullLogger<ConversationService>.Instance);
     }
 

--- a/tests/DiscordEventService.Tests/ConversationWebSearchTests.cs
+++ b/tests/DiscordEventService.Tests/ConversationWebSearchTests.cs
@@ -192,6 +192,7 @@ public sealed class ConversationWebSearchTests(PostgresFixture fixture)
             new ConversationMemoryService(NewContext(), conversationOptions, NullLogger<ConversationMemoryService>.Instance),
             conversationOptions,
             Options.Create(new OpenRouterOptions { ApiKey = "test-key" }),
+            new TestHostEnvironment(),
             NullLogger<ConversationService>.Instance);
     }
 

--- a/tests/DiscordEventService.Tests/TestHostEnvironment.cs
+++ b/tests/DiscordEventService.Tests/TestHostEnvironment.cs
@@ -1,0 +1,14 @@
+using Microsoft.Extensions.FileProviders;
+using Microsoft.Extensions.Hosting;
+
+namespace DiscordEventService.Tests;
+
+// Minimal IHostEnvironment for constructing services directly in tests. "Test" is
+// deliberately not "Development" so environment-gated behavior stays off by default.
+internal sealed class TestHostEnvironment : IHostEnvironment
+{
+    public string EnvironmentName { get; set; } = "Test";
+    public string ApplicationName { get; set; } = "DiscordEventService.Tests";
+    public string ContentRootPath { get; set; } = Path.GetTempPath();
+    public IFileProvider ContentRootFileProvider { get; set; } = new NullFileProvider();
+}


### PR DESCRIPTION
## Summary

#257's live verification (local Devtuś against prod Langfuse) proved the export pipeline works but exposed a structural bug: **one conversation turn fragmented into 3–4 separate traces**. Only the round-1 generation nested under `conversation.turn`; every tool span and round-2+ generation exported as an orphan root trace.

Root cause: `GenerateReplyAsync`/`StreamRoundAsync` are async iterators — after each `yield return` they resume on the consumer's execution context, where `Activity.Current` is no longer the turn span, so subsequently-started child activities begin fresh root traces.

## Changes

- **Nesting fix**: `ReanchorTurnSpan()` restores `Activity.Current` to the turn span before each round's chat call (including retries) and before tool dispatch.
- **Langfuse identity mapping** (requested follow-on): invoker id → `user.id` (trace userId), thread id → `session.id` (trace sessionId), invoker display name + guild/channel ids → `langfuse.trace.metadata.*` (top-level filterable).
- **Trace-level input/output**: question/final answer via `langfuse.trace.input`/`.output`, gated by the same sensitive-data condition as the MEAI chat client (`EnableSensitiveData || IsDevelopment`).
- **Resource attributes**: `service.name=discord-event-service` (was `unknown_service`) and `langfuse.environment` (lowercased host environment) so dev and prod traces separate inside the shared Langfuse project.
- `AddConversationFeature` now takes `IHostEnvironment`; `ConversationService` gets it via DI (registered in both root and DSharpPlus child containers).

## Testing

- All 53 conversation unit/integration tests pass.
- Live-verified on dev bot against prod Langfuse: post-fix turn `cd844d3cd7…` is a single trace — turn span → round-1 generation + `tool server_info` + `tool top_posters` + round-2 generation all nested; userId/sessionId/metadata/input/output/environment all present and correct via read API.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DiPCMbiX1JzTsXda3X4WyS