### PR TITLE
fix: #288 #289 backfill chain lifecycle — startup sweep + atomic per-guild chain guard

### DIFF
--- a/src/DiscordEventService/Data/Entities/Core/BackfillCheckpointEntity.cs
+++ b/src/DiscordEventService/Data/Entities/Core/BackfillCheckpointEntity.cs
@@ -32,6 +32,14 @@ public class BackfillCheckpointEntity : ITimestamped
     // as an interrupted run and resumes from its cursor.
     public bool IsActivelyInProgress(DateTime nowUtc)
         => Status == BackfillStatus.InProgress && nowUtc - LastUpdatedUtc < StaleInProgressAfter;
+
+    // Chain-guard predicate (#289): the orchestrator marks every checkpoint of a freshly enqueued
+    // chain Pending (with its Hangfire job id) before the first job runs, so a fresh Pending row
+    // means "chain queued but not started yet" and must block a second chain the same way a live
+    // InProgress row does. Same staleness cutoff — a dead process can strand Pending rows too.
+    public bool IsChainActive(DateTime nowUtc)
+        => (Status == BackfillStatus.InProgress || Status == BackfillStatus.Pending)
+            && nowUtc - LastUpdatedUtc < StaleInProgressAfter;
 }
 
 // Persisted as int in the DB — values are a data contract; never renumber or strip explicit values.

