### PR TITLE
fix: #290 route channel writers through ChannelUpsertService

### DIFF
--- a/src/DiscordEventService/Data/Entities/Core/ChannelEntity.cs
+++ b/src/DiscordEventService/Data/Entities/Core/ChannelEntity.cs
@@ -29,11 +29,10 @@ public class ChannelEntity : ITimestamped
 // a data contract on both sides; never renumber or strip explicit values (they are non-sequential).
 public enum ChannelType
 {
-    // Sentinel for Discord-side types we don't yet model. Direct casts
-    // ((ChannelType)channel.Type) preserve the raw int regardless of whether
-    // it's a known value, but downstream switches and mappers need a name to
-    // route on. Anything mapped via MapChannelType that isn't recognized
-    // becomes Unknown and logs a warning so drift is visible. See §P2.2 / #71.
+    // Sentinel for Discord-side types we don't yet model. Storage always keeps the
+    // raw int via the (ChannelType)channel.Type cast in ChannelUpsertService (which
+    // warns on undefined values so drift is visible); Unknown exists as a name for
+    // downstream switches and mappers to route on. See §P2.2 / #71.
     Unknown = -1,
     Text = 0,
     Private = 1,

--- a/src/DiscordEventService/Jobs/ChannelsBackfillJob.cs
+++ b/src/DiscordEventService/Jobs/ChannelsBackfillJob.cs
@@ -1,5 +1,6 @@
 using DiscordEventService.Data;
 using DiscordEventService.Data.Entities.Core;
+using DiscordEventService.Services;
 using DSharpPlus;
 using Microsoft.EntityFrameworkCore;
 
@@ -17,6 +18,7 @@ internal sealed class ChannelsBackfillJob(
     public Task ExecuteAsync(ulong guildId, CancellationToken cancellationToken)
         => executor.RunAsync(BackfillType, guildId, async ctx =>
         {
+            var channelUpsert = ctx.Services.GetRequiredService<ChannelUpsertService>();
             var guild = await discordClient.GetGuildAsync(guildId);
             var channels = await guild.GetChannelsAsync();
             var guildEntity = await ctx.Db.Guilds.FirstOrDefaultAsync(g => g.DiscordId == guildId, cancellationToken);
@@ -38,36 +40,7 @@ internal sealed class ChannelsBackfillJob(
             {
                 cancellationToken.ThrowIfCancellationRequested();
 
-                await ctx.Db.Channels.UpsertAsync(
-                    c => c.DiscordId == channel.Id,
-                    s => s
-                        .SetProperty(c => c.Name, channel.Name)
-                        .SetProperty(c => c.Type, (ChannelType)(int)channel.Type)
-                        .SetProperty(c => c.Topic, channel.Topic)
-                        .SetProperty(c => c.Bitrate, channel.Bitrate)
-                        .SetProperty(c => c.UserLimit, channel.UserLimit)
-                        .SetProperty(c => c.RateLimitPerUser, channel.PerUserRateLimit)
-                        .SetProperty(c => c.IsNsfw, channel.IsNSFW)
-                        .SetProperty(c => c.Position, channel.Position)
-                        .SetProperty(c => c.ParentDiscordId, channel.ParentId)
-                        .SetProperty(c => c.IsDeleted, false)
-                        .SetProperty(c => c.DeletedAtUtc, (DateTime?)null),
-                    () => new ChannelEntity
-                    {
-                        DiscordId = channel.Id,
-                        GuildId = guildEntity.Id,
-                        ParentDiscordId = channel.ParentId,
-                        Name = channel.Name,
-                        Type = (ChannelType)(int)channel.Type,
-                        Topic = channel.Topic,
-                        Bitrate = channel.Bitrate,
-                        UserLimit = channel.UserLimit,
-                        RateLimitPerUser = channel.PerUserRateLimit,
-                        IsNsfw = channel.IsNSFW,
-                        Position = channel.Position
-                    },
-                    c => c.Id,
-                    cancellationToken);
+                await channelUpsert.UpsertChannelAsync(channel, guildEntity.Id, cancellationToken);
 
                 ctx.Checkpoint.ProcessedCount++;
 

--- a/src/DiscordEventService/Services/ChannelUpsertService.cs
+++ b/src/DiscordEventService/Services/ChannelUpsertService.cs
@@ -5,28 +5,44 @@ using Microsoft.EntityFrameworkCore;
 
 namespace DiscordEventService.Services;
 
+// The single write seam for channel rows (#290): live events, guild cold-sync, and
+// backfill all go through UpsertChannelAsync so the column map exists exactly once.
 internal sealed class ChannelUpsertService(DiscordDbContext db, ILogger<ChannelUpsertService> logger)
 {
-    public async Task<UpsertResult<Guid>> UpsertChannelAsync(DiscordChannel channel, Guid guildId)
+    public async Task<UpsertResult<Guid>> UpsertChannelAsync(
+        DiscordChannel channel, Guid guildId, CancellationToken cancellationToken = default)
     {
+        // Raw-int cast, not a switch: unmodeled Discord types must keep their value in the DB
+        // (Unknown=-1 is only a routing label — see ChannelType). The warning keeps drift visible.
+        var type = (ChannelType)channel.Type;
+        if (!Enum.IsDefined(type))
+        {
+            logger.LogWarning(
+                "Unknown Discord channel type {ChannelTypeValue} for channel {ChannelId}; persisting raw value",
+                (int)type, channel.Id);
+        }
+
+        // A live sighting means the channel exists — always clear soft-deletion.
         var id = await db.Channels.UpsertAsync(
             c => c.DiscordId == channel.Id,
             s => s
                 .SetProperty(c => c.Name, channel.Name)
-                .SetProperty(c => c.Type, (ChannelType)channel.Type)
+                .SetProperty(c => c.Type, type)
                 .SetProperty(c => c.Topic, channel.Topic)
                 .SetProperty(c => c.Position, channel.Position)
                 .SetProperty(c => c.ParentDiscordId, channel.ParentId)
                 .SetProperty(c => c.Bitrate, channel.Bitrate)
                 .SetProperty(c => c.UserLimit, channel.UserLimit)
                 .SetProperty(c => c.RateLimitPerUser, channel.PerUserRateLimit)
-                .SetProperty(c => c.IsNsfw, channel.IsNSFW),
+                .SetProperty(c => c.IsNsfw, channel.IsNSFW)
+                .SetProperty(c => c.IsDeleted, false)
+                .SetProperty(c => c.DeletedAtUtc, (DateTime?)null),
             () => new ChannelEntity
             {
                 DiscordId = channel.Id,
                 GuildId = guildId,
                 Name = channel.Name,
-                Type = (ChannelType)channel.Type,
+                Type = type,
                 Topic = channel.Topic,
                 Position = channel.Position,
                 ParentDiscordId = channel.ParentId,
@@ -36,7 +52,8 @@ internal sealed class ChannelUpsertService(DiscordDbContext db, ILogger<ChannelU
                 IsNsfw = channel.IsNSFW,
                 IsDeleted = false
             },
-            c => c.Id);
+            c => c.Id,
+            cancellationToken);
 
         if (id == Guid.Empty)
         {

--- a/src/DiscordEventService/Services/EventHandlers/ChannelEventHandler.cs
+++ b/src/DiscordEventService/Services/EventHandlers/ChannelEventHandler.cs
@@ -1,9 +1,6 @@
-using DiscordEventService.Data;
-using DiscordEventService.Data.Entities.Core;
 using DiscordEventService.Data.Entities.Events;
 using DiscordEventService.Services.Pipeline;
 using DSharpPlus;
-using DSharpPlus.Entities;
 using DSharpPlus.EventArgs;
 using Microsoft.EntityFrameworkCore;
 
@@ -21,6 +18,7 @@ internal sealed class ChannelEventHandler(EventPipeline pipeline) :
             e.Guild.Id, e.Channel.Id, null, async ctx =>
             {
                 var guildUpsert = ctx.Services.GetRequiredService<GuildUpsertService>();
+                var channelUpsert = ctx.Services.GetRequiredService<ChannelUpsertService>();
                 var guildGuid = (await guildUpsert.UpsertGuildAsync(e.Guild)).Value;
 
                 // Upsert the channel (handles the 23505 race internally) before staging the event,
@@ -34,7 +32,7 @@ internal sealed class ChannelEventHandler(EventPipeline pipeline) :
                     ctx.Db.ChangeTracker.Clear();
                     await using var tx = await ctx.Db.Database.BeginTransactionAsync();
 
-                    await UpsertCreatedChannelAsync(ctx, e.Channel, guildGuid);
+                    await channelUpsert.UpsertChannelAsync(e.Channel, guildGuid);
 
                     ctx.Db.ChannelEvents.Add(BuildChannelCreatedEvent(e, ctx));
                     await ctx.Db.SaveChangesAsync();
@@ -48,11 +46,9 @@ internal sealed class ChannelEventHandler(EventPipeline pipeline) :
         await pipeline.ExecuteAsync(e, "ChannelUpdated", nameof(ChannelEventHandler),
             e.ChannelAfter.Guild.Id, e.ChannelAfter.Id, null, async ctx =>
             {
-                var channelEntity = await ctx.Db.Channels
-                    .FirstOrDefaultAsync(c => c.DiscordId == e.ChannelAfter.Id);
-
-                if (channelEntity is not null)
-                    UpdateChannelEntity(channelEntity, e.ChannelAfter);
+                var guildUpsert = ctx.Services.GetRequiredService<GuildUpsertService>();
+                var channelUpsert = ctx.Services.GetRequiredService<ChannelUpsertService>();
+                var guildGuid = (await guildUpsert.UpsertGuildAsync(e.ChannelAfter.Guild)).Value;
 
                 var channelEvent = new ChannelEventEntity
                 {
@@ -83,8 +79,24 @@ internal sealed class ChannelEventHandler(EventPipeline pipeline) :
                     channelEvent.PositionAfter = e.ChannelAfter.Position;
                 }
 
-                ctx.Db.ChannelEvents.Add(channelEvent);
-                await ctx.Db.SaveChangesAsync();
+                // Channel row + event row must commit together. ExecutionStrategy is
+                // required because EnableRetryOnFailure is configured on the DbContext.
+                var strategy = ctx.Db.Database.CreateExecutionStrategy();
+                await strategy.ExecuteAsync(async () =>
+                {
+                    // Reset the tracker so an EnableRetryOnFailure retry doesn't re-stage entities
+                    // left Added by a rolled-back attempt.
+                    ctx.Db.ChangeTracker.Clear();
+                    await using var tx = await ctx.Db.Database.BeginTransactionAsync();
+
+                    // Through the shared seam so an update for a channel we never saw creates
+                    // the row instead of being dropped.
+                    await channelUpsert.UpsertChannelAsync(e.ChannelAfter, guildGuid);
+
+                    ctx.Db.ChannelEvents.Add(channelEvent);
+                    await ctx.Db.SaveChangesAsync();
+                    await tx.CommitAsync();
+                });
             });
     }
 
@@ -138,55 +150,6 @@ internal sealed class ChannelEventHandler(EventPipeline pipeline) :
 
                 await ctx.Db.SaveChangesAsync();
             });
-    }
-
-    private static void UpdateChannelEntity(ChannelEntity entity, DiscordChannel channel)
-    {
-        entity.Name = channel.Name;
-        entity.Type = (ChannelType)channel.Type;
-        entity.Topic = channel.Topic;
-        entity.Position = channel.Position;
-        entity.ParentDiscordId = channel.ParentId;
-        entity.Bitrate = channel.Bitrate;
-        entity.UserLimit = channel.UserLimit;
-        entity.RateLimitPerUser = channel.PerUserRateLimit;
-        entity.IsNsfw = channel.IsNSFW;
-        entity.IsDeleted = false;
-        entity.DeletedAtUtc = null;
-    }
-
-    private static async Task UpsertCreatedChannelAsync(EventContext ctx, DiscordChannel channel, Guid guildGuid)
-    {
-        await ctx.Db.Channels.UpsertAsync(
-            c => c.DiscordId == channel.Id,
-            s => s
-                .SetProperty(c => c.Name, channel.Name)
-                .SetProperty(c => c.Type, (ChannelType)channel.Type)
-                .SetProperty(c => c.Topic, channel.Topic)
-                .SetProperty(c => c.Position, channel.Position)
-                .SetProperty(c => c.ParentDiscordId, channel.ParentId)
-                .SetProperty(c => c.Bitrate, channel.Bitrate)
-                .SetProperty(c => c.UserLimit, channel.UserLimit)
-                .SetProperty(c => c.RateLimitPerUser, channel.PerUserRateLimit)
-                .SetProperty(c => c.IsNsfw, channel.IsNSFW)
-                .SetProperty(c => c.IsDeleted, false)
-                .SetProperty(c => c.DeletedAtUtc, (DateTime?)null),
-            () => new ChannelEntity
-            {
-                DiscordId = channel.Id,
-                GuildId = guildGuid,
-                Name = channel.Name,
-                Type = (ChannelType)channel.Type,
-                Topic = channel.Topic,
-                Position = channel.Position,
-                ParentDiscordId = channel.ParentId,
-                Bitrate = channel.Bitrate,
-                UserLimit = channel.UserLimit,
-                RateLimitPerUser = channel.PerUserRateLimit,
-                IsNsfw = channel.IsNSFW,
-                IsDeleted = false,
-            },
-            c => c.Id);
     }
 
     private static ChannelEventEntity BuildChannelCreatedEvent(ChannelCreatedEventArgs e, EventContext ctx) => new ChannelEventEntity

--- a/src/DiscordEventService/Services/EventHandlers/GuildEventHandler.cs
+++ b/src/DiscordEventService/Services/EventHandlers/GuildEventHandler.cs
@@ -50,7 +50,8 @@ internal sealed class GuildEventHandler(EventPipeline pipeline) :
                         },
                         g => g.Id);
 
-                    await UpsertChannelsAndRolesAsync(ctx.Db, ctx.Logger, e.Guild, guildGuid);
+                    await UpsertChannelsAndRolesAsync(
+                        ctx.Db, ctx.Services.GetRequiredService<ChannelUpsertService>(), e.Guild, guildGuid);
 
                     await tx.CommitAsync();
                 });
@@ -99,48 +100,13 @@ internal sealed class GuildEventHandler(EventPipeline pipeline) :
 
     // Per-entity upsert: each channel/role goes through the shared primitive, which absorbs
     // the 23505 race a concurrent GuildCreate could otherwise cause in a batched insert.
-    private static async Task UpsertChannelsAndRolesAsync(DiscordDbContext db, ILogger logger, DiscordGuild guild, Guid guildGuid)
-    {
-        await UpsertGuildChannelsAsync(db, logger, guild, guildGuid);
-        await UpsertGuildRolesAsync(db, guild, guildGuid);
-    }
-
-    private static async Task UpsertGuildChannelsAsync(DiscordDbContext db, ILogger logger, DiscordGuild guild, Guid guildGuid)
+    private static async Task UpsertChannelsAndRolesAsync(
+        DiscordDbContext db, ChannelUpsertService channelUpsert, DiscordGuild guild, Guid guildGuid)
     {
         foreach (var channel in guild.Channels.Values)
-        {
-            var mappedType = MapChannelType(channel.Type, logger);
-            await db.Channels.UpsertAsync(
-                c => c.DiscordId == channel.Id,
-                s => s
-                    .SetProperty(c => c.Name, channel.Name)
-                    .SetProperty(c => c.ParentDiscordId, channel.Parent?.Id)
-                    .SetProperty(c => c.Type, mappedType)
-                    .SetProperty(c => c.Topic, channel.Topic)
-                    .SetProperty(c => c.Bitrate, channel.Bitrate)
-                    .SetProperty(c => c.UserLimit, channel.UserLimit)
-                    .SetProperty(c => c.RateLimitPerUser, channel.PerUserRateLimit)
-                    .SetProperty(c => c.IsNsfw, channel.IsNSFW)
-                    .SetProperty(c => c.Position, channel.Position)
-                    .SetProperty(c => c.IsDeleted, false)
-                    .SetProperty(c => c.DeletedAtUtc, (DateTime?)null),
-                () => new ChannelEntity
-                {
-                    DiscordId = channel.Id,
-                    GuildId = guildGuid,
-                    ParentDiscordId = channel.Parent?.Id,
-                    Name = channel.Name,
-                    Type = mappedType,
-                    Topic = channel.Topic,
-                    Bitrate = channel.Bitrate,
-                    UserLimit = channel.UserLimit,
-                    RateLimitPerUser = channel.PerUserRateLimit,
-                    IsNsfw = channel.IsNSFW,
-                    Position = channel.Position,
-                    IsDeleted = false,
-                },
-                c => c.Id);
-        }
+            await channelUpsert.UpsertChannelAsync(channel, guildGuid);
+
+        await UpsertGuildRolesAsync(db, guild, guildGuid);
     }
 
     private static async Task UpsertGuildRolesAsync(DiscordDbContext db, DiscordGuild guild, Guid guildGuid)
@@ -177,37 +143,4 @@ internal sealed class GuildEventHandler(EventPipeline pipeline) :
         }
     }
 
