### PR TITLE
fix: #297 upsert backfill authors/reactors only for newly recorded rows

### DIFF
--- a/src/DiscordEventService/Jobs/MessagesBackfillJob.cs
+++ b/src/DiscordEventService/Jobs/MessagesBackfillJob.cs
@@ -167,12 +167,17 @@ internal sealed class MessagesBackfillJob(
             return false;
         }
 
+        var exists = await db.Messages.AnyAsync(m => m.DiscordId == message.Id, cancellationToken);
+        if (exists) return false;
+
+        // Upsert the author only for messages we are about to insert (#297): re-scrolled batches
+        // contain already-stored messages whose author payloads can differ in shape between
+        // Discord surfaces (e.g. the deactivated Clyde bot flip-flops username casing and
+        // global_name presence), churning user_name_history on every run. Current members are
+        // kept fresh by MembersBackfillJob and live events.
         await userService.UpsertUserAsync(message.Author);
 
         var authorEntity = await db.Users.FirstOrDefaultAsync(u => u.DiscordId == message.Author.Id, cancellationToken);
-
-        var exists = await db.Messages.AnyAsync(m => m.DiscordId == message.Id, cancellationToken);
-        if (exists) return false;
 
         // §P2.6: MessageEntity.ChannelId/GuildId/AuthorId are NOT NULL. Skip
         // if any required FK row hasn't been backfilled yet — next run of

--- a/src/DiscordEventService/Jobs/ReactionsBackfillJob.cs
+++ b/src/DiscordEventService/Jobs/ReactionsBackfillJob.cs
@@ -143,8 +143,6 @@ internal sealed class ReactionsBackfillJob(
             {
                 cancellationToken.ThrowIfCancellationRequested();
 
-                await userService.UpsertUserAsync(user);
-
                 var exists = await db.ReactionEvents.AnyAsync(r =>
                     r.MessageDiscordId == message.Id &&
                     r.UserDiscordId == user.Id &&
@@ -154,6 +152,10 @@ internal sealed class ReactionsBackfillJob(
 
                 if (!exists)
                 {
+                    // Upsert only reactors we are about to record (#297): re-scrolled reactions
+                    // would otherwise re-upsert every reactor each run, churning user rows.
+                    await userService.UpsertUserAsync(user);
+
                     db.ReactionEvents.Add(new ReactionEventEntity
                     {
                         MessageDiscordId = message.Id,


### PR DESCRIPTION
Closes #297 (follow-up to #299, which silenced only the username half of the trigger)

## Root cause (traced from prod logs + data)
The Sunday periodic run's flip pair fired at 03:00:48, inside the **first batch** of the `dev` channel (720625250756198400) message scroll that started at 03:00:47. The periodic window (after 2026-07-05) limits *inserts*, but each batch still fetches the newest 100 messages — and in that near-dead channel those reach back to the 2023 Clyde-AI conversations. `TryInsertBackfilledMessageAsync` upserted `message.Author` **before** the message-exists check, so every run re-upserted Clyde from old payloads that arrive in two shapes (`username=clyde, global_name=Clyde` vs `username=Clyde, global_name=null` — confirmed by the paired "User name changed" log lines 25ms apart).

`ReactionsBackfillJob` had the same pattern for reactors.

## Fix
Move the author upsert after the exists check (messages) and inside the new-reaction branch (reactions) — upsert users only when we're about to record their content, mirroring `BootQuickSyncService`, which already does this. Current members keep getting refreshed by `MembersBackfillJob` and live gateway events (yesterday's genuine `Miki x-kom → Vicio x-kom` rename came through the live path).

Side benefit: a full re-scroll no longer issues an author upsert per already-stored message (thousands of redundant writes per weekly run).

## Verification (dev bot, local DB)
The dev guild reproduced the same disease class with a webhook author (same id, per-message display names):
- Run 1 (fresh scroll): 845 messages inserted, 6 history rows from that webhook author while its messages were being newly inserted — legitimate.
- Run 2 (identical, everything exists): **0 inserts, 0 new history rows, 0 author upserts**. Under the old code run 2 would have flapped again.

No exceptions in either run.

## Prod expectation after deploy
No new Clyde pair on the next periodic run (2026-07-26 03:00); the residual global-name pair predicted for 2026-07-20 03:00 only happens if this isn't deployed before then.

🤖 Generated with [Claude Code](https://claude.com/claude-code)