### PR TITLE
fix: #293 meme indexing — transient-error attempt refunds + stale-checkpoint recovery

### DIFF
--- a/src/DiscordEventService/Endpoints/MemeIndexEndpoints.cs
+++ b/src/DiscordEventService/Endpoints/MemeIndexEndpoints.cs
@@ -38,8 +38,13 @@ internal static class MemeIndexEndpoints
         if (string.IsNullOrWhiteSpace(openRouterOptions.Value.Model))
             return Results.BadRequest(new { error = "OpenRouter:Model is not set" });
 
-        var inProgress = await db.BackfillCheckpoints.AnyAsync(c =>
-            c.GuildDiscordId == guildId && c.Type == BackfillType.MemeIndex && c.Status == BackfillStatus.InProgress);
+        // Staleness-aware (#293), mirroring MemeIndexSweepJob: a dead job's InProgress checkpoint
+        // must not require manual DB surgery before indexing can be restarted.
+        var nowUtc = DateTime.UtcNow;
+        var inProgress = (await db.BackfillCheckpoints.AsNoTracking()
+                .Where(c => c.GuildDiscordId == guildId && c.Type == BackfillType.MemeIndex && c.Status == BackfillStatus.InProgress)
+                .ToListAsync())
+            .Any(c => c.IsActivelyInProgress(nowUtc));
         if (inProgress)
             return Results.BadRequest(new { error = "Meme indexing already in progress for this guild" });
 

--- a/src/DiscordEventService/Jobs/MemeIndexSweepJob.cs
+++ b/src/DiscordEventService/Jobs/MemeIndexSweepJob.cs
@@ -41,11 +41,16 @@ internal sealed class MemeIndexSweepJob(
             .Distinct()
             .ToListAsync(cancellationToken);
 
-        var inProgress = await db.BackfillCheckpoints.AsNoTracking()
-            .Where(c => c.Type == BackfillType.MemeIndex && c.Status == BackfillStatus.InProgress)
+        // Staleness-aware (#293): a checkpoint whose job died before writing a terminal status
+        // stays InProgress forever and would block the guild's sweep permanently. The heartbeat
+        // predicate (see #282/#285) treats it as dead; the executor resumes it from its cursor.
+        var nowUtc = DateTime.UtcNow;
+        var inProgressSet = (await db.BackfillCheckpoints.AsNoTracking()
+                .Where(c => c.Type == BackfillType.MemeIndex && c.Status == BackfillStatus.InProgress)
+                .ToListAsync(cancellationToken))
+            .Where(c => c.IsActivelyInProgress(nowUtc))
             .Select(c => c.GuildDiscordId)
-            .ToListAsync(cancellationToken);
-        var inProgressSet = inProgress.ToHashSet();
+            .ToHashSet();
 
         foreach (var guildId in guildIds)
         {

--- a/src/DiscordEventService/Services/MemeIndexing/MemeAttachmentIndexer.cs
+++ b/src/DiscordEventService/Services/MemeIndexing/MemeAttachmentIndexer.cs
@@ -135,7 +135,7 @@ internal sealed class MemeAttachmentIndexer(
         catch (Exception ex) when (ex is HttpRequestException
             || (ex is TaskCanceledException && !cancellationToken.IsCancellationRequested))
         {
-            Fail(row, counters, $"download failed: {ex.Message}");
+            FailTransient(row, counters, $"transient: download failed: {ex.Message}");
             return null;
         }
     }
@@ -194,7 +194,10 @@ internal sealed class MemeAttachmentIndexer(
                 break;
 
             default:
-                Fail(row, counters, result.Error ?? "unknown analysis error");
+                if (result.IsTransient)
+                    FailTransient(row, counters, $"transient: {result.Error ?? "unknown analysis error"}");
+                else
+                    Fail(row, counters, result.Error ?? "unknown analysis error");
                 break;
         }
     }
@@ -205,6 +208,16 @@ internal sealed class MemeAttachmentIndexer(
         row.Error = reason;
         counters.Skipped++;
         logger.LogWarning("Meme attachment {AttachmentId} skipped: {Reason}", row.AttachmentDiscordId, reason);
+    }
+
+    // Transient failures (429/5xx, transport, download hiccups) must not burn one of the sweep's
+    // capped attempts (#293): refund the increment from ProcessOneAsync so only deterministic
+    // failures walk the row toward permanent abandonment. Status still flips to Failed so the
+    // next sweep retries it.
+    private void FailTransient(MemeIndexEntity row, MemeIndexRunCounters counters, string error)
+    {
+        row.AttemptCount--;
+        Fail(row, counters, error);
     }
 
     private void Fail(MemeIndexEntity row, MemeIndexRunCounters counters, string error)

--- a/tests/DiscordEventService.Tests/MemeIndexLiveAndSweepTests.cs
+++ b/tests/DiscordEventService.Tests/MemeIndexLiveAndSweepTests.cs
@@ -204,6 +204,32 @@ public sealed class MemeIndexLiveAndSweepTests(PostgresFixture fixture) : IClass
     }
 
     [Fact]