-    private static ChannelType MapChannelType(DiscordChannelType discordType, ILogger logger)
-    {
-        // Add new DSharpPlus channel types here as they appear. Anything not
-        // listed becomes Unknown (with a warning log) instead of silently
-        // collapsing to Text. The int value is still preserved at the storage
-        // layer via (ChannelType)channel.Type casts elsewhere — Unknown is
-        // just the label.
-        var mapped = discordType switch
-        {
-            DiscordChannelType.Text => ChannelType.Text,
-            DiscordChannelType.Private => ChannelType.Private,
-            DiscordChannelType.Voice => ChannelType.Voice,
-            DiscordChannelType.Group => ChannelType.Group,
-            DiscordChannelType.Category => ChannelType.Category,
-            DiscordChannelType.News => ChannelType.News,
-            DiscordChannelType.NewsThread => ChannelType.NewsThread,
-            DiscordChannelType.PublicThread => ChannelType.PublicThread,
-            DiscordChannelType.PrivateThread => ChannelType.PrivateThread,
-            DiscordChannelType.Stage => ChannelType.Stage,
-            DiscordChannelType.GuildForum => ChannelType.Forum,
-            DiscordChannelType.GuildMedia => ChannelType.Media,
-            _ => ChannelType.Unknown
-        };
-
-        if (mapped == ChannelType.Unknown)
-        {
-            logger.LogWarning(
-                "Unknown Discord channel type {DiscordChannelType} (value {ChannelTypeValue}); mapping to ChannelType.Unknown",
-                discordType, (int)discordType);
-        }
-
-        return mapped;
-    }
 }

