### PR TITLE
fix: mount postgres_data at /var/lib/postgresql for postgres:18 images

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,7 +12,9 @@ services:
     ports:
       - "5432:5432"
     volumes:
-      - postgres_data:/var/lib/postgresql/data
+      # postgres:18 images moved the data root up a level (docker-library/postgres#1259);
+      # mounting at .../data makes the container refuse to start.
+      - postgres_data:/var/lib/postgresql
     healthcheck:
       test: ["CMD-SHELL", "pg_isready -U postgres"]
       interval: 10s


### PR DESCRIPTION
Newer `postgres:18` images ([docker-library/postgres#1259](https://github.com/docker-library/postgres/pull/1259)) refuse to boot when the volume is mounted at `/var/lib/postgresql/data` — hit locally after a fresh image pull. Mount moved to `/var/lib/postgresql`. Local dev compose only; prod compose is separate and unaffected (verified running).

🤖 Generated with [Claude Code](https://claude.com/claude-code)