--- a/src/DiscordEventService/Endpoints/BackfillEndpoints.cs
+++ b/src/DiscordEventService/Endpoints/BackfillEndpoints.cs
@@ -33,19 +33,13 @@ internal static class BackfillEndpoints
     private static async Task<IResult> StartBackfill(
         ulong guildId,
         BackfillRequest? request,
-        GuildBackfillOrchestrator orchestrator,
-        DiscordDbContext db)
+        GuildBackfillOrchestrator orchestrator)
     {
-        var inProgressCheckpoints = await db.BackfillCheckpoints
-            .Where(c => c.GuildDiscordId == guildId && c.Status == BackfillStatus.InProgress)
-            .ToListAsync();
-        var existingInProgress = inProgressCheckpoints.Any(c => c.IsActivelyInProgress(DateTime.UtcNow));
-
-        if (existingInProgress)
-            return Results.BadRequest(new { error = "Backfill already in progress for this guild" });
-
         var options = request?.ToOptions() ?? BackfillOptions.Default;
-        var jobId = orchestrator.StartBackfill(guildId, options);
+        var jobId = await orchestrator.StartBackfillAsync(guildId, options);
+
+        if (jobId is null)
+            return Results.BadRequest(new { error = "Backfill already in progress for this guild" });
 
         return Results.Accepted(
             $"/api/backfill/{guildId}/status",
@@ -90,8 +84,11 @@ internal static class BackfillEndpoints
         DiscordDbContext db,
         IBackgroundJobClient jobClient)
     {
+        // Pending rows are chain jobs that haven't started yet (#289) — cancelling must delete
+        // those too, or the rest of the chain keeps running.
         var inProgress = await db.BackfillCheckpoints
-            .Where(c => c.GuildDiscordId == guildId && c.Status == BackfillStatus.InProgress)
+            .Where(c => c.GuildDiscordId == guildId
+                && (c.Status == BackfillStatus.InProgress || c.Status == BackfillStatus.Pending))
             .ToListAsync();
 
         foreach (var checkpoint in inProgress)

--- a/src/DiscordEventService/Jobs/GuildBackfillOrchestrator.cs
+++ b/src/DiscordEventService/Jobs/GuildBackfillOrchestrator.cs
@@ -1,60 +1,167 @@
+using DiscordEventService.Data;
+using DiscordEventService.Data.Entities.Core;
 using Hangfire;
+using Microsoft.EntityFrameworkCore;
 
 namespace DiscordEventService.Jobs;
 
 internal sealed class GuildBackfillOrchestrator(
+    DiscordDbContext db,
     IBackgroundJobClient backgroundJobClient,
     ILogger<GuildBackfillOrchestrator> logger)
 {
-    public string StartBackfill(ulong guildId, BackfillOptions? options = null)
-        => EnqueueChain(guildId, options ?? BackfillOptions.Default, afterTimestampUtc: null);
+    // Delay before the first chain job so the Pending checkpoint rows (with their Hangfire job
+    // ids) are committed before any job starts flipping statuses — otherwise a fast worker could
+    // write InProgress that the enqueue transaction then overwrites with Pending.
+    private static readonly TimeSpan FirstJobDelay = TimeSpan.FromSeconds(5);
+
+    public Task<string?> StartBackfillAsync(ulong guildId, BackfillOptions? options = null)
+        => EnqueueChainAsync(guildId, options ?? BackfillOptions.Default, afterTimestampUtc: null);
 
     // afterTimestampUtc stops Messages/Reactions scrolling once older than the window;
     // used by reconnect-driven and historical-gap-driven backfills.
-    public string EnqueueBackfillFrom(ulong guildId, DateTime afterTimestampUtc, BackfillOptions? options = null)
-        => EnqueueChain(guildId, options ?? BackfillOptions.Default, afterTimestampUtc);
+    public Task<string?> EnqueueBackfillFromAsync(ulong guildId, DateTime afterTimestampUtc, BackfillOptions? options = null)
+        => EnqueueChainAsync(guildId, options ?? BackfillOptions.Default, afterTimestampUtc);
 
-    private string EnqueueChain(ulong guildId, BackfillOptions options, DateTime? afterTimestampUtc)
+    // Single authoritative guard against overlapping chains for a guild (#289): the check and the
+    // enqueue happen under a per-guild Postgres advisory lock, so two concurrent triggers (manual
+    // endpoint, reconnect, periodic) cannot both pass the check. Returns null when skipped.
+    private async Task<string?> EnqueueChainAsync(ulong guildId, BackfillOptions options, DateTime? afterTimestampUtc)
     {
+        // Session-level advisory lock on a pinned connection, not pg_advisory_xact_lock: the
+        // retrying execution strategy rejects user-initiated transactions, and wrapping this whole
+        // block in the strategy could re-run the (non-transactional) Hangfire enqueue on a
+        // transient retry — the exact double-chain this guard exists to prevent. One bigint key
+        // per guild id; nothing else in this app takes advisory locks.
+        await db.Database.OpenConnectionAsync();
+        try
+        {
+            await db.Database.ExecuteSqlAsync($"SELECT pg_advisory_lock({unchecked((long)guildId)})");
+            return await EnqueueChainLockedAsync(guildId, options, afterTimestampUtc);
+        }
+        finally
+        {
+            try
+            {
+                await db.Database.ExecuteSqlAsync($"SELECT pg_advisory_unlock_all()");
+            }
+            catch
+            {
+                // A dropped connection has already released the session lock server-side.
+            }
+            await db.Database.CloseConnectionAsync();
+        }
+    }
+
+    private async Task<string?> EnqueueChainLockedAsync(ulong guildId, BackfillOptions options, DateTime? afterTimestampUtc)
+    {
+        var now = DateTime.UtcNow;
+        var checkpoints = await db.BackfillCheckpoints
+            .Where(c => c.GuildDiscordId == guildId && c.Type != BackfillType.MemeIndex)
+            .ToListAsync();
+
+        foreach (var stale in checkpoints.Where(c =>
+                     c.Status == BackfillStatus.InProgress && !c.IsChainActive(now)))
+        {
+            logger.LogWarning(
+                "Ignoring stale InProgress {BackfillType} checkpoint for guild {GuildId}: no progress since {LastUpdatedUtc:O}",
+                stale.Type, stale.GuildDiscordId, stale.LastUpdatedUtc);
+        }
+
+        if (checkpoints.Any(c => c.IsChainActive(now)))
+        {
+            logger.LogInformation("Backfill skipped for guild {GuildId}: a backfill chain is already active", guildId);
+            return null;
+        }
+
         logger.LogInformation(
             "Starting backfill orchestration for guild {GuildId} with options {@Options}, backfilling after {AfterTimestampUtc:O}",
             guildId, options, afterTimestampUtc);
 
-        var rolesJobId = backgroundJobClient.Enqueue<RolesBackfillJob>(
-            j => j.ExecuteAsync(guildId, CancellationToken.None));
+        var chain = EnqueueChainJobs(guildId, options, afterTimestampUtc);
+        RecordChainOnCheckpoints(checkpoints, guildId, chain, now);
+        await db.SaveChangesAsync();
+
+        logger.LogInformation("Backfill orchestration started for guild {GuildId}, first job: {JobId}, final job: {FinalJobId}",
+            guildId, chain[0].JobId, chain[^1].JobId);
+
+        return chain[0].JobId;
+    }
+
+    private List<(BackfillType Type, string JobId)> EnqueueChainJobs(
+        ulong guildId, BackfillOptions options, DateTime? afterTimestampUtc)
+    {
+        List<(BackfillType Type, string JobId)> chain = [];
+
+        var rolesJobId = backgroundJobClient.Schedule<RolesBackfillJob>(
+            j => j.ExecuteAsync(guildId, CancellationToken.None), FirstJobDelay);
+        chain.Add((BackfillType.Roles, rolesJobId));
 
         var emojisJobId = backgroundJobClient.ContinueJobWith<EmojisBackfillJob>(
             rolesJobId, j => j.ExecuteAsync(guildId, CancellationToken.None));
+        chain.Add((BackfillType.Emojis, emojisJobId));
 
         var stickersJobId = backgroundJobClient.ContinueJobWith<StickersBackfillJob>(
             emojisJobId, j => j.ExecuteAsync(guildId, CancellationToken.None));
+        chain.Add((BackfillType.Stickers, stickersJobId));
 
         var channelsJobId = backgroundJobClient.ContinueJobWith<ChannelsBackfillJob>(
             stickersJobId, j => j.ExecuteAsync(guildId, CancellationToken.None));
+        chain.Add((BackfillType.Channels, channelsJobId));
 
         var membersJobId = backgroundJobClient.ContinueJobWith<MembersBackfillJob>(
             channelsJobId, j => j.ExecuteAsync(guildId, CancellationToken.None));
+        chain.Add((BackfillType.Members, membersJobId));
 
-        var finalJobId = membersJobId;
+        if (!options.IncludeMessages)
+            return chain;
 
-        if (options.IncludeMessages)
+        var messagesJobId = backgroundJobClient.ContinueJobWith<MessagesBackfillJob>(
+            membersJobId, j => j.ExecuteAsync(guildId, afterTimestampUtc, CancellationToken.None));
+        chain.Add((BackfillType.Messages, messagesJobId));
+
+        if (options.IncludeReactions)
         {
-            var messagesJobId = backgroundJobClient.ContinueJobWith<MessagesBackfillJob>(
-                membersJobId, j => j.ExecuteAsync(guildId, afterTimestampUtc, CancellationToken.None));
-            finalJobId = messagesJobId;
-
-            if (options.IncludeReactions)
-            {
-                var reactionsJobId = backgroundJobClient.ContinueJobWith<ReactionsBackfillJob>(
-                    messagesJobId, j => j.ExecuteAsync(guildId, afterTimestampUtc, CancellationToken.None));
-                finalJobId = reactionsJobId;
-            }
+            var reactionsJobId = backgroundJobClient.ContinueJobWith<ReactionsBackfillJob>(
+                messagesJobId, j => j.ExecuteAsync(guildId, afterTimestampUtc, CancellationToken.None));
+            chain.Add((BackfillType.Reactions, reactionsJobId));
         }
 
-        logger.LogInformation("Backfill orchestration started for guild {GuildId}, first job: {JobId}, final job: {FinalJobId}",
-            guildId, rolesJobId, finalJobId);
+        return chain;
+    }
 
-        return rolesJobId;
+    // Every chain job gets its Hangfire job id durably recorded before it runs, so the startup
+    // sweep (#288) and the cancel endpoint can delete the real jobs. Stale-InProgress rows keep
+    // their status — the executor resumes from the cursor only when Status==InProgress (#282);
+    // the SaveChanges heartbeat bump alone re-arms the chain guard for them.
+    private void RecordChainOnCheckpoints(
+        List<BackfillCheckpointEntity> checkpoints,
+        ulong guildId,
+        List<(BackfillType Type, string JobId)> chain,
+        DateTime now)
+    {
+        foreach (var (type, jobId) in chain)
+        {
+            var checkpoint = checkpoints.FirstOrDefault(c => c.Type == type);
+            if (checkpoint is null)
+            {
+                checkpoint = new BackfillCheckpointEntity
+                {
+                    GuildDiscordId = guildId,
+                    Type = type,
+                    StartedAtUtc = now
+                };
+                db.BackfillCheckpoints.Add(checkpoint);
+            }
+
+            if (checkpoint.Status != BackfillStatus.InProgress)
+            {
+                checkpoint.Status = BackfillStatus.Pending;
+                checkpoint.CompletedAtUtc = null;
+                checkpoint.StartedAtUtc = now;
+            }
+            checkpoint.HangfireJobId = jobId;
+        }
     }
 }
 

--- a/src/DiscordEventService/Jobs/PeriodicFullBackfillJob.cs
+++ b/src/DiscordEventService/Jobs/PeriodicFullBackfillJob.cs
@@ -5,8 +5,7 @@ using Microsoft.EntityFrameworkCore;
 namespace DiscordEventService.Jobs;
 
 // Reconnect-backfill is capped to 2 days, so anything older needs this periodic sweep;
-// skips guilds with an InProgress checkpoint to avoid stepping on the reconnect path or
-// the operator-triggered /api/backfill endpoint.
+// the orchestrator's chain guard skips guilds where a backfill is already active.
 internal sealed class PeriodicFullBackfillJob(
     IServiceScopeFactory scopeFactory,
     ILogger<PeriodicFullBackfillJob> logger)
@@ -23,38 +22,17 @@ internal sealed class PeriodicFullBackfillJob(
             .Where(g => g.LeftAtUtc == null)
             .Select(g => g.DiscordId)
             .ToListAsync();
-        var inProgress = await db.BackfillCheckpoints
-            .Where(c => c.Status == BackfillStatus.InProgress)
-            .ToListAsync();
-
-        var now = DateTime.UtcNow;
-        foreach (var stale in inProgress.Where(c => !c.IsActivelyInProgress(now)))
-        {
-            logger.LogWarning(
-                "Ignoring stale InProgress {BackfillType} checkpoint for guild {GuildId}: no progress since {LastUpdatedUtc:O}",
-                stale.Type, stale.GuildDiscordId, stale.LastUpdatedUtc);
-        }
-
-        var inProgressSet = inProgress
-            .Where(c => c.IsActivelyInProgress(now))
-            .Select(c => c.GuildDiscordId)
-            .ToHashSet();
 
         var afterTimestamp = DateTime.UtcNow - BackfillWindow;
 
+        // The orchestrator is the single guard against overlapping chains (#289) — it skips the
+        // guild (returns null) when a chain is already active and logs why.
         foreach (var guildId in guildIds)
         {
-            if (inProgressSet.Contains(guildId))
-            {
-                logger.LogInformation(
-                    "Periodic backfill skipped for guild {GuildId}: backfill already in progress",
-                    guildId);
-                continue;
-            }
-
-            logger.LogInformation("Periodic backfill enqueued for guild {GuildId} covering the last {WindowDays} days, after {AfterTimestampUtc:O}",
-                guildId, BackfillWindow.TotalDays, afterTimestamp);
-            orchestrator.EnqueueBackfillFrom(guildId, afterTimestamp);
+            var jobId = await orchestrator.EnqueueBackfillFromAsync(guildId, afterTimestamp);
+            if (jobId is not null)
+                logger.LogInformation("Periodic backfill enqueued for guild {GuildId} covering the last {WindowDays} days, after {AfterTimestampUtc:O}",
+                    guildId, BackfillWindow.TotalDays, afterTimestamp);
         }
     }
 }

--- a/src/DiscordEventService/Jobs/StartupBackfillSweep.cs
+++ b/src/DiscordEventService/Jobs/StartupBackfillSweep.cs
@@ -1,0 +1,71 @@
+using DiscordEventService.Data;
+using DiscordEventService.Data.Entities.Core;
+using Hangfire;
+using Microsoft.EntityFrameworkCore;
+
+namespace DiscordEventService.Jobs;
+
+// #288: no backfill chain survives a process restart. A Pending/InProgress checkpoint at boot
+// belongs to a dead run — but its Hangfire jobs DO survive in Postgres storage and would be
+// re-fetched once the sliding invisibility timeout expires, interleaving with the reconnect
+// chain that fires right after boot. So the sweep flips the checkpoint to Failed AND deletes
+// the recorded job, and must run before the Hangfire server starts processing.
+internal sealed class StartupBackfillSweep(
+    IServiceScopeFactory scopeFactory,
+    IBackgroundJobClient backgroundJobClient,
+    ILogger<StartupBackfillSweep> logger)
+{
+    public async Task SweepAsync()
+    {
+        using var scope = scopeFactory.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<DiscordDbContext>();
+
+        var deadCheckpoints = await db.BackfillCheckpoints
+            .Where(c => c.Status == BackfillStatus.InProgress || c.Status == BackfillStatus.Pending)
+            .ToListAsync();
+
+        if (deadCheckpoints.Count == 0)
+            return;
+
+        var now = DateTime.UtcNow;
+        foreach (var checkpoint in deadCheckpoints)
+        {
+            if (!string.IsNullOrEmpty(checkpoint.HangfireJobId))
+                TryDeleteJob(checkpoint);
+            else
+                logger.LogWarning(
+                    "Startup sweep: no Hangfire job id recorded on {BackfillType} checkpoint for guild {GuildId}; " +
+                    "an orphaned job may still re-run after the invisibility timeout",
+                    checkpoint.Type, checkpoint.GuildDiscordId);
+
+            logger.LogWarning(
+                "Startup sweep: marking {Status} {BackfillType} checkpoint for guild {GuildId} as Failed (job {JobId}, last progress {LastUpdatedUtc:O})",
+                checkpoint.Status, checkpoint.Type, checkpoint.GuildDiscordId,
+                checkpoint.HangfireJobId ?? "none", checkpoint.LastUpdatedUtc);
+
+            checkpoint.Status = BackfillStatus.Failed;
+            checkpoint.ErrorCount++;
+            checkpoint.LastError = "Interrupted by service restart (startup sweep)";
+            checkpoint.LastErrorAtUtc = now;
+        }
+
+        await db.SaveChangesAsync();
+        logger.LogInformation("Startup sweep: failed {Count} dead backfill checkpoint(s)", deadCheckpoints.Count);
+    }
+
+    // Delete throws when the job no longer exists in Hangfire storage (e.g. already expired) —
+    // then there is nothing to delete and the checkpoint must still be failed, not the boot.
+    private void TryDeleteJob(BackfillCheckpointEntity checkpoint)
+    {
+        try
+        {
+            backgroundJobClient.Delete(checkpoint.HangfireJobId);
+        }
+        catch (Exception ex)
+        {
+            logger.LogWarning(ex,
+                "Startup sweep: could not delete Hangfire job {JobId} for {BackfillType} checkpoint of guild {GuildId}",
+                checkpoint.HangfireJobId, checkpoint.Type, checkpoint.GuildDiscordId);
+        }
+    }
+}

--- a/src/DiscordEventService/Program.cs
+++ b/src/DiscordEventService/Program.cs
@@ -196,6 +196,7 @@ builder.Services.AddScoped<MembersBackfillJob>();
 builder.Services.AddScoped<MessagesBackfillJob>();
 builder.Services.AddScoped<ReactionsBackfillJob>();
 builder.Services.AddScoped<PeriodicFullBackfillJob>();
+builder.Services.AddSingleton<StartupBackfillSweep>();
 
 var app = builder.Build();
 
@@ -231,6 +232,10 @@ if (dbOptions.AutoMigrate)
     var db = scope.ServiceProvider.GetRequiredService<DiscordDbContext>();
     await db.Database.MigrateAsync();
 }