--- a/tests/DiscordEventService.Tests/ChannelUpsertServiceTests.cs
+++ b/tests/DiscordEventService.Tests/ChannelUpsertServiceTests.cs
@@ -1,0 +1,196 @@
+using DiscordEventService.Data;
+using DiscordEventService.Data.Entities.Core;
+using DiscordEventService.Services;
+using DSharpPlus.Entities;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
+using Newtonsoft.Json;
+using Xunit;
+
+namespace DiscordEventService.Tests;
+
+// Contract tests for the single channel-write seam (#290): every writer (live events,
+// guild cold-sync, backfill) goes through ChannelUpsertService, so the full column map,
+// soft-delete revival, and unknown-type handling are pinned here once.
+public sealed class ChannelUpsertServiceTests(PostgresFixture fixture) : IClassFixture<PostgresFixture>, IAsyncLifetime
+{
+    private DiscordDbContext _db = null!;
+    private RecordingLogger _logger = null!;
+    private ChannelUpsertService _service = null!;
+    private Guid _guildId;
+
+    public async Task InitializeAsync()
+    {
+        _db = NewContext();
+        await _db.Database.MigrateAsync();
+        await _db.Channels.ExecuteDeleteAsync();
+        await _db.Guilds.ExecuteDeleteAsync();
+
+        var guild = new GuildEntity { DiscordId = 1UL, Name = "TestGuild" };
+        _db.Guilds.Add(guild);
+        await _db.SaveChangesAsync();
+        _db.ChangeTracker.Clear();
+        _guildId = guild.Id;
+
+        _logger = new RecordingLogger();
+        _service = new ChannelUpsertService(_db, _logger.For<ChannelUpsertService>());
+    }
+
+    public Task DisposeAsync() => _db.DisposeAsync().AsTask();
+
+    [Fact]
+    public async Task UpsertChannelAsync_WhenNew_InsertsFullColumnMap()
+    {
+        var channel = Channel(id: 10, type: 2, name: "voice-lounge", topic: "hangout",
+            position: 3, parentId: 99, bitrate: 64000, userLimit: 5, rateLimit: 30, nsfw: true);
+
+        var result = await _service.UpsertChannelAsync(channel, _guildId);
+
+        Assert.True(result.IsSuccess);
+        await using var verify = NewContext();
+        var row = await verify.Channels.SingleAsync(c => c.DiscordId == 10UL);
+        Assert.Equal(result.Value, row.Id);
+        Assert.Equal(_guildId, row.GuildId);
+        Assert.Equal("voice-lounge", row.Name);
+        Assert.Equal(ChannelType.Voice, row.Type);
+        Assert.Equal("hangout", row.Topic);
+        Assert.Equal(3, row.Position);
+        Assert.Equal(99UL, row.ParentDiscordId);
+        Assert.Equal(64000, row.Bitrate);
+        Assert.Equal(5, row.UserLimit);
+        Assert.Equal(30, row.RateLimitPerUser);
+        Assert.True(row.IsNsfw);
+        Assert.False(row.IsDeleted);
+        Assert.Null(row.DeletedAtUtc);
+    }
+
+    [Fact]
+    public async Task UpsertChannelAsync_WhenExists_UpdatesEveryMappedColumn()
+    {
+        _db.Channels.Add(new ChannelEntity
+        {
+            DiscordId = 20UL,
+            GuildId = _guildId,
+            Name = "before",
+            Type = ChannelType.Text,
+            Position = 0,
+        });
+        await _db.SaveChangesAsync();
+        _db.ChangeTracker.Clear();
+
+        var channel = Channel(id: 20, type: 0, name: "after", topic: "new-topic",
+            position: 7, parentId: 42, bitrate: null, userLimit: null, rateLimit: 60, nsfw: true);
+        var result = await _service.UpsertChannelAsync(channel, _guildId);
+
+        Assert.True(result.IsSuccess);
+        await using var verify = NewContext();
+        var row = await verify.Channels.SingleAsync(c => c.DiscordId == 20UL);
+        Assert.Equal("after", row.Name);
+        Assert.Equal("new-topic", row.Topic);
+        Assert.Equal(7, row.Position);
+        Assert.Equal(42UL, row.ParentDiscordId);
+        Assert.Equal(60, row.RateLimitPerUser);
+        Assert.True(row.IsNsfw);
+    }
+
+    [Fact]
+    public async Task UpsertChannelAsync_WhenSoftDeleted_RevivesRow()
+    {
+        _db.Channels.Add(new ChannelEntity
+        {
+            DiscordId = 30UL,
+            GuildId = _guildId,
+            Name = "ghost",
+            Type = ChannelType.Text,
+            IsDeleted = true,
+            DeletedAtUtc = new DateTime(2026, 1, 1, 0, 0, 0, DateTimeKind.Utc),
+        });
+        await _db.SaveChangesAsync();
+        _db.ChangeTracker.Clear();
+
+        var result = await _service.UpsertChannelAsync(Channel(id: 30, type: 0, name: "ghost"), _guildId);
+
+        Assert.True(result.IsSuccess);
+        await using var verify = NewContext();
+        var row = await verify.Channels.SingleAsync(c => c.DiscordId == 30UL);
+        Assert.False(row.IsDeleted);
+        Assert.Null(row.DeletedAtUtc);
+    }
+
+    [Fact]
+    public async Task UpsertChannelAsync_WhenUnknownType_PreservesRawIntAndWarns()
+    {
+        var result = await _service.UpsertChannelAsync(Channel(id: 40, type: 99, name: "future-type"), _guildId);
+
+        Assert.True(result.IsSuccess);
+        await using var verify = NewContext();
+        var row = await verify.Channels.SingleAsync(c => c.DiscordId == 40UL);
+        // Data contract: the raw Discord type int is persisted even when unmodeled —
+        // Unknown(-1) would destroy information. Drift stays visible via the warning.
+        Assert.Equal((ChannelType)99, row.Type);
+        Assert.Contains(_logger.Entries, e => e.Level == LogLevel.Warning);
+    }
+
+    [Fact]
+    public async Task UpsertChannelAsync_ForThread_StoresParentDiscordId()
+    {
+        var thread = Channel(id: 50, type: 11, name: "some-thread", parentId: 10);
+
+        var result = await _service.UpsertChannelAsync(thread, _guildId);
+
+        Assert.True(result.IsSuccess);
+        await using var verify = NewContext();
+        var row = await verify.Channels.SingleAsync(c => c.DiscordId == 50UL);
+        Assert.Equal(ChannelType.PublicThread, row.Type);
+        Assert.Equal(10UL, row.ParentDiscordId);
+    }
+
+    // DSharpPlus entities have internal setters; hydrating from gateway-shaped JSON is the
+    // supported way to build one outside the library.
+    private static DiscordChannel Channel(ulong id, int type, string name, string? topic = null,
+        int position = 0, ulong? parentId = null, int? bitrate = null, int? userLimit = null,
+        int? rateLimit = null, bool nsfw = false)
+    {
+        var json = JsonConvert.SerializeObject(new Dictionary<string, object?>
+        {
+            ["id"] = id.ToString(),
+            ["type"] = type,
+            ["name"] = name,
+            ["topic"] = topic,
+            ["position"] = position,
+            ["parent_id"] = parentId?.ToString(),
+            ["bitrate"] = bitrate,
+            ["user_limit"] = userLimit,
+            ["rate_limit_per_user"] = rateLimit,
+            ["nsfw"] = nsfw,
+        });
+        return JsonConvert.DeserializeObject<DiscordChannel>(json)
+            ?? throw new InvalidOperationException("DiscordChannel deserialization returned null");
+    }
+
+    private DiscordDbContext NewContext()
+    {
+        var options = new DbContextOptionsBuilder<DiscordDbContext>()
+            .UseNpgsql(fixture.Container.GetConnectionString())
+            .UseSnakeCaseNamingConvention()
+            .Options;
+        return new DiscordDbContext(options);
+    }
+
+    internal sealed class RecordingLogger
+    {
+        public List<(LogLevel Level, string Message)> Entries { get; } = [];
+
+        public ILogger<T> For<T>() => new TypedLogger<T>(Entries);
+
+        private sealed class TypedLogger<T>(List<(LogLevel, string)> entries) : ILogger<T>
+        {
+            public IDisposable? BeginScope<TState>(TState state) where TState : notnull => null;
+            public bool IsEnabled(LogLevel logLevel) => true;
+
+            public void Log<TState>(LogLevel logLevel, EventId eventId, TState state,
+                Exception? exception, Func<TState, Exception?, string> formatter)
+                => entries.Add((logLevel, formatter(state, exception)));
+        }
+    }
+}


