### PR TITLE
fix: #282 treat stale InProgress backfill checkpoints as dead in skip checks

### DIFF
--- a/src/DiscordEventService/Data/Entities/Core/BackfillCheckpointEntity.cs
+++ b/src/DiscordEventService/Data/Entities/Core/BackfillCheckpointEntity.cs
@@ -22,6 +22,16 @@ public class BackfillCheckpointEntity : ITimestamped
     public DateTime? CompletedAtUtc { get; set; }
     public DateTime FirstSeenUtc { get; set; }
     public DateTime LastUpdatedUtc { get; set; }
+
+    public static readonly TimeSpan StaleInProgressAfter = TimeSpan.FromHours(1);
+
+    // LastUpdatedUtc is bumped on every SaveChanges (ITimestamped) and a live backfill saves at
+    // least once per batch, so it is a heartbeat: an InProgress row with no write for longer than
+    // StaleInProgressAfter belongs to a process that died before writing a terminal status (#282).
+    // Callers leave Status untouched — the next run's executor treats the surviving InProgress row
+    // as an interrupted run and resumes from its cursor.
+    public bool IsActivelyInProgress(DateTime nowUtc)
+        => Status == BackfillStatus.InProgress && nowUtc - LastUpdatedUtc < StaleInProgressAfter;
 }
 
 // Persisted as int in the DB — values are a data contract; never renumber or strip explicit values.

