### PR TITLE
fix: #297 ignore case-only username changes in name-history detection

### DIFF
--- a/src/DiscordEventService/Services/UserService.cs
+++ b/src/DiscordEventService/Services/UserService.cs
@@ -16,11 +16,19 @@ internal sealed class UserService(DiscordDbContext db, ILogger<UserService> logg
             .Select(u => new { u.Id, u.Username, u.GlobalName })
             .FirstOrDefaultAsync();
 
-        if (existing is not null && (existing.Username != user.Username || existing.GlobalName != user.GlobalName))
+        if (existing is not null && (UsernameChangedForHistory(existing.Username, user.Username) || existing.GlobalName != user.GlobalName))
             return await UpdateUserWithNameHistoryAsync(user, existing.Username, existing.GlobalName, existing.Id);
 
         return await UpsertUserUnchangedAsync(user);
     }
+
+    // Case-only username differences are not name changes: Discord usernames are lowercase-only
+    // post-migration, but system users (e.g. Clyde) come back as "Clyde" from one API surface and
+    // "clyde" from another, which otherwise flips a history-row pair on every backfill run (#297).
+    // The latest casing is still persisted; only the history trigger ignores case. GlobalName is a
+    // display name where casing is a deliberate user choice, so it stays case-sensitive.
+    private static bool UsernameChangedForHistory(string? oldUsername, string? newUsername) =>
+        !string.Equals(oldUsername, newUsername, StringComparison.OrdinalIgnoreCase);
 
     // A name change is the only flow that issues a SECOND write (the history row) after
     // updating the user. Do it as load-modify-save committed in a SINGLE SaveChanges so the
@@ -31,7 +39,7 @@ internal sealed class UserService(DiscordDbContext db, ILogger<UserService> logg
     private async Task<UpsertResult<Guid>> UpdateUserWithNameHistoryAsync(
         DiscordUser user, string? oldUsername, string? oldGlobalName, Guid existingId)
     {
-        var usernameChanged = oldUsername != user.Username;
+        var usernameChanged = UsernameChangedForHistory(oldUsername, user.Username);
         var globalNameChanged = oldGlobalName != user.GlobalName;
 
         var entity = await db.Users.FirstOrDefaultAsync(u => u.DiscordId == user.Id);

--- a/tests/DiscordEventService.Tests/UserUpsertTests.cs
+++ b/tests/DiscordEventService.Tests/UserUpsertTests.cs
@@ -89,6 +89,44 @@ public sealed class UserUpsertTests(PostgresFixture fixture) : IClassFixture<Pos
         Assert.Equal(0, await verify.UserNameHistory.CountAsync());
     }
 
+    [Fact]
+    public async Task UpsertUserAsync_WhenUsernameCaseOnlyChanged_PersistsCasingWithoutHistory()
+    {
+        var service = new UserService(_db, NullLogger<UserService>.Instance);
+        await service.UpsertUserAsync(MakeUser(600UL, "clyde", "Clyde"));
+        _db.ChangeTracker.Clear();
+
+        // System users case-flap between API surfaces (#297): the new casing must be persisted,
+        // but a case-only username difference must not produce a name-history row.
+        await service.UpsertUserAsync(MakeUser(600UL, "Clyde", "Clyde"));
+
+        await using var verify = NewContext();
+        var row = await verify.Users.SingleAsync(u => u.DiscordId == 600UL);
+        Assert.Equal("Clyde", row.Username);
+        Assert.Equal(0, await verify.UserNameHistory.CountAsync());
+    }
+
+    [Fact]
+    public async Task UpsertUserAsync_WhenUsernameCaseFlappedAndGlobalNameChanged_RecordsOnlyGlobalName()
+    {
+        var service = new UserService(_db, NullLogger<UserService>.Instance);
+        await service.UpsertUserAsync(MakeUser(700UL, "clyde", "Clyde"));
+        _db.ChangeTracker.Clear();
+
+        await service.UpsertUserAsync(MakeUser(700UL, "Clyde", "Clyde AI"));
+
+        await using var verify = NewContext();
+        var row = await verify.Users.SingleAsync(u => u.DiscordId == 700UL);
+        Assert.Equal("Clyde", row.Username);
+        Assert.Equal("Clyde AI", row.GlobalName);
+
+        var history = await verify.UserNameHistory.SingleAsync(h => h.UserId == row.Id);
+        Assert.Null(history.UsernameBefore);
+        Assert.Null(history.UsernameAfter);
+        Assert.Equal("Clyde", history.GlobalNameBefore);
+        Assert.Equal("Clyde AI", history.GlobalNameAfter);
+    }
+
     private DiscordDbContext NewContext()
     {
         var options = new DbContextOptionsBuilder<DiscordDbContext>()


### PR DESCRIPTION
Closes #297

## Problem
Every backfill run wrote a paired `Clyde→clyde` + `clyde→Clyde` into `user_name_history` for Discord's system bot Clyde (`discord_id 1081004946872352958`). Two API surfaces exercised within one backfill chain disagree on the casing of system-user usernames, and `UserService` name-change detection treated the case flip as a real name change — twice per run, producing history-row pairs that cancel out (8 junk rows so far, growing with the Sunday periodic).

## Fix
Case-only username differences no longer trigger the name-history path (`StringComparison.OrdinalIgnoreCase` in the history-trigger comparison only). The latest casing is still persisted via the normal upsert. `GlobalName` comparison stays case-sensitive — display-name casing is a deliberate user choice; usernames are the only lowercase-normalized field where case drift can't be a real change.

## Tests
Two new Testcontainers cases in `UserUpsertTests` (real Postgres, no mocking):
- case-only username flip → new casing persisted, **no** history row
- case-only username flip + real GlobalName change → history row records only the GlobalName fields

All 6 tests in the class pass.

## Verification plan
The Sunday periodic backfill (2026-07-20 03:00) is the real-world check: no new Clyde pair should appear in `user_name_history` after this deploys. The 8 existing junk rows are left untouched (prod DB is read-only by convention — cleanup, if wanted, is a separate decision).

🤖 Generated with [Claude Code](https://claude.com/claude-code)