### PR DESCRIPTION
Part of #290 (steps 1–2; the role/emoji/sticker maps from step 3 are a separate follow-up — do NOT auto-close the issue).

## What

All four channel upsert column maps collapse into the single seam `ChannelUpsertService.UpsertChannelAsync`:

- `ChannelUpsertService` — now owns the full column map, soft-delete revival (`IsDeleted=false`, `DeletedAtUtc=null` on every live sighting — previously missing from the seam itself), the unknown-type warning, and takes a `CancellationToken`.
- `ChannelEventHandler` — Created and Updated both call the seam; inline `UpsertCreatedChannelAsync` + `UpdateChannelEntity` deleted. Updated keeps channel-row + event-row atomicity via the same ExecutionStrategy/transaction pattern Created already used.
- `GuildEventHandler` cold-sync — inline map + `MapChannelType` deleted.
- `ChannelsBackfillJob` — inline map deleted.

## Deliberate behavior changes

1. Cold-sync now persists the **raw Discord type int** for unmodeled channel types instead of `Unknown=-1` (`MapChannelType`). This matches the `ChannelType` enum's documented data contract (raw int preserved at storage; `Unknown` is a routing label) and removes the drift where the same channel flipped between `-1` and the raw value depending on which writer touched it last. The drift-visibility warning moved into the seam.
2. `ChannelUpdated` for a channel we never saw now **inserts** the row (previously the update was silently dropped), and any live sighting revives a soft-deleted row.
3. Cold-sync uses `channel.ParentId` (raw snowflake) instead of `channel.Parent?.Id`, so parent linkage no longer depends on cache resolution.

## Testing

- New `ChannelUpsertServiceTests` (Testcontainers, real Postgres): full column map on insert/update, soft-delete revival, raw-int preservation + warning for unknown types, thread `ParentDiscordId`. Red-first: revival and unknown-type warning failed against the old seam.
- Full suite: 289 passed, 0 failed.
- Live-verified on the dev bot: cold-sync on boot, ChannelCreated/Updated/Deleted round-trip (DB rows + before/after event columns checked), reconnect backfill pushed 201 channels through the seam. No errors in the log.

🤖 Generated with [Claude Code](https://claude.com/claude-code)