+
+// #288: must run before app.Run() starts the Hangfire server, so dead chain jobs are deleted
+// before any worker can re-fetch them.
+await app.Services.GetRequiredService<StartupBackfillSweep>().SweepAsync();
 
 // Serve the bundled dashboard SPA (Vite build output in wwwroot). Must precede
 // the route-mapping below; the SPA fallback is registered LAST so it never

--- a/src/DiscordEventService/Services/EventHandlers/SocketLifecycleHandler.cs
+++ b/src/DiscordEventService/Services/EventHandlers/SocketLifecycleHandler.cs
@@ -147,36 +147,15 @@ internal sealed class SocketLifecycleHandler(
             afterTimestamp = earliestAllowed;
         }
 
-        var inProgressCheckpoints = await db.BackfillCheckpoints
-            .Where(c => c.Status == BackfillStatus.InProgress)
-            .ToListAsync();
-
-        foreach (var stale in inProgressCheckpoints.Where(c => !c.IsActivelyInProgress(now)))
-        {
-            logger.LogWarning(
-                "Ignoring stale InProgress {BackfillType} checkpoint for guild {GuildId}: no progress since {LastUpdatedUtc:O}",
-                stale.Type, stale.GuildDiscordId, stale.LastUpdatedUtc);
-        }
-
-        var inProgressSet = inProgressCheckpoints
-            .Where(c => c.IsActivelyInProgress(now))
-            .Select(c => c.GuildDiscordId)
-            .ToHashSet();
-
+        // The orchestrator is the single guard against overlapping chains (#289) — it skips the
+        // guild (returns null) when a chain is already active and logs why.
         foreach (var guildId in guildIds)
         {
-            if (inProgressSet.Contains(guildId))
-            {
+            var jobId = await orchestrator.EnqueueBackfillFromAsync(guildId, afterTimestamp);
+            if (jobId is not null)
                 logger.LogInformation(
-                    "Reconnect backfill skipped for guild {GuildId}: backfill already in progress",
-                    guildId);
-                continue;
-            }
-
-            logger.LogInformation(
-                "Reconnect backfill enqueued for guild {GuildId} after gap {GapDuration:c}, backfilling from {AfterTimestampUtc:O}",
-                guildId, gap, afterTimestamp);
-            orchestrator.EnqueueBackfillFrom(guildId, afterTimestamp);
+                    "Reconnect backfill enqueued for guild {GuildId} after gap {GapDuration:c}, backfilling from {AfterTimestampUtc:O}",
+                    guildId, gap, afterTimestamp);
         }
     }
 }

