### PR TITLE
fix: #283 enumerate threads in backfill jobs (active + archived)

### DIFF
--- a/src/DiscordEventService/Jobs/BackfillJobBase.cs
+++ b/src/DiscordEventService/Jobs/BackfillJobBase.cs
@@ -58,6 +58,79 @@ internal abstract class BackfillJobBase
         }
     }
 
+    private const int ArchivedThreadPageSize = 100;
+
+    // Threads never appear in GET /guilds/{id}/channels (Discord excludes them), so the backfill
+    // jobs must enumerate them explicitly (#283): all active threads guild-wide, plus per-parent
+    // archived pages. Private archived threads require ManageThreads — Unauthorized there just
+    // means none are visible to the bot, not a failure.
+    protected static async Task<List<DSharpPlus.Entities.DiscordThreadChannel>> ListGuildThreadsAsync(
+        DSharpPlus.Entities.DiscordGuild guild,
+        IReadOnlyList<DSharpPlus.Entities.DiscordChannel> channels,
+        ILogger logger,
+        CancellationToken cancellationToken)
+    {
+        var threads = new Dictionary<ulong, DSharpPlus.Entities.DiscordThreadChannel>();
+
+        foreach (var thread in (await guild.ListActiveThreadsAsync()).Threads)
+            threads[thread.Id] = thread;
+
+        var threadParents = channels
+            .Where(c => c.Type is DSharpPlus.Entities.DiscordChannelType.Text
+                     or DSharpPlus.Entities.DiscordChannelType.News
+                     or DSharpPlus.Entities.DiscordChannelType.GuildForum
+                     or DSharpPlus.Entities.DiscordChannelType.GuildMedia)
+            .ToList();
+
+        foreach (var parent in threadParents)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            await CollectArchivedThreadsAsync(
+                parent, before => parent.ListPublicArchivedThreadsAsync(before, ArchivedThreadPageSize),
+                "public", threads, logger, cancellationToken);
+            await CollectArchivedThreadsAsync(
+                parent, before => parent.ListPrivateArchivedThreadsAsync(before, ArchivedThreadPageSize),
+                "private", threads, logger, cancellationToken);
+        }
+
+        return [.. threads.Values];
+    }
+
+    private static async Task CollectArchivedThreadsAsync(
+        DSharpPlus.Entities.DiscordChannel parent,
+        Func<DateTimeOffset?, Task<DSharpPlus.Entities.ThreadQueryResult>> listPage,
+        string visibility,
+        Dictionary<ulong, DSharpPlus.Entities.DiscordThreadChannel> threads,
+        ILogger logger,
+        CancellationToken cancellationToken)
+    {
+        try
+        {
+            DateTimeOffset? before = null;
+            while (true)
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+
+                var page = await listPage(before);
+                foreach (var thread in page.Threads)
+                    threads[thread.Id] = thread;
+
+                // Archived listings page backwards by archive timestamp.
+                before = page.Threads.Count > 0 ? page.Threads[^1].ThreadMetadata?.ArchiveTimestamp : null;
+                if (!page.HasMore || before is null)
+                    break;
+            }
+        }
+        catch (DSharpPlus.Exceptions.UnauthorizedException)
+        {
+            logger.LogDebug("No permission to list {Visibility} archived threads in channel {ChannelId}", visibility, parent.Id);
+        }
+        catch (DSharpPlus.Exceptions.NotFoundException)
+        {
+            logger.LogDebug("Channel {ChannelId} not found while listing {Visibility} archived threads", parent.Id, visibility);
+        }
+    }
+
     // Drives the per-item resume-cursor loop shared by the history jobs (Messages, Reactions): skip to the
     // channel a genuinely-interrupted run stopped on (CurrentChannelId, reset to null by the executor after a
     // terminal run), then walk the rest, clearing the per-channel batch cursor (LastProcessedId) only AFTER an

