### PR TITLE
fix: #284 map channel.IsNSFW in GuildEventHandler channel upsert

### DIFF
--- a/src/DiscordEventService/Services/EventHandlers/GuildEventHandler.cs
+++ b/src/DiscordEventService/Services/EventHandlers/GuildEventHandler.cs
@@ -120,7 +120,7 @@ internal sealed class GuildEventHandler(EventPipeline pipeline) :
                     .SetProperty(c => c.Bitrate, channel.Bitrate)
                     .SetProperty(c => c.UserLimit, channel.UserLimit)
                     .SetProperty(c => c.RateLimitPerUser, channel.PerUserRateLimit)
-                    .SetProperty(c => c.IsNsfw, false)
+                    .SetProperty(c => c.IsNsfw, channel.IsNSFW)
                     .SetProperty(c => c.Position, channel.Position)
                     .SetProperty(c => c.IsDeleted, false)
                     .SetProperty(c => c.DeletedAtUtc, (DateTime?)null),
@@ -135,7 +135,7 @@ internal sealed class GuildEventHandler(EventPipeline pipeline) :
                     Bitrate = channel.Bitrate,
                     UserLimit = channel.UserLimit,
                     RateLimitPerUser = channel.PerUserRateLimit,
-                    IsNsfw = false,
+                    IsNsfw = channel.IsNSFW,
                     Position = channel.Position,
                     IsDeleted = false,
                 },


### PR DESCRIPTION
## Problem

#284: `GuildEventHandler.UpsertGuildChannelsAsync` hardcoded `IsNsfw = false` in both upsert branches while `ChannelUpsertService` and `ChannelEventHandler` map `channel.IsNSFW` — so a channel's stored NSFW flag depended on which event last wrote it, and every guild cold-sync stomped it back to `false`.

## Fix

Two lines: map `channel.IsNSFW` in both branches, matching the other writers.

## Testing

No unit seam exists for this handler (DSharpPlus `DiscordGuild`/`DiscordChannel` aren't constructible in tests — the known handler-testability gap from the 2026-07-07 architecture review, candidate #7). Live-verified end-to-end on the dev bot instead:

1. Flipped `#devtuś` to NSFW via Discord API while the bot was offline (dev DB stale at `is_nsfw = f`).
2. Booted the bot — `GuildCreated` cold-sync (the exact changed path) upserted `is_nsfw = t`.
3. Reverted the channel with the bot running — live `ChannelUpdated` wrote `f` back. Zero errors in the boot log.

🤖 Generated with [Claude Code](https://claude.com/claude-code)