### PR TITLE
fix: #293 items 3-5 — cap-split resume cursor, oversized pre-skip, resume progress total

### DIFF
--- a/src/DiscordEventService/Jobs/MemeIndexingJob.cs
+++ b/src/DiscordEventService/Jobs/MemeIndexingJob.cs
@@ -98,24 +98,26 @@ internal sealed class MemeIndexingJob(
             var urlRefreshService = ctx.Services.GetRequiredService<AttachmentUrlRefreshService>();
             var indexer = ctx.Services.GetRequiredService<MemeAttachmentIndexer>();
 
-            var pending = await CollectPendingAsync(
+            var allPending = await CollectPendingAsync(
                 ctx.Db, sampleService, guildId, ctx.Checkpoint, maxFailedAttempts, cancellationToken);
 
             var cap = memeOptions.MaxImagesPerRun;
-            var capped = pending.Count > cap;
+            var capped = allPending.Count > cap;
+            var pending = allPending;
             if (capped)
             {
                 logger.LogInformation(
                     "Meme indexing for guild {GuildId}: {Pending} attachments pending, capping this run at {Cap}",
-                    guildId, pending.Count, cap);
-                pending = pending.Take(cap).ToList();
+                    guildId, allPending.Count, cap);
+                pending = allPending.Take(cap).ToList();
             }
 
             // A fresh run (no resume cursor) restarts the per-run progress pair;
-            // a mid-flight resume keeps accumulating into it.
+            // a mid-flight resume keeps accumulating into it, so the total must
+            // include the prior progress or status shows processed > total.
             if (ctx.Checkpoint.LastProcessedId is null)
                 ctx.Checkpoint.ProcessedCount = 0;
-            ctx.Checkpoint.TotalCount = pending.Count;
+            ctx.Checkpoint.TotalCount = ctx.Checkpoint.ProcessedCount + pending.Count;
             await ctx.Db.SaveChangesAsync(cancellationToken);
 
             if (pending.Count == 0)
@@ -128,8 +130,14 @@ internal sealed class MemeIndexingJob(
                 "Meme indexing starting for guild {GuildId}: {Count} attachments, model {Model}",
                 guildId, pending.Count, openRouterOptions.Model);
 
+            // When the cap slices a multi-attachment message in half, the last capped
+            // item is NOT the end of its message — the cursor must not advance past it.
+            ulong? messageSplitByCap = capped && allPending[cap].MessageDiscordId == pending[^1].MessageDiscordId
+                ? pending[^1].MessageDiscordId
+                : null;
+
             var counters = new MemeIndexRunCounters();
-            await ProcessPendingBatchesAsync(ctx, indexer, urlRefreshService, pending, counters, cancellationToken);
+            await ProcessPendingBatchesAsync(ctx, indexer, urlRefreshService, pending, messageSplitByCap, counters, cancellationToken);
 
             logger.LogInformation(
                 "Meme indexing finished for guild {GuildId}: {Indexed} indexed, {Deduped} deduped, {Skipped} skipped, {Failed} failed; " +
@@ -211,6 +219,7 @@ internal sealed class MemeIndexingJob(
         MemeAttachmentIndexer indexer,
         AttachmentUrlRefreshService urlRefreshService,
         List<MemeSampleItem> pending,
+        ulong? messageSplitByCap,
         MemeIndexRunCounters counters,
         CancellationToken cancellationToken)
     {
@@ -234,7 +243,8 @@ internal sealed class MemeIndexingJob(
                 // Advance the resume cursor only once a message's LAST pending
                 // attachment is done — a mid-message cursor would skip siblings.
                 var lastOfMessage = position == pending.Count
-                    || pending[position].MessageDiscordId != item.MessageDiscordId;
+                    ? item.MessageDiscordId != messageSplitByCap
+                    : pending[position].MessageDiscordId != item.MessageDiscordId;
                 if (lastOfMessage)
                     ctx.Checkpoint.LastProcessedId = item.MessageDiscordId;
 

--- a/src/DiscordEventService/Program.cs
+++ b/src/DiscordEventService/Program.cs
@@ -135,7 +135,14 @@ builder.Services.AddHttpClient(OpenRouterClient.HttpClientName)
     });
 
 builder.Services.AddHttpClient(MemeBenchmarkJob.DownloadHttpClientName)
-    .ConfigureHttpClient(client => client.Timeout = memeDownloadTimeout);
+    .ConfigureHttpClient((sp, client) =>
+    {
+        client.Timeout = memeDownloadTimeout;
+        // Hard cap on buffering: attachments whose metadata lied small still
+        // can't pull an unbounded body into memory (#293).
+        client.MaxResponseContentBufferSize =
+            sp.GetRequiredService<IOptions<MemeIndexOptions>>().Value.MaxImageBytes;
+    });
 
 builder.Services.AddHttpClient(AttachmentUrlRefreshService.HttpClientName)
     .ConfigureHttpClient(client =>

--- a/src/DiscordEventService/Services/MemeIndexing/MemeAttachmentIndexer.cs
+++ b/src/DiscordEventService/Services/MemeIndexing/MemeAttachmentIndexer.cs
@@ -62,6 +62,16 @@ internal sealed class MemeAttachmentIndexer(
         var memeOptions = memeIndexOptions.Value;
         var openRouter = openRouterOptions.Value;
 
+        // Discord metadata already carries the size — pre-skip oversized files
+        // before spending a download. Deterministic, so no attempt is charged.
+        // (0 = unknown size from pre-#221 data; those still go through the
+        // post-download check below.)
+        if (item.FileSizeBytes > memeOptions.MaxImageBytes)
+        {
+            Skip(row, counters, $"unsupported: image too large ({item.FileSizeBytes} bytes per metadata)");
+            return;
+        }
+
         var refreshOutcome = freshUrls.GetFreshUrl(item.StoredUrl, out var freshUrl);
         if (refreshOutcome == AttachmentUrlRefreshOutcome.BatchFailed)
         {
@@ -130,6 +140,14 @@ internal sealed class MemeAttachmentIndexer(
             or System.Net.HttpStatusCode.Forbidden or System.Net.HttpStatusCode.Gone)
         {
             Skip(row, counters, $"dead attachment: download HTTP {(int)ex.StatusCode!}");
+            return null;
+        }
+        catch (HttpRequestException ex) when (ex.HttpRequestError == HttpRequestError.ConfigurationLimitExceeded)
+        {
+            // The discord-cdn client caps buffering at MaxImageBytes; blowing it is
+            // deterministic (metadata lied small), so terminal Skip — a transient
+            // Failed would be refunded and retried by every sweep forever.
+            Skip(row, counters, "unsupported: image too large (exceeded download buffer cap)");
             return null;
         }
         catch (Exception ex) when (ex is HttpRequestException

--- a/tests/DiscordEventService.Tests/MemeIndexingJobTests.cs
+++ b/tests/DiscordEventService.Tests/MemeIndexingJobTests.cs
@@ -16,6 +16,8 @@ public sealed class MemeIndexingJobTests(PostgresFixture fixture) : IClassFixtur
 {
     private const ulong GuildDiscordId = 1UL;
     private const ulong ChannelDiscordId = 2UL;
+    // Mirrors the MemeIndexOptions.MaxImageBytes default.
+    private const int DefaultMaxImageBytes = 25 * 1024 * 1024;
 
     private DiscordDbContext _db = null!;
     private GuildEntity _guild = null!;
@@ -320,11 +322,111 @@ public sealed class MemeIndexingJobTests(PostgresFixture fixture) : IClassFixtur
         Assert.Equal(3, _http.ModelCalls);
     }
 
-    private Task RunJobAsync(int maxImagesPerRun = 500) => RunAsync(maxImagesPerRun, sweep: false);
+    [Fact]
+    public async Task ExecuteAsync_MetadataOversizedAttachment_SkippedWithoutDownload()
+    {
+        // Discord already told us the file size — an attachment over MaxImageBytes
+        // must be pre-skipped from metadata, not buffered in full first.
+        AddMessage(1001UL, Attachment(11UL, "huge.png", fileSize: 26L * 1024 * 1024));
+        await _db.SaveChangesAsync();
+        _http.SetImage(11UL, Png(1));
 
-    private Task RunSweepAsync() => RunAsync(maxImagesPerRun: 500, sweep: true);
+        await RunJobAsync();
 
-    private async Task RunAsync(int maxImagesPerRun, bool sweep)
+        await using var verify = NewContext();
+        var row = await verify.MemeIndex.SingleAsync(m => m.AttachmentDiscordId == 11UL);
+        Assert.Equal(MemeIndexStatus.Skipped, row.Status);
+        Assert.StartsWith("unsupported: image too large", row.Error);
+        Assert.Equal(0, _http.CdnRequests);
+        Assert.Equal(0, _http.ModelCalls);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_DownloadExceedsBufferCap_SkippedNotRetriedForever()
+    {
+        // Metadata can lie small. The download client's buffer cap is the backstop —
+        // and blowing it is deterministic, so it must be a terminal Skip, not a
+        // transient Failure that every future sweep retries (and refunds) forever.
+        AddMessage(1001UL, Attachment(11UL, "liar.png", fileSize: 10));
+        await _db.SaveChangesAsync();
+        var oversized = new byte[100];
+        Png(1).CopyTo(oversized, 0);
+        _http.SetImage(11UL, oversized);
+
+        await RunJobAsync(maxImageBytes: 64);
+
+        await using var verify = NewContext();
+        var row = await verify.MemeIndex.SingleAsync(m => m.AttachmentDiscordId == 11UL);
+        Assert.Equal(MemeIndexStatus.Skipped, row.Status);
+        Assert.StartsWith("unsupported: image too large", row.Error);
+        Assert.Equal(0, _http.ModelCalls);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_CapSplitsMultiAttachmentMessage_ResumeDoesNotSkipSiblings()
+    {
+        // MaxImagesPerRun can cut a multi-attachment message in half. The resume
+        // cursor must NOT advance to that message: a crash before the run's
+        // Completed flip would otherwise make the resumed run skip the siblings.
+        AddMessage(1001UL, Attachment(11UL, "a.png"), Attachment(12UL, "b.png"));
+        await _db.SaveChangesAsync();
+        _http.SetImage(11UL, Png(1));
+        _http.SetImage(12UL, Png(2));
+
+        await RunJobAsync(maxImagesPerRun: 1);
+
+        // Simulate a SIGKILL between the last per-item save and MarkCompleted:
+        // status stays InProgress, so the next run honors the saved cursor.
+        await using (var crash = NewContext())
+        {
+            await crash.BackfillCheckpoints
+                .Where(c => c.Type == BackfillType.MemeIndex)
+                .ExecuteUpdateAsync(s => s.SetProperty(c => c.Status, BackfillStatus.InProgress));
+        }
+
+        await RunJobAsync();
+
+        await using var verify = NewContext();
+        var sibling = await verify.MemeIndex.SingleAsync(m => m.AttachmentDiscordId == 12UL);
+        Assert.Equal(MemeIndexStatus.Indexed, sibling.Status);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_MidFlightResume_NeverReportsProcessedAboveTotal()
+    {
+        // A resumed run keeps accumulating ProcessedCount — TotalCount must
+        // include that prior progress or the status endpoint shows processed > total.
+        AddMessage(1001UL, Attachment(11UL, "done-before-crash.png"));
+        AddMessage(1002UL, Attachment(12UL, "after-cursor.png"));
+        await _db.SaveChangesAsync();
+        _http.SetImage(12UL, Png(2));
+
+        _db.BackfillCheckpoints.Add(new BackfillCheckpointEntity
+        {
+            GuildDiscordId = GuildDiscordId,
+            Type = BackfillType.MemeIndex,
+            Status = BackfillStatus.InProgress,
+            LastProcessedId = 1001UL,
+            ProcessedCount = 5,
+            TotalCount = 6,
+            StartedAtUtc = DateTime.UtcNow
+        });
+        await _db.SaveChangesAsync();
+
+        await RunJobAsync();
+
+        await using var verify = NewContext();
+        var checkpoint = await verify.BackfillCheckpoints.SingleAsync(c => c.Type == BackfillType.MemeIndex);
+        Assert.Equal(6, checkpoint.ProcessedCount);
+        Assert.Equal(6, checkpoint.TotalCount);
+    }
+
+    private Task RunJobAsync(int maxImagesPerRun = 500, int maxImageBytes = DefaultMaxImageBytes)
+        => RunAsync(maxImagesPerRun, maxImageBytes, sweep: false);
+
+    private Task RunSweepAsync() => RunAsync(maxImagesPerRun: 500, DefaultMaxImageBytes, sweep: true);
+
+    private async Task RunAsync(int maxImagesPerRun, int maxImageBytes, bool sweep)
     {
         var services = new ServiceCollection();
         services.AddLogging();
@@ -335,6 +437,7 @@ public sealed class MemeIndexingJobTests(PostgresFixture fixture) : IClassFixtur
         {
             o.ChannelIds = [ChannelDiscordId];
             o.MaxImagesPerRun = maxImagesPerRun;
+            o.MaxImageBytes = maxImageBytes;
         });
         services.Configure<OpenRouterOptions>(o =>
         {
@@ -343,7 +446,7 @@ public sealed class MemeIndexingJobTests(PostgresFixture fixture) : IClassFixtur
             o.RequestDelayMs = 0;
         });
         services.Configure<DiscordOptions>(o => o.Token = new string('x', 60));
-        services.AddSingleton<IHttpClientFactory>(new FakeHttpClientFactory(_http));
+        services.AddSingleton<IHttpClientFactory>(new FakeHttpClientFactory(_http, maxImageBytes));
         services.AddScoped<MemeSampleService>();
         services.AddScoped<AttachmentUrlRefreshService>();
         services.AddScoped<OpenRouterClient>();
@@ -375,8 +478,8 @@ public sealed class MemeIndexingJobTests(PostgresFixture fixture) : IClassFixtur
     }
 
     // The 4-field PascalCase shape MessageEventHandler/MessagesBackfillJob serialize.
-    private static string Attachment(ulong id, string fileName) =>
-        $"{{\"Id\":{id},\"Url\":\"https://cdn.test/attachments/{ChannelDiscordId}/{id}/{fileName}?ex=expired\",\"FileName\":\"{fileName}\",\"FileSize\":123}}";
+    private static string Attachment(ulong id, string fileName, long fileSize = 123) =>
+        $"{{\"Id\":{id},\"Url\":\"https://cdn.test/attachments/{ChannelDiscordId}/{id}/{fileName}?ex=expired\",\"FileName\":\"{fileName}\",\"FileSize\":{fileSize}}}";
 
     // Distinct valid-PNG-magic payloads (≥12 bytes for the sniffer).
     private static byte[] Png(byte seed) =>
@@ -401,6 +504,7 @@ internal sealed class FakeMemeHttpHandler : HttpMessageHandler
     public List<byte[]> TransientErrorFor { get; } = [];
     public int RefreshFailuresRemaining { get; set; }
     public int ModelCalls { get; private set; }
+    public int CdnRequests { get; private set; }
 
     public void SetImage(ulong attachmentId, byte[] bytes) => _imagesByAttachment[attachmentId] = bytes;
 
@@ -439,6 +543,7 @@ internal sealed class FakeMemeHttpHandler : HttpMessageHandler
 
     private HttpResponseMessage HandleCdn(HttpRequestMessage request)
     {
+        CdnRequests++;
         var id = AttachmentIdOf(request.RequestUri!.AbsoluteUri);
         if (!_imagesByAttachment.TryGetValue(id, out var bytes))
             return new HttpResponseMessage(HttpStatusCode.NotFound);
@@ -498,10 +603,11 @@ internal sealed class FakeMemeHttpHandler : HttpMessageHandler
         };
 }
 
-internal sealed class FakeHttpClientFactory(HttpMessageHandler handler) : IHttpClientFactory
+internal sealed class FakeHttpClientFactory(HttpMessageHandler handler, long maxImageBytes = 25 * 1024 * 1024) : IHttpClientFactory
 {
-    public HttpClient CreateClient(string name) =>
-        new HttpClient(handler, disposeHandler: false)
+    public HttpClient CreateClient(string name)
+    {
+        var client = new HttpClient(handler, disposeHandler: false)
         {
             BaseAddress = name switch
             {
@@ -510,4 +616,9 @@ internal sealed class FakeHttpClientFactory(HttpMessageHandler handler) : IHttpC
                 _ => null
             }
         };
+        // Mirrors the prod discord-cdn client's download hard cap.
+        if (name == MemeBenchmarkJob.DownloadHttpClientName)
+            client.MaxResponseContentBufferSize = maxImageBytes;
+        return client;
+    }
 }


### PR DESCRIPTION
Closes #293 (items 1–2 were fixed in #302; this covers the remaining three).

## Item 3 — resume cursor could land mid-message
`MaxImagesPerRun` can slice a multi-attachment message in half; the cursor advance treated "last item of the capped list" as "last attachment of its message" and set `LastProcessedId` to the split message. A crash between the last per-item save and the checkpoint's `Completed` flip then made the resumed run skip the message's remaining attachments. The job now detects when the cap split the trailing message and refuses to advance the cursor onto it.

## Item 4 — size check ran after a full download
- `ProcessOneAsync` pre-skips attachments whose Discord-supplied `FileSizeBytes` exceeds `MaxImageBytes` — no URL-refresh spend, no download. (Size 0 = unknown from pre-#221 data; those still go through the post-download check.)
- The `discord-cdn` client gets `MaxResponseContentBufferSize = MaxImageBytes` as a backstop against metadata that lied small; unbounded bodies can no longer be buffered.
- Blowing that cap (`HttpRequestError.ConfigurationLimitExceeded`) is deterministic, so it's classified as a terminal **Skip** — the generic catch would have made it a transient **Failed**, which (post-#302) refunds the attempt and would retry forever.

## Item 5 — status could show processed > total
A mid-flight resume keeps accumulating `ProcessedCount` but reset `TotalCount` to the remaining count. `TotalCount` now includes prior progress.

## Tests
Red-first Testcontainers tests (real Postgres, fake HTTP handler), one per contract:
- `ExecuteAsync_CapSplitsMultiAttachmentMessage_ResumeDoesNotSkipSiblings`
- `ExecuteAsync_MetadataOversizedAttachment_SkippedWithoutDownload`
- `ExecuteAsync_DownloadExceedsBufferCap_SkippedNotRetriedForever`
- `ExecuteAsync_MidFlightResume_NeverReportsProcessedAboveTotal`

Full suite: 284 passed / 1 skipped (live-API test), 0 warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)