--- a/src/DiscordEventService/Jobs/ChannelsBackfillJob.cs
+++ b/src/DiscordEventService/Jobs/ChannelsBackfillJob.cs
@@ -7,7 +7,8 @@ namespace DiscordEventService.Jobs;
 
 internal sealed class ChannelsBackfillJob(
     DiscordClient discordClient,
-    BackfillJobExecutor executor) : BackfillJobBase, IBackfillJob
+    BackfillJobExecutor executor,
+    ILogger<ChannelsBackfillJob> logger) : BackfillJobBase, IBackfillJob
 {
     private const int SaveProgressInterval = 50;
 
@@ -23,10 +24,17 @@ internal sealed class ChannelsBackfillJob(
             if (guildEntity is null)
                 return BackfillOutcome.ShortCircuit($"Guild {guildId} not found in database");
 
-            ctx.Checkpoint.TotalCount = channels.Count;
+            // Threads must be rows in channels too — Messages/Reactions backfill FK onto them (#283).
+            var threads = await ListGuildThreadsAsync(guild, channels, logger, cancellationToken);
+            var allChannels = channels
+                .Concat<DSharpPlus.Entities.DiscordChannel>(threads)
+                .DistinctBy(c => c.Id)
+                .ToList();
+
+            ctx.Checkpoint.TotalCount = allChannels.Count;
             await ctx.Db.SaveChangesAsync(cancellationToken);
 
-            foreach (var channel in channels)
+            foreach (var channel in allChannels)
             {
                 cancellationToken.ThrowIfCancellationRequested();
 

--- a/src/DiscordEventService/Jobs/MessagesBackfillJob.cs
+++ b/src/DiscordEventService/Jobs/MessagesBackfillJob.cs
@@ -35,12 +35,15 @@ internal sealed class MessagesBackfillJob(
             if (guildEntity is null)
                 return BackfillOutcome.ShortCircuit($"Guild {guildId} not found in database");
 
-            var textChannels = channels
+            var threads = await ListGuildThreadsAsync(guild, channels, logger, cancellationToken);
+
+            var textChannels = channels.Concat<DiscordChannel>(threads)
                 .Where(c => c.Type is DSharpPlus.Entities.DiscordChannelType.Text
                          or DSharpPlus.Entities.DiscordChannelType.News
                          or DSharpPlus.Entities.DiscordChannelType.PublicThread
                          or DSharpPlus.Entities.DiscordChannelType.PrivateThread
                          or DSharpPlus.Entities.DiscordChannelType.NewsThread)
+                .DistinctBy(c => c.Id)
                 .OrderBy(c => c.Id)
                 .ToList();
 

--- a/src/DiscordEventService/Jobs/ReactionsBackfillJob.cs
+++ b/src/DiscordEventService/Jobs/ReactionsBackfillJob.cs
@@ -34,12 +34,15 @@ internal sealed class ReactionsBackfillJob(
             if (guildEntity is null)
                 return BackfillOutcome.ShortCircuit($"Guild {guildId} not found in database");
 
-            var textChannels = channels
+            var threads = await ListGuildThreadsAsync(guild, channels, logger, cancellationToken);
+
+            var textChannels = channels.Concat<DiscordChannel>(threads)
                 .Where(c => c.Type is DiscordChannelType.Text
                          or DiscordChannelType.News
                          or DiscordChannelType.PublicThread
                          or DiscordChannelType.PrivateThread
                          or DiscordChannelType.NewsThread)
+                .DistinctBy(c => c.Id)
                 .OrderBy(c => c.Id)
                 .ToList();
 


### PR DESCRIPTION
## Problem

#283: threads never appear in `GET /guilds/{id}/channels`, so the thread-type filter arms in `MessagesBackfillJob`/`ReactionsBackfillJob` were dead code, `ChannelsBackfillJob` never created thread channel rows, and thread messages posted during gateway outages were unrecoverable by any backfill. Prod evidence: 90 live-created thread message_events, 0 backfilled.

## Fix

- `BackfillJobBase.ListGuildThreadsAsync`: guild-wide `ListActiveThreadsAsync()` + paged `ListPublicArchivedThreadsAsync`/`ListPrivateArchivedThreadsAsync` per text/news/forum/media parent (pages backwards by archive timestamp; `Unauthorized` on private archived just means none visible — logged at debug and skipped).
- `ChannelsBackfillJob`: upserts threads as channel rows (types 10-12 via the existing direct cast) so the history jobs' FK lookups resolve.
- `MessagesBackfillJob` / `ReactionsBackfillJob`: concat threads into the existing channel walk — the previously-dead filter arms are now live. `DistinctBy(Id)` + `OrderBy(Id)` keeps the resume-cursor ordering stable.

## Testing

No unit seam (jobs take `DiscordClient` directly — known gap). Live-verified end-to-end on the dev bot:

1. With the bot **offline**, created a forum channel + thread with 2 messages (nothing captured live).
2. Booted the bot; reconnect backfill ran with the new code.
3. Local DB: thread channel row (`type 11`, correct `parent_discord_id`), both messages inserted, provenance `message_events.event_type = 4` (Backfilled) ×2, reactions job visited the thread, zero errors in the log.

After merge, the next full backfill on prod will recover any thread messages missed during past outages (Discord still retains them).

🤖 Generated with [Claude Code](https://claude.com/claude-code)