--- a/src/DiscordEventService/Endpoints/BackfillEndpoints.cs
+++ b/src/DiscordEventService/Endpoints/BackfillEndpoints.cs
@@ -36,8 +36,10 @@ internal static class BackfillEndpoints
         GuildBackfillOrchestrator orchestrator,
         DiscordDbContext db)
     {
-        var existingInProgress = await db.BackfillCheckpoints
-            .AnyAsync(c => c.GuildDiscordId == guildId && c.Status == BackfillStatus.InProgress);
+        var inProgressCheckpoints = await db.BackfillCheckpoints
+            .Where(c => c.GuildDiscordId == guildId && c.Status == BackfillStatus.InProgress)
+            .ToListAsync();
+        var existingInProgress = inProgressCheckpoints.Any(c => c.IsActivelyInProgress(DateTime.UtcNow));
 
         if (existingInProgress)
             return Results.BadRequest(new { error = "Backfill already in progress for this guild" });

--- a/src/DiscordEventService/Jobs/PeriodicFullBackfillJob.cs
+++ b/src/DiscordEventService/Jobs/PeriodicFullBackfillJob.cs
@@ -25,10 +25,20 @@ internal sealed class PeriodicFullBackfillJob(
             .ToListAsync();
         var inProgress = await db.BackfillCheckpoints
             .Where(c => c.Status == BackfillStatus.InProgress)
-            .Select(c => c.GuildDiscordId)
-            .Distinct()
             .ToListAsync();
-        var inProgressSet = inProgress.ToHashSet();
+
+        var now = DateTime.UtcNow;
+        foreach (var stale in inProgress.Where(c => !c.IsActivelyInProgress(now)))
+        {
+            logger.LogWarning(
+                "Ignoring stale InProgress {BackfillType} checkpoint for guild {GuildId}: no progress since {LastUpdatedUtc:O}",
+                stale.Type, stale.GuildDiscordId, stale.LastUpdatedUtc);
+        }
+
+        var inProgressSet = inProgress
+            .Where(c => c.IsActivelyInProgress(now))
+            .Select(c => c.GuildDiscordId)
+            .ToHashSet();
 
         var afterTimestamp = DateTime.UtcNow - BackfillWindow;
 

--- a/src/DiscordEventService/Services/EventHandlers/SocketLifecycleHandler.cs
+++ b/src/DiscordEventService/Services/EventHandlers/SocketLifecycleHandler.cs
@@ -147,12 +147,21 @@ internal sealed class SocketLifecycleHandler(
             afterTimestamp = earliestAllowed;
         }
 
-        var inProgressGuilds = await db.BackfillCheckpoints
+        var inProgressCheckpoints = await db.BackfillCheckpoints
             .Where(c => c.Status == BackfillStatus.InProgress)
-            .Select(c => c.GuildDiscordId)
-            .Distinct()
             .ToListAsync();
-        var inProgressSet = inProgressGuilds.ToHashSet();
+
+        foreach (var stale in inProgressCheckpoints.Where(c => !c.IsActivelyInProgress(now)))
+        {
+            logger.LogWarning(
+                "Ignoring stale InProgress {BackfillType} checkpoint for guild {GuildId}: no progress since {LastUpdatedUtc:O}",
+                stale.Type, stale.GuildDiscordId, stale.LastUpdatedUtc);
+        }
+
+        var inProgressSet = inProgressCheckpoints
+            .Where(c => c.IsActivelyInProgress(now))
+            .Select(c => c.GuildDiscordId)
+            .ToHashSet();
 
         foreach (var guildId in guildIds)
         {

--- a/tests/DiscordEventService.Tests/BackfillStaleCheckpointTests.cs
+++ b/tests/DiscordEventService.Tests/BackfillStaleCheckpointTests.cs
@@ -1,0 +1,129 @@
+using DiscordEventService.Data;
+using DiscordEventService.Data.Entities.Core;
+using DiscordEventService.Jobs;
+using Hangfire;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging.Abstractions;
+using Xunit;
+
+namespace DiscordEventService.Tests;
+
+// #282: a checkpoint left InProgress by a hard kill must not starve automatic backfill
+// forever — the periodic sweep treats an InProgress row with a stale heartbeat as dead.
+public sealed class BackfillStaleCheckpointTests(PostgresFixture fixture)
+    : IClassFixture<PostgresFixture>, IAsyncLifetime
+{
+    private const ulong GuildId = 777_000_001UL;
+
+    private ServiceProvider _provider = null!;
+    private RecordingJobClient _jobClient = null!;
+
+    public async Task InitializeAsync()
+    {
+        await using var db = NewContext();
+        await db.Database.MigrateAsync();
+        await db.BackfillCheckpoints.ExecuteDeleteAsync();
+        await db.Guilds.ExecuteDeleteAsync();
+
+        db.Guilds.Add(new GuildEntity { DiscordId = GuildId, Name = "stale-test-guild", OwnerId = 1UL });
+        db.BackfillCheckpoints.Add(new BackfillCheckpointEntity
+        {
+            GuildDiscordId = GuildId,
+            Type = BackfillType.Messages,
+            Status = BackfillStatus.InProgress,
+            StartedAtUtc = DateTime.UtcNow
+        });
+        await db.SaveChangesAsync();
+
+        _jobClient = new RecordingJobClient();
+        _provider = new ServiceCollection()
+            .AddDbContext<DiscordDbContext>(o => o
+                .UseNpgsql(fixture.Container.GetConnectionString())
+                .UseSnakeCaseNamingConvention())
+            .AddSingleton<IBackgroundJobClient>(_jobClient)
+            .AddScoped<GuildBackfillOrchestrator>()
+            .AddLogging()
+            .BuildServiceProvider();
+    }
+
+    public async Task DisposeAsync() => await _provider.DisposeAsync();
+
+    [Fact]
+    public async Task ExecuteAsync_FreshInProgressCheckpoint_SkipsGuild()
+    {
+        await RunPeriodicJobAsync();
+
+        Assert.Empty(_jobClient.Created);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_StaleInProgressCheckpoint_EnqueuesChain()
+    {
+        await AgeCheckpointHeartbeatAsync(BackfillCheckpointEntity.StaleInProgressAfter + TimeSpan.FromMinutes(5));
+
+        await RunPeriodicJobAsync();
+
+        Assert.NotEmpty(_jobClient.Created);
+        Assert.Contains(_jobClient.Created, j => j.Type == typeof(RolesBackfillJob));
+    }
+
+    [Theory]
+    [InlineData(BackfillStatus.Pending)]
+    [InlineData(BackfillStatus.Completed)]
+    [InlineData(BackfillStatus.Failed)]
+    [InlineData(BackfillStatus.Cancelled)]
+    public void IsActivelyInProgress_IsFalse_ForTerminalStatuses(BackfillStatus status)
+    {
+        var checkpoint = new BackfillCheckpointEntity { Status = status, LastUpdatedUtc = DateTime.UtcNow };
+
+        Assert.False(checkpoint.IsActivelyInProgress(DateTime.UtcNow));
+    }
+
+    [Fact]
+    public void IsActivelyInProgress_FlipsAtTheStaleThreshold()
+    {
+        var now = DateTime.UtcNow;
+        var fresh = new BackfillCheckpointEntity
+        {
+            Status = BackfillStatus.InProgress,
+            LastUpdatedUtc = now - BackfillCheckpointEntity.StaleInProgressAfter + TimeSpan.FromMinutes(1)
+        };
+        var stale = new BackfillCheckpointEntity
+        {
+            Status = BackfillStatus.InProgress,
+            LastUpdatedUtc = now - BackfillCheckpointEntity.StaleInProgressAfter - TimeSpan.FromMinutes(1)
+        };
+
+        Assert.True(fresh.IsActivelyInProgress(now));
+        Assert.False(stale.IsActivelyInProgress(now));
+    }
+
+    private async Task RunPeriodicJobAsync()
+    {
+        var job = new PeriodicFullBackfillJob(
+            _provider.GetRequiredService<IServiceScopeFactory>(),
+            NullLogger<PeriodicFullBackfillJob>.Instance);
+        await job.ExecuteAsync();
+    }
+
+    // ExecuteUpdate bypasses SaveChangesAsync's UpdateTimestamps, so the heartbeat
+    // can be backdated the same way a dead process leaves it frozen.
+    private async Task AgeCheckpointHeartbeatAsync(TimeSpan age)
+    {
+        await using var db = NewContext();
+        var frozenAt = DateTime.UtcNow - age;
+        await db.BackfillCheckpoints
+            .Where(c => c.GuildDiscordId == GuildId)
+            .ExecuteUpdateAsync(s => s.SetProperty(c => c.LastUpdatedUtc, frozenAt));
+    }
+
+    private DiscordDbContext NewContext()
+    {
+        var options = new DbContextOptionsBuilder<DiscordDbContext>()
+            .UseNpgsql(fixture.Container.GetConnectionString())
+            .UseSnakeCaseNamingConvention()
+            .Options;
+        return new DiscordDbContext(options);
+    }
+}


### PR DESCRIPTION
## Problem

#282: the Messages backfill checkpoint sat `InProgress` since **2026-05-25** (process killed between `BackfillJobExecutor`'s `InProgress` flip and the terminal-status write). Because `PeriodicFullBackfillJob`, `SocketLifecycleHandler` (reconnect backfill), and the `POST /api/backfill/{guildId}` guard all treat any `InProgress` checkpoint as "backfill running", **no automatic backfill ran for ~8 weeks** — the 31-minute outage on 2026-06-20 was never backfilled.

## Fix

`BackfillCheckpointEntity.IsActivelyInProgress(nowUtc)`: `InProgress` counts as running only while its `LastUpdatedUtc` heartbeat is fresher than `StaleInProgressAfter` (1 h). The heartbeat is real: `ITimestamped` bumps `LastUpdatedUtc` on every SaveChanges, and a live backfill saves at least once per batch. All three skip sites use the predicate and log a warning when bypassing a stale row. `Status` is deliberately left untouched — the executor's existing interrupted-run path then resumes from the surviving cursor.

## Testing

- New `BackfillStaleCheckpointTests` (Testcontainers, real Postgres + `RecordingJobClient`): fresh `InProgress` → periodic sweep skips the guild; stale → enqueues the chain; threshold boundary + terminal-status unit cases.
- Verified red-capable: the stale-enqueue test fails against the pre-fix `PeriodicFullBackfillJob`.
- Prod already remediated manually (cancel + re-trigger) earlier today; this prevents recurrence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)