--- a/tests/DiscordEventService.Tests/BackfillChainGuardTests.cs
+++ b/tests/DiscordEventService.Tests/BackfillChainGuardTests.cs
@@ -1,0 +1,168 @@
+using DiscordEventService.Data;
+using DiscordEventService.Data.Entities.Core;
+using DiscordEventService.Jobs;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging.Abstractions;
+using Xunit;
+
+namespace DiscordEventService.Tests;
+
+// #289: the orchestrator is the single atomic guard against two chains running for the same
+// guild — the active-chain check and the enqueue happen under a per-guild advisory lock, and
+// every chain job's Hangfire id lands on its checkpoint row before the job runs.
+public sealed class BackfillChainGuardTests(PostgresFixture fixture)
+    : IClassFixture<PostgresFixture>, IAsyncLifetime
+{
+    private const ulong GuildId = 888_000_001UL;
+
+    public async Task InitializeAsync()
+    {
+        await using var db = NewContext();
+        await db.Database.MigrateAsync();
+        await db.BackfillCheckpoints.ExecuteDeleteAsync();
+    }
+
+    public Task DisposeAsync() => Task.CompletedTask;
+
+    [Fact]
+    public async Task EnqueueChain_RecordsPendingCheckpointWithJobId_ForEveryChainType()
+    {
+        await using var db = NewContext();
+        var jobClient = new RecordingJobClient();
+        var orchestrator = NewOrchestrator(db, jobClient);
+
+        var jobId = await orchestrator.StartBackfillAsync(GuildId);
+
+        Assert.NotNull(jobId);
+        Assert.Equal(7, jobClient.Created.Count);
+
+        await using var verify = NewContext();
+        var checkpoints = await verify.BackfillCheckpoints
+            .Where(c => c.GuildDiscordId == GuildId)
+            .ToListAsync();
+        Assert.Equal(7, checkpoints.Count);
+        Assert.All(checkpoints, c =>
+        {
+            Assert.Equal(BackfillStatus.Pending, c.Status);
+            Assert.False(string.IsNullOrEmpty(c.HangfireJobId));
+        });
+    }
+
+    [Fact]
+    public async Task EnqueueChain_WhilePendingRowsFresh_IsSkipped()
+    {
+        await using var db = NewContext();
+        var jobClient = new RecordingJobClient();
+        var orchestrator = NewOrchestrator(db, jobClient);
+        Assert.NotNull(await orchestrator.StartBackfillAsync(GuildId));
+
+        await using var db2 = NewContext();
+        var jobClient2 = new RecordingJobClient();
+        var second = await NewOrchestrator(db2, jobClient2).StartBackfillAsync(GuildId);
+
+        Assert.Null(second);
+        Assert.Empty(jobClient2.Created);
+    }
+
+    [Fact]
+    public async Task EnqueueChain_OtherGuildChainActive_IsNotBlocked()
+    {
+        await using var db = NewContext();
+        Assert.NotNull(await NewOrchestrator(db, new RecordingJobClient()).StartBackfillAsync(GuildId));
+
+        await using var db2 = NewContext();
+        var other = await NewOrchestrator(db2, new RecordingJobClient()).StartBackfillAsync(GuildId + 1);
+
+        Assert.NotNull(other);
+    }
+
+    [Fact]
+    public async Task EnqueueChain_StaleInProgressRow_EnqueuesAndPreservesResumeStatus()
+    {
+        await using (var seed = NewContext())
+        {
+            seed.BackfillCheckpoints.Add(new BackfillCheckpointEntity
+            {
+                GuildDiscordId = GuildId,
+                Type = BackfillType.Messages,
+                Status = BackfillStatus.InProgress,
+                CurrentChannelId = 42UL,
+                StartedAtUtc = DateTime.UtcNow
+            });
+            await seed.SaveChangesAsync();
+            var frozenAt = DateTime.UtcNow - BackfillCheckpointEntity.StaleInProgressAfter - TimeSpan.FromMinutes(5);
+            await seed.BackfillCheckpoints
+                .Where(c => c.GuildDiscordId == GuildId)
+                .ExecuteUpdateAsync(s => s.SetProperty(c => c.LastUpdatedUtc, frozenAt));
+        }
+
+        await using var db = NewContext();
+        var jobId = await NewOrchestrator(db, new RecordingJobClient()).StartBackfillAsync(GuildId);
+
+        Assert.NotNull(jobId);
+        await using var verify = NewContext();
+        var messages = await verify.BackfillCheckpoints
+            .SingleAsync(c => c.GuildDiscordId == GuildId && c.Type == BackfillType.Messages);
+        // Status stays InProgress so the executor's resume branch keeps the cursor (#282/PR #285);
+        // the heartbeat bump from the enqueue save re-arms the chain guard.
+        Assert.Equal(BackfillStatus.InProgress, messages.Status);
+        Assert.Equal(42UL, messages.CurrentChannelId);
+        Assert.False(string.IsNullOrEmpty(messages.HangfireJobId));
+        Assert.True(messages.IsChainActive(DateTime.UtcNow));
+    }
+
+    [Fact]
+    public async Task EnqueueChain_ConcurrentTriggers_OnlyOneWins()
+    {
+        await using var db1 = NewContext();
+        await using var db2 = NewContext();
+        var client1 = new RecordingJobClient();
+        var client2 = new RecordingJobClient();
+
+        var results = await Task.WhenAll(
+            NewOrchestrator(db1, client1).StartBackfillAsync(GuildId),
+            NewOrchestrator(db2, client2).StartBackfillAsync(GuildId));
+
+        Assert.Single(results, r => r is not null);
+        Assert.Equal(7, client1.Created.Count + client2.Created.Count);
+    }
+
+    [Fact]
+    public async Task EnqueueChain_TerminalCheckpoints_DoNotBlock()
+    {
+        await using (var seed = NewContext())
+        {
+            seed.BackfillCheckpoints.Add(new BackfillCheckpointEntity
+            {
+                GuildDiscordId = GuildId,
+                Type = BackfillType.Messages,
+                Status = BackfillStatus.Completed,
+                CompletedAtUtc = DateTime.UtcNow,
+                StartedAtUtc = DateTime.UtcNow
+            });
+            await seed.SaveChangesAsync();
+        }
+
+        await using var db = NewContext();
+        var jobId = await NewOrchestrator(db, new RecordingJobClient()).StartBackfillAsync(GuildId);
+
+        Assert.NotNull(jobId);
+        await using var verify = NewContext();
+        var messages = await verify.BackfillCheckpoints
+            .SingleAsync(c => c.GuildDiscordId == GuildId && c.Type == BackfillType.Messages);
+        Assert.Equal(BackfillStatus.Pending, messages.Status);
+        Assert.Null(messages.CompletedAtUtc);
+    }
+
+    private static GuildBackfillOrchestrator NewOrchestrator(DiscordDbContext db, RecordingJobClient jobClient)
+        => new(db, jobClient, NullLogger<GuildBackfillOrchestrator>.Instance);
+
+    private DiscordDbContext NewContext()
+    {
+        var options = new DbContextOptionsBuilder<DiscordDbContext>()
+            .UseNpgsql(fixture.Container.GetConnectionString())
+            .UseSnakeCaseNamingConvention()
+            .Options;
+        return new DiscordDbContext(options);
+    }
+}

