### PR TITLE
fix: #298 null-guard AuditLogEntry in AuditLogEventHandler

### DIFF
--- a/src/DiscordEventService/Services/EventHandlers/AuditLogEventHandler.cs
+++ b/src/DiscordEventService/Services/EventHandlers/AuditLogEventHandler.cs
@@ -10,9 +10,20 @@ internal sealed class AuditLogEventHandler(EventPipeline pipeline) :
 {
     public async Task HandleEventAsync(DiscordClient sender, GuildAuditLogCreatedEventArgs e)
     {
+        // DSharpPlus leaves AuditLogEntry null for audit-log kinds it doesn't materialize
+        // (#298: one NRE'd here 2026-05-05 before the pipeline could even capture the payload).
+        // Guard the argument dereference too — it evaluates before ExecuteAsync's try/catch.
         await pipeline.ExecuteAsync(e, "GuildAuditLogCreated", nameof(AuditLogEventHandler),
-            e.Guild.Id, null, e.AuditLogEntry.UserResponsible?.Id, async ctx =>
+            e.Guild.Id, null, e.AuditLogEntry?.UserResponsible?.Id, async ctx =>
             {
+                if (e.AuditLogEntry is null)
+                {
+                    ctx.Logger.LogWarning(
+                        "AuditLogEntry not materialized for guild {GuildId}; skipping typed insert, raw payload kept in raw_event_logs",
+                        e.Guild.Id);
+                    return;
+                }
+
                 ctx.Db.AuditLogEvents.Add(new AuditLogEventEntity
                 {
                     AuditLogDiscordId = e.AuditLogEntry.Id,


### PR DESCRIPTION
Closes #298

## Problem
`AuditLogEventHandler` dereferences `e.AuditLogEntry` unguarded. DSharpPlus leaves it null for audit-log kinds it doesn't materialize — the single prod occurrence (2026-05-05, guild 341531063920754700) NRE'd at the *argument* dereference (`e.AuditLogEntry.UserResponsible?.Id`), which evaluates before `pipeline.ExecuteAsync`'s try/catch, so the dead-letter row captured an **empty** `event_json` (verified in prod: the row has no payload).

## Fix
- `e.AuditLogEntry?.UserResponsible?.Id` in the pipeline arguments (the pre-pipeline crash spot).
- Null-guard inside the handler lambda: log a warning and skip the typed `audit_log_events` insert. The pipeline has already raw-logged the full payload into `raw_event_logs` at that point, so nothing is lost; a recurrence is now a visible warning instead of a silent dead-letter.

## Stored row fate
The 2026-05-05 `failed_events` row (`019df990-6d8c-7c33-b730-8bcbfd849dca`) has empty `event_json` — nothing to replay. Plan: after this deploys, mark it resolved via the sanctioned `POST /api/ops/failed-events/{id}/resolve` endpoint with a note pointing at this PR.

## Verification
Null-`AuditLogEntry` events can't be triggered on demand (depends on Discord emitting an unmaterialized kind); the happy path is unchanged code that prod exercises on every audit-loggable action. Post-deploy check: normal audit events keep inserting, no new NRE/warning patterns in Loki.

🤖 Generated with [Claude Code](https://claude.com/claude-code)