+    public async Task ExecuteAsync_GuildWithStaleInProgressCheckpoint_IsSwept()
+    {
+        _db.BackfillCheckpoints.Add(new BackfillCheckpointEntity
+        {
+            GuildDiscordId = GuildDiscordId,
+            Type = BackfillType.MemeIndex,
+            Status = BackfillStatus.InProgress,
+            StartedAtUtc = DateTime.UtcNow
+        });
+        await _db.SaveChangesAsync();
+        // ITimestamped bumps LastUpdatedUtc on every SaveChanges; ExecuteUpdate bypasses it so the
+        // heartbeat can be aged past the staleness cutoff (#293: dead job must not block the sweep).
+        await _db.BackfillCheckpoints
+            .Where(c => c.GuildDiscordId == GuildDiscordId && c.Type == BackfillType.MemeIndex)
+            .ExecuteUpdateAsync(s => s.SetProperty(
+                c => c.LastUpdatedUtc,
+                DateTime.UtcNow - BackfillCheckpointEntity.StaleInProgressAfter - TimeSpan.FromMinutes(1)));
+        var jobClient = new RecordingJobClient();
+
+        await RunCoordinatorAsync(jobClient, configured: true);
+
+        var job = Assert.Single(jobClient.Created);
+        Assert.Equal(nameof(MemeIndexingJob.ExecuteSweepAsync), job.Method.Name);
+    }
+
+    [Fact]
     public async Task ExecuteAsync_Unconfigured_IsANoOp()
     {
         var jobClient = new RecordingJobClient();

--- a/tests/DiscordEventService.Tests/MemeIndexingJobTests.cs
+++ b/tests/DiscordEventService.Tests/MemeIndexingJobTests.cs
@@ -142,7 +142,10 @@ public sealed class MemeIndexingJobTests(PostgresFixture fixture) : IClassFixtur
         Assert.Equal(MemeIndexStatus.Skipped, byId[11UL].Status);
         Assert.StartsWith("model refusal", byId[11UL].Error);
         Assert.Equal(MemeIndexStatus.Failed, byId[12UL].Status);
-        Assert.Equal(1, byId[12UL].AttemptCount);
+        // Transient model errors refund the attempt (#293): only deterministic failures
+        // may walk a row toward the sweep's permanent-abandonment cap.
+        Assert.Equal(0, byId[12UL].AttemptCount);
+        Assert.StartsWith("transient", byId[12UL].Error);
         Assert.Equal(MemeIndexStatus.Skipped, byId[13UL].Status);
         Assert.StartsWith("unsupported", byId[13UL].Error);
         Assert.Equal(MemeIndexStatus.Skipped, byId[14UL].Status);
@@ -157,7 +160,7 @@ public sealed class MemeIndexingJobTests(PostgresFixture fixture) : IClassFixtur
         await using var verify2 = NewContext();
         var retried = await verify2.MemeIndex.SingleAsync(m => m.AttachmentDiscordId == 12UL);
         Assert.Equal(MemeIndexStatus.Indexed, retried.Status);
-        Assert.Equal(2, retried.AttemptCount);
+        Assert.Equal(1, retried.AttemptCount);
         Assert.Null(retried.Error);
     }
 


### PR DESCRIPTION
Addresses items 1–2 of #293 (the two that matter before the #223 prod backfill; items 3–5 remain open on the issue).

## Item 1 — transient errors no longer burn the sweep attempt cap
`OpenRouterClient` already classifies 408/429/5xx and transport failures as transient (`MemeAnalysisResult.IsTransient`), but `MemeAttachmentIndexer` ignored the flag: every transient failure did `Failed` + kept the `AttemptCount++`, so three unlucky tries abandoned the row permanently (sweep cap 3). New `FailTransient` refunds the attempt — status still flips to `Failed` so the next sweep retries, but only deterministic failures walk a row toward abandonment. Transient CDN download errors get the same treatment; the URL-refresh path already behaved this way since PR #262.

## Item 2 — stuck `InProgress` checkpoint no longer blocks the guild
`MemeIndexSweepJob` and the `POST /api/ops/meme-index/start` guard refused to run while a `MemeIndex` checkpoint sat `InProgress`, with no staleness cutoff — a dead Hangfire job meant manual DB surgery (same disease as #282). Both now use the `IsActivelyInProgress` heartbeat predicate shipped in PR #285 (meme indexing shares the same checkpoint table/executor, which already resumes a stale row from its cursor).

## Tests (Testcontainers, real Postgres, faked HTTP)
- `ExecuteAsync_OutcomeMapping_SkippedVsFailed` updated: it previously **asserted the buggy behavior** (`AttemptCount == 1` after a transient 500). Now asserts the refund (0 after transient failure, 1 after the successful retry) and the `transient` error marker.
- New `ExecuteAsync_GuildWithStaleInProgressCheckpoint_IsSwept`: fresh `InProgress` still skips (existing test), aged heartbeat (>1h via `ExecuteUpdate` to bypass the `ITimestamped` bump) now enqueues.
- All 27 meme-index tests pass.

Live-verify note: transient 429/5xx can't be forced against the dev OpenRouter path on demand; the Testcontainers suite drives the real indexer/sweep code against real Postgres with a faked HTTP boundary, which is the strongest available signal for these two contracts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)