--- a/tests/DiscordEventService.Tests/MemeIndexLiveAndSweepTests.cs
+++ b/tests/DiscordEventService.Tests/MemeIndexLiveAndSweepTests.cs
@@ -312,10 +312,11 @@ public sealed class MemeIndexLiveAndSweepTests(PostgresFixture fixture) : IClass
     }
 }
 
-// Captures enqueues without a storage backend.
+// Captures enqueues and state changes (e.g. Delete) without a storage backend.
 internal sealed class RecordingJobClient : IBackgroundJobClient
 {
     public List<Job> Created { get; } = [];
+    public List<(string JobId, string State)> StateChanges { get; } = [];
 
     public string Create(Job job, IState state)
     {
@@ -323,5 +324,9 @@ internal sealed class RecordingJobClient : IBackgroundJobClient
         return Created.Count.ToString();
     }
 
-    public bool ChangeState(string jobId, IState state, string expectedState) => true;
+    public bool ChangeState(string jobId, IState state, string expectedState)
+    {
+        StateChanges.Add((jobId, state.Name));
+        return true;
+    }
 }

--- a/tests/DiscordEventService.Tests/StartupBackfillSweepTests.cs
+++ b/tests/DiscordEventService.Tests/StartupBackfillSweepTests.cs
@@ -1,0 +1,153 @@
+using DiscordEventService.Data;
+using DiscordEventService.Data.Entities.Core;
+using DiscordEventService.Jobs;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging.Abstractions;
+using Xunit;
+
+namespace DiscordEventService.Tests;
+
+// #288: a Pending/InProgress checkpoint at boot belongs to a dead run — the sweep flips it to
+// Failed and deletes its recorded Hangfire job so the orphan cannot re-run after the sliding
+// invisibility timeout and interleave with the reconnect chain.
+public sealed class StartupBackfillSweepTests(PostgresFixture fixture)
+    : IClassFixture<PostgresFixture>, IAsyncLifetime
+{
+    private const ulong GuildId = 999_000_001UL;
+
+    private ServiceProvider _provider = null!;
+    private RecordingJobClient _jobClient = null!;
+
+    public async Task InitializeAsync()
+    {
+        await using var db = NewContext();
+        await db.Database.MigrateAsync();
+        await db.BackfillCheckpoints.ExecuteDeleteAsync();
+
+        _jobClient = new RecordingJobClient();
+        _provider = new ServiceCollection()
+            .AddDbContext<DiscordDbContext>(o => o
+                .UseNpgsql(fixture.Container.GetConnectionString())
+                .UseSnakeCaseNamingConvention())
+            .BuildServiceProvider();
+    }
+
+    public async Task DisposeAsync() => await _provider.DisposeAsync();
+
+    [Fact]
+    public async Task Sweep_FailsDeadCheckpoints_AndDeletesTheirJobs()
+    {
+        await SeedAsync(
+            Checkpoint(BackfillType.Messages, BackfillStatus.InProgress, "job-messages"),
+            Checkpoint(BackfillType.Reactions, BackfillStatus.Pending, "job-reactions"),
+            Checkpoint(BackfillType.MemeIndex, BackfillStatus.InProgress, "job-meme"));
+
+        await RunSweepAsync();
+
+        await using var db = NewContext();
+        var rows = await db.BackfillCheckpoints.Where(c => c.GuildDiscordId == GuildId).ToListAsync();
+        Assert.All(rows, c =>
+        {
+            Assert.Equal(BackfillStatus.Failed, c.Status);
+            Assert.Equal(1, c.ErrorCount);
+            Assert.Contains("restart", c.LastError);
+            Assert.NotNull(c.LastErrorAtUtc);
+        });
+
+        var deleted = _jobClient.StateChanges.Where(s => s.State == "Deleted").Select(s => s.JobId).ToList();
+        Assert.Equal(["job-meme", "job-messages", "job-reactions"], deleted.Order());
+    }
+
+    [Fact]
+    public async Task Sweep_LegacyRowWithoutJobId_StillFailsCheckpoint()
+    {
+        await SeedAsync(Checkpoint(BackfillType.Messages, BackfillStatus.InProgress, hangfireJobId: null));
+
+        await RunSweepAsync();
+
+        await using var db = NewContext();
+        var row = await db.BackfillCheckpoints.SingleAsync(c => c.GuildDiscordId == GuildId);
+        Assert.Equal(BackfillStatus.Failed, row.Status);
+        Assert.Empty(_jobClient.StateChanges);
+    }
+
+    // Live-caught on first boot: Hangfire's Delete throws when the job id no longer exists in
+    // storage; the sweep must still fail the checkpoint instead of crashing startup.
+    [Fact]
+    public async Task Sweep_JobDeleteThrows_StillFailsCheckpoint()
+    {
+        await SeedAsync(Checkpoint(BackfillType.Messages, BackfillStatus.InProgress, "gone-job"));
+
+        var sweep = new StartupBackfillSweep(
+            _provider.GetRequiredService<IServiceScopeFactory>(),
+            new ThrowingJobClient(),
+            NullLogger<StartupBackfillSweep>.Instance);
+        await sweep.SweepAsync();
+
+        await using var db = NewContext();
+        var row = await db.BackfillCheckpoints.SingleAsync(c => c.GuildDiscordId == GuildId);
+        Assert.Equal(BackfillStatus.Failed, row.Status);
+    }
+
+    [Fact]
+    public async Task Sweep_TerminalCheckpoints_AreUntouched()
+    {
+        await SeedAsync(
+            Checkpoint(BackfillType.Roles, BackfillStatus.Completed, "job-roles"),
+            Checkpoint(BackfillType.Messages, BackfillStatus.Failed, "job-messages"),
+            Checkpoint(BackfillType.Reactions, BackfillStatus.Cancelled, "job-reactions"));
+
+        await RunSweepAsync();
+
+        await using var db = NewContext();
+        var rows = await db.BackfillCheckpoints.Where(c => c.GuildDiscordId == GuildId).ToListAsync();
+        Assert.All(rows, c => Assert.Equal(0, c.ErrorCount));
+        Assert.Equal(BackfillStatus.Completed,
+            rows.Single(c => c.Type == BackfillType.Roles).Status);
+        Assert.Empty(_jobClient.StateChanges);
+    }
+
+    private static BackfillCheckpointEntity Checkpoint(
+        BackfillType type, BackfillStatus status, string? hangfireJobId) => new()
+        {
+            GuildDiscordId = GuildId,
+            Type = type,
+            Status = status,
+            HangfireJobId = hangfireJobId,
+            StartedAtUtc = DateTime.UtcNow
+        };
+
+    private async Task SeedAsync(params BackfillCheckpointEntity[] checkpoints)
+    {
+        await using var db = NewContext();
+        db.BackfillCheckpoints.AddRange(checkpoints);
+        await db.SaveChangesAsync();
+    }
+
+    private async Task RunSweepAsync()
+    {
+        var sweep = new StartupBackfillSweep(
+            _provider.GetRequiredService<IServiceScopeFactory>(),
+            _jobClient,
+            NullLogger<StartupBackfillSweep>.Instance);
+        await sweep.SweepAsync();
+    }
+
+    private DiscordDbContext NewContext()
+    {
+        var options = new DbContextOptionsBuilder<DiscordDbContext>()
+            .UseNpgsql(fixture.Container.GetConnectionString())
+            .UseSnakeCaseNamingConvention()
+            .Options;
+        return new DiscordDbContext(options);
+    }
+}
+
+internal sealed class ThrowingJobClient : Hangfire.IBackgroundJobClient
+{
+    public string Create(Hangfire.Common.Job job, Hangfire.States.IState state) => "1";
+
+    public bool ChangeState(string jobId, Hangfire.States.IState state, string expectedState)
+        => throw new Hangfire.BackgroundJobClientException("state change failed", new FormatException(jobId));
+}


### PR DESCRIPTION
Fixes #288, fixes #289.

## What

Two checkpoint-lifecycle fixes sharing one foundation: the orchestrator now records every chain job's Hangfire id on its checkpoint row **before** the job runs.

### #289 — atomic per-guild chain guard
`GuildBackfillOrchestrator.EnqueueChain` is now the single authoritative guard against overlapping chains:
- Takes a **session-level Postgres advisory lock** keyed on the guild id, so the active-chain check and the enqueue are atomic across all three triggers (manual endpoint, reconnect, periodic).
- Skips (returns `null`) when any checkpoint is **chain-active**: fresh `InProgress` *or* fresh `Pending` — the new `Pending`-with-job-id rows close the previously unguarded enqueue→first-job gap.
- First chain job is scheduled with a 5s delay so the checkpoint rows land before any status flips.
- The duplicated read-then-enqueue skip checks in `SocketLifecycleHandler`, `PeriodicFullBackfillJob`, and `BackfillEndpoints` are deleted.

### #288 — startup sweep
`StartupBackfillSweep` runs after migrations and **before the Hangfire server starts**: flips every `Pending`/`InProgress` checkpoint to `Failed` and deletes its recorded Hangfire job. Verified interaction with Hangfire persisted-job semantics: storage is Postgres with a 15-min sliding invisibility timeout, so a hard-killed job's chain *does* survive restart and would be re-fetched — deleting the recorded jobs (not just flipping status) is what prevents the orphan re-run from interleaving with the reconnect chain. Job deletion is fault-tolerant (a missing/expired job id logs a warning instead of crashing boot — caught live).

### Also
- The cancel endpoint's job-delete was a **silent no-op** (HangfireJobId was never written for backfill chains) — now functional, and extended to cover `Pending` chain jobs.
- Stale-`InProgress` rows keep their status when a new chain is recorded, preserving the executor's cursor resume from #282/PR #285; the heartbeat bump alone re-arms the guard.
- MemeIndex (type 7) checkpoints are excluded from the chain guard but **are** swept at boot (their job ids are recorded by the ops endpoint) — this also resolves the restart case of #293 item 2.

## Behavior change worth noting
A chain that would previously survive a graceful deploy (continuations resuming post-restart) is now killed at boot; coverage falls to the reconnect backfill (≤2 days) and the Sunday full sweep (14 days). Clean invariant preferred over partially-resumed chains writing to swept checkpoints.

## Testing
- 9 new Testcontainers tests: chain guard (pending recording, skip-while-fresh, concurrency via parallel triggers, stale-resume preservation, terminal-not-blocking, cross-guild independence) + sweep (flip+delete, legacy null job id, delete-throws resilience, terminal untouched). Full suite: 277 passed.
- Live on dev bot: boot sweep flipped seeded dead checkpoints; POST while chain active → 400; **hard-kill mid-chain → sweep deleted orphan jobs 4040/4041 (confirmed `Deleted` in Hangfire storage) → reconnect chain enqueued 3 min later, ran to completion cleanly** — the exact #288 starvation scenario, now recovering immediately instead of waiting for Sunday.

🤖 Generated with [Claude Code](https://claude.com/claude-code)