### PR TITLE
fix: #292 route unchecked UpsertResult.Value sites through FkResolver

### DIFF
--- a/src/DiscordEventService/Services/BootQuickSyncService.cs
+++ b/src/DiscordEventService/Services/BootQuickSyncService.cs
@@ -81,8 +81,24 @@ internal sealed class BootQuickSyncService(
         var guildUpsert = scope.ServiceProvider.GetRequiredService<GuildUpsertService>();
         var channelUpsert = scope.ServiceProvider.GetRequiredService<ChannelUpsertService>();
 
-        var guildId = (await guildUpsert.UpsertGuildAsync(guild)).Value;
-        var channelId = (await channelUpsert.UpsertChannelAsync(channel, guildId)).Value;
+        // A failed upsert must not flow Guid.Empty into backfilled message FKs (#292);
+        // skip the channel — the caller logs per-channel and continues the sweep.
+        var guildResult = await guildUpsert.UpsertGuildAsync(guild);
+        if (!guildResult.IsSuccess)
+        {
+            logger.LogWarning("Quick-sync: guild FK unresolved for channel {ChannelId} ({Reason}), skipping", channel.Id, guildResult.FailureReason);
+            return 0;
+        }
+
+        var guildId = guildResult.Value;
+        var channelResult = await channelUpsert.UpsertChannelAsync(channel, guildId);
+        if (!channelResult.IsSuccess)
+        {
+            logger.LogWarning("Quick-sync: channel FK unresolved for channel {ChannelId} ({Reason}), skipping", channel.Id, channelResult.FailureReason);
+            return 0;
+        }
+
+        var channelId = channelResult.Value;
 
         var existingDiscordIds = await db.Messages
             .Where(m => messages.Select(msg => msg.Id).Contains(m.DiscordId))

--- a/src/DiscordEventService/Services/EventHandlers/ChannelEventHandler.cs
+++ b/src/DiscordEventService/Services/EventHandlers/ChannelEventHandler.cs
@@ -17,9 +17,12 @@ internal sealed class ChannelEventHandler(EventPipeline pipeline) :
         await pipeline.ExecuteAsync(e, "ChannelCreated", nameof(ChannelEventHandler),
             e.Guild.Id, e.Channel.Id, null, async ctx =>
             {
-                var guildUpsert = ctx.Services.GetRequiredService<GuildUpsertService>();
                 var channelUpsert = ctx.Services.GetRequiredService<ChannelUpsertService>();
-                var guildGuid = (await guildUpsert.UpsertGuildAsync(e.Guild)).Value;
+                // Resolve the required guild FK via the shared resolver: on a miss it logs and
+                // records a FailedEvent instead of flowing Guid.Empty into a fresh channels row
+                // (#292). The ChannelEvent timeline row is FK-free and still lands below.
+                var fks = await ctx.Services.GetRequiredService<FkResolver>()
+                    .ResolveAsync(ctx, e.Guild, $"ChannelCreated ChannelId={e.Channel.Id}");
 
                 // Upsert the channel (handles the 23505 race internally) before staging the event,
                 // then commit channel + event together. ExecutionStrategy is required because
@@ -32,7 +35,8 @@ internal sealed class ChannelEventHandler(EventPipeline pipeline) :
                     ctx.Db.ChangeTracker.Clear();
                     await using var tx = await ctx.Db.Database.BeginTransactionAsync();
 
-                    await channelUpsert.UpsertChannelAsync(e.Channel, guildGuid);
+                    if (fks.Success)
+                        await channelUpsert.UpsertChannelAsync(e.Channel, fks.GuildId);
 
                     ctx.Db.ChannelEvents.Add(BuildChannelCreatedEvent(e, ctx));
                     await ctx.Db.SaveChangesAsync();
@@ -46,9 +50,10 @@ internal sealed class ChannelEventHandler(EventPipeline pipeline) :
         await pipeline.ExecuteAsync(e, "ChannelUpdated", nameof(ChannelEventHandler),
             e.ChannelAfter.Guild.Id, e.ChannelAfter.Id, null, async ctx =>
             {
-                var guildUpsert = ctx.Services.GetRequiredService<GuildUpsertService>();
                 var channelUpsert = ctx.Services.GetRequiredService<ChannelUpsertService>();
-                var guildGuid = (await guildUpsert.UpsertGuildAsync(e.ChannelAfter.Guild)).Value;
+                // Shared resolver: a guild miss must not flow Guid.Empty into a fresh channels row (#292).
+                var fks = await ctx.Services.GetRequiredService<FkResolver>()
+                    .ResolveAsync(ctx, e.ChannelAfter.Guild, $"ChannelUpdated ChannelId={e.ChannelAfter.Id}");
 
                 var channelEvent = new ChannelEventEntity
                 {
@@ -91,7 +96,8 @@ internal sealed class ChannelEventHandler(EventPipeline pipeline) :
 
                     // Through the shared seam so an update for a channel we never saw creates
                     // the row instead of being dropped.
-                    await channelUpsert.UpsertChannelAsync(e.ChannelAfter, guildGuid);
+                    if (fks.Success)
+                        await channelUpsert.UpsertChannelAsync(e.ChannelAfter, fks.GuildId);
 
                     ctx.Db.ChannelEvents.Add(channelEvent);
                     await ctx.Db.SaveChangesAsync();

--- a/src/DiscordEventService/Services/EventHandlers/IntegrationEventHandler.cs
+++ b/src/DiscordEventService/Services/EventHandlers/IntegrationEventHandler.cs
@@ -17,17 +17,23 @@ internal sealed class IntegrationEventHandler(EventPipeline pipeline) :
         await pipeline.ExecuteAsync(e, "IntegrationCreated", nameof(IntegrationEventHandler),
             e.Guild.Id, null, null, async ctx =>
             {
-                var guildUpsert = ctx.Services.GetRequiredService<GuildUpsertService>();
-                var guildGuid = (await guildUpsert.UpsertGuildAsync(e.Guild)).Value;
+                // Resolve the required guild FK via the shared resolver: on a miss it logs and
+                // records a FailedEvent instead of flowing Guid.Empty into the integrations row
+                // (#292). The IntegrationEvent timeline row is FK-free and still lands below.
+                var fks = await ctx.Services.GetRequiredService<FkResolver>()
+                    .ResolveAsync(ctx, e.Guild, $"IntegrationCreated IntegrationId={e.Integration.Id}");
 
-                ctx.Db.Integrations.Add(new IntegrationEntity
+                if (fks.Success)
                 {
-                    DiscordId = e.Integration.Id,
-                    GuildId = guildGuid,
-                    Name = e.Integration.Name,
-                    Type = e.Integration.Type,
-                    IsEnabled = e.Integration.IsEnabled,
-                });
+                    ctx.Db.Integrations.Add(new IntegrationEntity
+                    {
+                        DiscordId = e.Integration.Id,
+                        GuildId = fks.GuildId,
+                        Name = e.Integration.Name,
+                        Type = e.Integration.Type,
+                        IsEnabled = e.Integration.IsEnabled,
+                    });
+                }
 
                 ctx.Db.IntegrationEvents.Add(new IntegrationEventEntity
                 {

--- a/src/DiscordEventService/Services/EventHandlers/InviteEventHandler.cs
+++ b/src/DiscordEventService/Services/EventHandlers/InviteEventHandler.cs
@@ -16,38 +16,44 @@ internal sealed class InviteEventHandler(EventPipeline pipeline) :
         await pipeline.ExecuteAsync(e, "InviteCreated", nameof(InviteEventHandler),
             e.Guild.Id, e.Channel.Id, e.Invite.Inviter?.Id, async ctx =>
             {
-                var guildUpsert = ctx.Services.GetRequiredService<GuildUpsertService>();
-                var channelUpsert = ctx.Services.GetRequiredService<ChannelUpsertService>();
                 var userService = ctx.Services.GetRequiredService<UserService>();
 
-                var guildResult = await guildUpsert.UpsertGuildAsync(e.Guild);
-                var channelResult = await channelUpsert.UpsertChannelAsync(e.Channel, guildResult.Value);
-                Guid? inviterGuid = null;
-                if (e.Invite.Inviter is not null)
-                {
-                    var inviterResult = await userService.UpsertUserAsync(e.Invite.Inviter);
-                    inviterGuid = inviterResult.IsSuccess ? inviterResult.Value : null;
-                }
-
+                // Resolve the required guild+channel FKs via the shared resolver: on a miss it
+                // logs and records a FailedEvent (replayable trace) instead of staging an invites
+                // row with Guid.Empty FKs (#292). The InviteEvent timeline row is FK-free
+                // (snowflake columns) and still lands below.
                 var invite = e.Invite;
-                var inviteEntity = await ctx.Db.Invites.FirstOrDefaultAsync(i => i.Code == invite.Code);
-                if (inviteEntity is null)
-                {
-                    inviteEntity = new InviteEntity { Code = invite.Code };
-                    ctx.Db.Invites.Add(inviteEntity);
-                }
+                var fks = await ctx.Services.GetRequiredService<FkResolver>()
+                    .ResolveAsync(ctx, e.Guild, e.Channel, $"InviteCreated Code={invite.Code}");
 
-                if (guildResult.IsSuccess) inviteEntity.GuildId = guildResult.Value;
-                if (channelResult.IsSuccess) inviteEntity.ChannelId = channelResult.Value;
-                inviteEntity.InviterId = inviterGuid;
-                inviteEntity.MaxAge = invite.MaxAge;
-                inviteEntity.MaxUses = invite.MaxUses;
-                inviteEntity.Uses = invite.Uses;
-                inviteEntity.IsTemporary = invite.IsTemporary;
-                inviteEntity.CreatedAtUtc = invite.CreatedAt.UtcDateTime;
-                inviteEntity.ExpiresAtUtc = invite.MaxAge > 0 ? invite.CreatedAt.AddSeconds(invite.MaxAge).UtcDateTime : null;
-                inviteEntity.IsDeleted = false;
-                inviteEntity.DeletedAtUtc = null;
+                if (fks.Success)
+                {
+                    Guid? inviterGuid = null;
+                    if (invite.Inviter is not null)
+                    {
+                        var inviterResult = await userService.UpsertUserAsync(invite.Inviter);
+                        inviterGuid = inviterResult.IsSuccess ? inviterResult.Value : null;
+                    }
+
+                    var inviteEntity = await ctx.Db.Invites.FirstOrDefaultAsync(i => i.Code == invite.Code);
+                    if (inviteEntity is null)
+                    {
+                        inviteEntity = new InviteEntity { Code = invite.Code };
+                        ctx.Db.Invites.Add(inviteEntity);
+                    }
+
+                    inviteEntity.GuildId = fks.GuildId;
+                    inviteEntity.ChannelId = fks.ChannelId;
+                    inviteEntity.InviterId = inviterGuid;
+                    inviteEntity.MaxAge = invite.MaxAge;
+                    inviteEntity.MaxUses = invite.MaxUses;
+                    inviteEntity.Uses = invite.Uses;
+                    inviteEntity.IsTemporary = invite.IsTemporary;
+                    inviteEntity.CreatedAtUtc = invite.CreatedAt.UtcDateTime;
+                    inviteEntity.ExpiresAtUtc = invite.MaxAge > 0 ? invite.CreatedAt.AddSeconds(invite.MaxAge).UtcDateTime : null;
+                    inviteEntity.IsDeleted = false;
+                    inviteEntity.DeletedAtUtc = null;
+                }
 
                 ctx.Db.InviteEvents.Add(new InviteEventEntity
                 {

--- a/src/DiscordEventService/Services/EventHandlers/RoleEventHandler.cs
+++ b/src/DiscordEventService/Services/EventHandlers/RoleEventHandler.cs
@@ -19,8 +19,11 @@ internal sealed class RoleEventHandler(EventPipeline pipeline) :
         await pipeline.ExecuteAsync(e, "GuildRoleCreated", nameof(RoleEventHandler),
             e.Guild.Id, null, null, async ctx =>
             {
-                var guildUpsert = ctx.Services.GetRequiredService<GuildUpsertService>();
-                var guildGuid = (await guildUpsert.UpsertGuildAsync(e.Guild)).Value;
+                // Resolve the required guild FK via the shared resolver: on a miss it logs and
+                // records a FailedEvent (replayable trace) instead of flowing Guid.Empty into the
+                // roles row (#292). The RoleEvent timeline row is FK-free and still lands below.
+                var fks = await ctx.Services.GetRequiredService<FkResolver>()
+                    .ResolveAsync(ctx, e.Guild, $"GuildRoleCreated RoleId={e.Role.Id}");
 
                 var permissions = long.TryParse(e.Role.Permissions.ToString(), out var perm) ? perm : 0;
 
@@ -35,7 +38,8 @@ internal sealed class RoleEventHandler(EventPipeline pipeline) :
                     ctx.Db.ChangeTracker.Clear();
                     await using var tx = await ctx.Db.Database.BeginTransactionAsync();
 
-                    await UpsertCreatedRoleAsync(ctx, e.Role, guildGuid, permissions);
+                    if (fks.Success)
+                        await UpsertCreatedRoleAsync(ctx, e.Role, fks.GuildId, permissions);
 
                     ctx.Db.RoleEvents.Add(BuildRoleCreatedEvent(e, ctx));
                     await ctx.Db.SaveChangesAsync();

--- a/src/DiscordEventService/Services/EventHandlers/ThreadEventHandler.cs
+++ b/src/DiscordEventService/Services/EventHandlers/ThreadEventHandler.cs
@@ -18,13 +18,16 @@ internal sealed class ThreadEventHandler(EventPipeline pipeline) :
         await pipeline.ExecuteAsync(e, "ThreadCreated", nameof(ThreadEventHandler),
             e.Guild.Id, e.Thread.Id, e.Thread.CreatorId, async ctx =>
             {
-                var guildUpsert = ctx.Services.GetRequiredService<GuildUpsertService>();
                 var channelUpsert = ctx.Services.GetRequiredService<ChannelUpsertService>();
 
                 // Threads are channels (ADR-0003): upsert the thread into `channels` so messages
-                // sent into it have a non-null channel_id from the first event onward.
-                var guildId = (await guildUpsert.UpsertGuildAsync(e.Guild)).Value;
-                await channelUpsert.UpsertChannelAsync(e.Thread, guildId);
+                // sent into it have a non-null channel_id from the first event onward. A guild
+                // miss must not flow Guid.Empty into the fresh row (#292); the FK-free
+                // ThreadEvent below still lands either way.
+                var fks = await ctx.Services.GetRequiredService<FkResolver>()
+                    .ResolveAsync(ctx, e.Guild, $"ThreadCreated ThreadId={e.Thread.Id}");
+                if (fks.Success)
+                    await channelUpsert.UpsertChannelAsync(e.Thread, fks.GuildId);
 
                 // For message threads (parent is text/news), thread ID == starter message ID
                 var isMessageThread = e.Parent?.Type is DiscordChannelType.Text or DiscordChannelType.News;
@@ -54,11 +57,13 @@ internal sealed class ThreadEventHandler(EventPipeline pipeline) :
         await pipeline.ExecuteAsync(e, "ThreadUpdated", nameof(ThreadEventHandler),
             e.Guild.Id, e.ThreadAfter.Id, e.ThreadAfter.CreatorId, async ctx =>
             {
-                var guildUpsert = ctx.Services.GetRequiredService<GuildUpsertService>();
                 var channelUpsert = ctx.Services.GetRequiredService<ChannelUpsertService>();
 
-                var guildId = (await guildUpsert.UpsertGuildAsync(e.Guild)).Value;
-                await channelUpsert.UpsertChannelAsync(e.ThreadAfter, guildId);
+                // Shared resolver: a guild miss must not flow Guid.Empty into a fresh channels row (#292).
+                var fks = await ctx.Services.GetRequiredService<FkResolver>()
+                    .ResolveAsync(ctx, e.Guild, $"ThreadUpdated ThreadId={e.ThreadAfter.Id}");
+                if (fks.Success)
+                    await channelUpsert.UpsertChannelAsync(e.ThreadAfter, fks.GuildId);
 
                 ctx.Db.ThreadEvents.Add(new ThreadEventEntity
                 {

--- a/src/DiscordEventService/Services/Pipeline/FkResolver.cs
+++ b/src/DiscordEventService/Services/Pipeline/FkResolver.cs
@@ -15,9 +15,7 @@ internal sealed class FkResolver(
         string? logContext = null)
     {
         var guildResult = await guildUpsert.UpsertGuildAsync(guild);
-        // Unconditional, matching the prior inline behavior: channel upsert runs even when the
-        // guild failed (passing Guid.Empty), so a single validation pass reports every failed FK.
-        var channelResult = await channelUpsert.UpsertChannelAsync(channel, guildResult.Value);
+        var channelResult = await UpsertChannelIfGuildResolvedAsync(guildResult, channel);
         var userResult = await userService.UpsertUserAsync(user);
 
         return await ValidateAsync(ctx, guildResult, channelResult, userResult, logContext);
@@ -39,6 +37,61 @@ internal sealed class FkResolver(
         await ctx.RecordFailureAsync(new InvalidOperationException(
             $"Required FK not resolved ({logContext ?? "no context"}): guildResolved={guild.IsSuccess} channelResolved={channel.IsSuccess} userResolved={user.IsSuccess}"));
         return ResolvedFks.Failed;
+    }
+
+    public async Task<ResolvedChannelFks> ResolveAsync(
+        EventContext ctx,
+        DiscordGuild guild,
+        DiscordChannel channel,
+        string? logContext = null)
+    {
+        var guildResult = await guildUpsert.UpsertGuildAsync(guild);
+        var channelResult = await UpsertChannelIfGuildResolvedAsync(guildResult, channel);
+
+        return await ValidateGuildChannelAsync(ctx, guildResult, channelResult, logContext);
+    }
+
+    internal static async Task<ResolvedChannelFks> ValidateGuildChannelAsync(
+        EventContext ctx,
+        UpsertResult<Guid> guild,
+        UpsertResult<Guid> channel,
+        string? logContext = null)
+    {
+        if (guild.IsSuccess && channel.IsSuccess)
+            return ResolvedChannelFks.Resolved(guild.Value, channel.Value);
+
+        ctx.Logger.LogError(
+            "Could not resolve required FKs for {LogContext}: guild resolved {GuildResolved}, channel resolved {ChannelResolved}; skipping insert",
+            logContext ?? "no context", guild.IsSuccess, channel.IsSuccess);
+        await ctx.RecordFailureAsync(new InvalidOperationException(
+            $"Required FK not resolved ({logContext ?? "no context"}): guildResolved={guild.IsSuccess} channelResolved={channel.IsSuccess}"));
+        return ResolvedChannelFks.Failed;
+    }
+
+    public async Task<ResolvedGuildFk> ResolveAsync(
+        EventContext ctx,
+        DiscordGuild guild,
+        string? logContext = null)
+    {
+        var guildResult = await guildUpsert.UpsertGuildAsync(guild);
+
+        return await ValidateAsync(ctx, guildResult, logContext);
+    }
+
+    internal static async Task<ResolvedGuildFk> ValidateAsync(
+        EventContext ctx,
+        UpsertResult<Guid> guild,
+        string? logContext = null)
+    {
+        if (guild.IsSuccess)
+            return ResolvedGuildFk.Resolved(guild.Value);
+
+        ctx.Logger.LogError(
+            "Could not resolve required FKs for {LogContext}: guild resolved {GuildResolved}; skipping insert",
+            logContext ?? "no context", guild.IsSuccess);
+        await ctx.RecordFailureAsync(new InvalidOperationException(
+            $"Required FK not resolved ({logContext ?? "no context"}): guildResolved={guild.IsSuccess}"));
+        return ResolvedGuildFk.Failed;
     }
 
     public async Task<ResolvedUserFks> ResolveAsync(
@@ -69,4 +122,12 @@ internal sealed class FkResolver(
             $"Required FK not resolved ({logContext ?? "no context"}): guildResolved={guild.IsSuccess} userResolved={user.IsSuccess}"));
         return ResolvedUserFks.Failed;
     }
+
+    // A failed guild must not flow Guid.Empty into a fresh channel row's GuildId (#292);
+    // the skipped upsert surfaces as a channel failure in the validation pass.
+    private async Task<UpsertResult<Guid>> UpsertChannelIfGuildResolvedAsync(
+        UpsertResult<Guid> guildResult, DiscordChannel channel) =>
+        guildResult.IsSuccess
+            ? await channelUpsert.UpsertChannelAsync(channel, guildResult.Value)
+            : UpsertResult<Guid>.Failure("guild FK unresolved; channel upsert skipped");
 }

--- a/src/DiscordEventService/Services/Pipeline/ResolvedFks.cs
+++ b/src/DiscordEventService/Services/Pipeline/ResolvedFks.cs
@@ -14,3 +14,18 @@ internal sealed record ResolvedUserFks(bool Success, Guid GuildId, Guid UserId)
 
     public static ResolvedUserFks Resolved(Guid guildId, Guid userId) => new ResolvedUserFks(true, guildId, userId);
 }
+
+internal sealed record ResolvedChannelFks(bool Success, Guid GuildId, Guid ChannelId)
+{
+    public static readonly ResolvedChannelFks Failed = new ResolvedChannelFks(false, default, default);
+
+    public static ResolvedChannelFks Resolved(Guid guildId, Guid channelId) =>
+        new ResolvedChannelFks(true, guildId, channelId);
+}
+
+internal sealed record ResolvedGuildFk(bool Success, Guid GuildId)
+{
+    public static readonly ResolvedGuildFk Failed = new ResolvedGuildFk(false, default);
+
+    public static ResolvedGuildFk Resolved(Guid guildId) => new ResolvedGuildFk(true, guildId);
+}

--- a/tests/DiscordEventService.Tests/FkResolverResolveTests.cs
+++ b/tests/DiscordEventService.Tests/FkResolverResolveTests.cs
@@ -1,0 +1,176 @@
+using System.Reflection;
+using DiscordEventService.Data;
+using DiscordEventService.Services;
+using DiscordEventService.Services.Pipeline;
+using DSharpPlus.Entities;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+using Newtonsoft.Json;
+using Xunit;
+
+namespace DiscordEventService.Tests;
+
+// Instance-half coverage for FkResolver (#292): the resolver driving real upsert services
+// against real Postgres. The static ValidateAsync halves are pinned in FkResolverTests.
+public sealed class FkResolverResolveTests(PostgresFixture fixture) : IClassFixture<PostgresFixture>, IAsyncLifetime
+{
+    private DiscordDbContext _db = null!;
+    private FkResolver _resolver = null!;
+    private List<Exception> _recordedFailures = null!;
+
+    public async Task InitializeAsync()
+    {
+        _db = NewContext();
+        await _db.Database.MigrateAsync();
+        await _db.Channels.ExecuteDeleteAsync();
+        await _db.UserNameHistory.ExecuteDeleteAsync();
+        await _db.Users.ExecuteDeleteAsync();
+        await _db.Guilds.ExecuteDeleteAsync();
+        _db.ChangeTracker.Clear();
+
+        _resolver = new FkResolver(
+            new GuildUpsertService(_db, NullLogger<GuildUpsertService>.Instance),
+            new ChannelUpsertService(_db, NullLogger<ChannelUpsertService>.Instance),
+            new UserService(_db, NullLogger<UserService>.Instance));
+        _recordedFailures = [];
+    }
+
+    public Task DisposeAsync() => _db.DisposeAsync().AsTask();
+
+    [Fact]
+    public async Task ResolveAsync_GuildOnly_UpsertsGuildAndReturnsItsId()
+    {
+        var result = await _resolver.ResolveAsync(NewEventContext(), Guild(id: 500, name: "Solo"), "GuildId=500");
+
+        Assert.True(result.Success);
+        await using var verify = NewContext();
+        var row = await verify.Guilds.SingleAsync(g => g.DiscordId == 500UL);
+        Assert.Equal(row.Id, result.GuildId);
+        Assert.Empty(_recordedFailures);
+    }
+
+    [Fact]
+    public async Task ResolveAsync_GuildChannelUser_UpsertsAllThreeAndReturnsTheirIds()
+    {
+        var result = await _resolver.ResolveAsync(
+            NewEventContext(),
+            Guild(id: 600, name: "Trio"),
+            Channel(id: 601, type: 0, name: "general"),
+            User(id: 602, username: "resolver-user"),
+            "MessageId=603");
+
+        Assert.True(result.Success);
+        await using var verify = NewContext();
+        var guildRow = await verify.Guilds.SingleAsync(g => g.DiscordId == 600UL);
+        var channelRow = await verify.Channels.SingleAsync(c => c.DiscordId == 601UL);
+        var userRow = await verify.Users.SingleAsync(u => u.DiscordId == 602UL);
+        Assert.Equal(guildRow.Id, result.GuildId);
+        Assert.Equal(channelRow.Id, result.ChannelId);
+        Assert.Equal(userRow.Id, result.UserId);
+        Assert.Equal(guildRow.Id, channelRow.GuildId);
+        Assert.Empty(_recordedFailures);
+    }
+
+    [Fact]
+    public async Task ResolveAsync_GuildChannel_UpsertsBothAndReturnsTheirIds()
+    {
+        var result = await _resolver.ResolveAsync(
+            NewEventContext(),
+            Guild(id: 800, name: "Pair"),
+            Channel(id: 801, type: 0, name: "invites"),
+            "InviteCode=abc");
+
+        Assert.True(result.Success);
+        await using var verify = NewContext();
+        var guildRow = await verify.Guilds.SingleAsync(g => g.DiscordId == 800UL);
+        var channelRow = await verify.Channels.SingleAsync(c => c.DiscordId == 801UL);
+        Assert.Equal(guildRow.Id, result.GuildId);
+        Assert.Equal(channelRow.Id, result.ChannelId);
+        Assert.Equal(guildRow.Id, channelRow.GuildId);
+        Assert.Empty(_recordedFailures);
+    }
+
+    [Fact]
+    public async Task ResolveAsync_GuildUser_UpsertsBothAndReturnsTheirIds()
+    {
+        var result = await _resolver.ResolveAsync(
+            NewEventContext(),
+            Guild(id: 700, name: "Duo"),
+            User(id: 701, username: "duo-user"),
+            "GuildId=700 UserId=701");
+
+        Assert.True(result.Success);
+        await using var verify = NewContext();
+        var guildRow = await verify.Guilds.SingleAsync(g => g.DiscordId == 700UL);
+        var userRow = await verify.Users.SingleAsync(u => u.DiscordId == 701UL);
+        Assert.Equal(guildRow.Id, result.GuildId);
+        Assert.Equal(userRow.Id, result.UserId);
+        Assert.Empty(_recordedFailures);
+    }
+
+    private EventContext NewEventContext() =>
+        new EventContext(
+            Db: _db,
+            Services: null!,
+            CorrelationId: Guid.NewGuid(),
+            RawJson: null,
+            ReceivedAtUtc: DateTime.UnixEpoch,
+            Logger: NullLogger.Instance,
+            RecordFailureAsync: ex =>
+            {
+                _recordedFailures.Add(ex);
+                return Task.CompletedTask;
+            });
+
+    // DSharpPlus entities have internal setters; hydrating from gateway-shaped JSON is the
+    // supported way to build one outside the library.
+    private static DiscordGuild Guild(ulong id, string name)
+    {
+        var json = JsonConvert.SerializeObject(new Dictionary<string, object?>
+        {
+            ["id"] = id.ToString(),
+            ["name"] = name,
+        });
+        return JsonConvert.DeserializeObject<DiscordGuild>(json)
+            ?? throw new InvalidOperationException("DiscordGuild deserialization returned null");
+    }
+
+    private static DiscordChannel Channel(ulong id, int type, string name)
+    {
+        var json = JsonConvert.SerializeObject(new Dictionary<string, object?>
+        {
+            ["id"] = id.ToString(),
+            ["type"] = type,
+            ["name"] = name,
+        });
+        return JsonConvert.DeserializeObject<DiscordChannel>(json)
+            ?? throw new InvalidOperationException("DiscordChannel deserialization returned null");
+    }
+
+    // DiscordUser exposes a parameterless ctor with non-public setters; reflection is the only
+    // way to build one outside the library.
+    private static DiscordUser User(ulong id, string username)
+    {
+        var user = (DiscordUser)Activator.CreateInstance(typeof(DiscordUser), nonPublic: true)!;
+        SetProp(user, nameof(DiscordUser.Id), id);
+        SetProp(user, nameof(DiscordUser.Username), username);
+        SetProp(user, nameof(DiscordUser.Discriminator), "0");
+        return user;
+    }
+
+    private static void SetProp(DiscordUser user, string name, object value)
+    {
+        var property = typeof(DiscordUser).GetProperty(name, BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance);
+        property!.SetValue(user, value);
+    }
+
+    private DiscordDbContext NewContext()
+    {
+        var options = new DbContextOptionsBuilder<DiscordDbContext>()
+            .UseNpgsql(fixture.Container.GetConnectionString())
+            .UseSnakeCaseNamingConvention()
+            .Options;
+        return new DiscordDbContext(options);
+    }
+}

--- a/tests/DiscordEventService.Tests/FkResolverTests.cs
+++ b/tests/DiscordEventService.Tests/FkResolverTests.cs
@@ -113,6 +113,91 @@ public sealed class FkResolverTests
         Assert.Contains("GuildId=7 UserId=8", failure.Message);
     }
 
+    [Fact]
+    public async Task ValidateGuildChannelAsync_WhenBothResolve_ReturnsResolvedIdsAndDoesNotRecordFailure()
+    {
+        var guildId = Guid.NewGuid();
+        var channelId = Guid.NewGuid();
+        var logger = new RecordingLogger();
+        var recordedFailures = new List<Exception>();
+        var ctx = NewContext(logger, recordedFailures);
+
+        var result = await FkResolver.ValidateGuildChannelAsync(
+            ctx,
+            UpsertResult<Guid>.Success(guildId),
+            UpsertResult<Guid>.Success(channelId),
+            "InviteCode=xyz");
+
+        Assert.True(result.Success);
+        Assert.Equal(guildId, result.GuildId);
+        Assert.Equal(channelId, result.ChannelId);
+        Assert.Empty(recordedFailures);
+        Assert.DoesNotContain(logger.Entries, e => e.Level == LogLevel.Error);
+    }
+
+    [Theory]
+    [InlineData(false, true)]
+    [InlineData(true, false)]
+    [InlineData(false, false)]
+    public async Task ValidateGuildChannelAsync_WhenAnyFkFails_LogsRecordsFailureAndReturnsFailed(
+        bool guildOk, bool channelOk)
+    {
+        var logger = new RecordingLogger();
+        var recordedFailures = new List<Exception>();
+        var ctx = NewContext(logger, recordedFailures);
+
+        var result = await FkResolver.ValidateGuildChannelAsync(
+            ctx,
+            guildOk ? UpsertResult<Guid>.Success(Guid.NewGuid()) : UpsertResult<Guid>.Failure("guild lost"),
+            channelOk ? UpsertResult<Guid>.Success(Guid.NewGuid()) : UpsertResult<Guid>.Failure("channel lost"),
+            "InviteCode=qrs");
+
+        Assert.False(result.Success);
+        Assert.Equal(Guid.Empty, result.GuildId);
+        Assert.Equal(Guid.Empty, result.ChannelId);
+
+        // Logged an aggregate error and recorded exactly one FailedEvent carrying the log context.
+        Assert.Contains(logger.Entries, e => e.Level == LogLevel.Error);
+        var failure = Assert.Single(recordedFailures);
+        Assert.IsType<InvalidOperationException>(failure);
+        Assert.Contains("InviteCode=qrs", failure.Message);
+    }
+
+    [Fact]
+    public async Task ValidateAsync_GuildOnly_WhenResolved_ReturnsIdAndDoesNotRecordFailure()
+    {
+        var guildId = Guid.NewGuid();
+        var logger = new RecordingLogger();
+        var recordedFailures = new List<Exception>();
+        var ctx = NewContext(logger, recordedFailures);
+
+        var result = await FkResolver.ValidateAsync(ctx, UpsertResult<Guid>.Success(guildId), "GuildId=3");
+
+        Assert.True(result.Success);
+        Assert.Equal(guildId, result.GuildId);
+        Assert.Empty(recordedFailures);
+        Assert.DoesNotContain(logger.Entries, e => e.Level == LogLevel.Error);
+    }
+
+    [Fact]
+    public async Task ValidateAsync_GuildOnly_WhenGuildFails_LogsRecordsFailureAndReturnsFailed()
+    {
+        var logger = new RecordingLogger();
+        var recordedFailures = new List<Exception>();
+        var ctx = NewContext(logger, recordedFailures);
+
+        var result = await FkResolver.ValidateAsync(ctx, UpsertResult<Guid>.Failure("guild lost"), "GuildId=9");
+
+        Assert.False(result.Success);
+        Assert.Equal(Guid.Empty, result.GuildId);
+
+        // Logged an aggregate error and recorded exactly one FailedEvent carrying the log context.
+        Assert.Contains(logger.Entries, e => e.Level == LogLevel.Error);
+        var failure = Assert.Single(recordedFailures);
+        Assert.IsType<InvalidOperationException>(failure);
+        Assert.Contains("GuildId=9", failure.Message);
+    }
+
     private static EventContext NewContext(ILogger logger, List<Exception> recordedFailures) =>
         new EventContext(
             Db: null!,


### PR DESCRIPTION
Closes #292.

## Problem

Six handlers plus `BootQuickSyncService` read `.Value` off `UpsertResult<Guid>` without checking `IsSuccess`. A failed guild upsert yields `Guid.Empty`, which flowed into FK columns of fresh `roles`/`channels`/`integrations`/`invites` rows (FK violation crash at best, corrupt row at worst) with no clean failure trace. `FkResolver` itself also deliberately passed a failed guild's `Guid.Empty` into the channel upsert.

## Audit result

Actual unchecked sites were 8 across 6 files (not the ~21 estimated at review time — #304's channel seam and existing `IsSuccess` ternaries covered the rest):

- `RoleEventHandler` (GuildRoleCreated), `ChannelEventHandler` (Created/Updated), `ThreadEventHandler` (Created/Updated), `IntegrationEventHandler` (Created), `InviteEventHandler` (Created), `BootQuickSyncService.SyncChannelMessagesAsync`

## Fix

- New `FkResolver` overloads: guild-only → `ResolvedGuildFk`, guild+channel → `ResolvedChannelFks` (static `ValidateGuildChannelAsync` named distinctly — the natural overload would collide with the guild+user signature). On a miss: error log + replayable `FailedEvent`, same as the existing 3-FK path.
- Handlers follow the `BanEventHandler` idiom: FK-dependent core-entity write gated on `fks.Success`; FK-free timeline event row (snowflake columns) always lands.
- `FkResolver` 3-FK path no longer passes a failed guild's `Guid.Empty` into `UpsertChannelAsync` — the skipped upsert surfaces as a channel failure in the same validation pass.
- `BootQuickSyncService` checks both results and skips the channel with a warning (caller already continues per-channel).
- `InviteEventHandler`: invite core row (non-nullable `GuildId`/`ChannelId`) now written only when both FKs resolve; previously a new invite with a failed resolve staged `Guid.Empty` FKs.

## Testing

- Also closes the issue's noted gap: `FkResolver` instance `ResolveAsync` now has Testcontainers coverage (all three shapes, real Postgres); static validate halves pinned for the new overloads incl. failure paths. 299 passed / 1 skipped (live API test).
- Live-verified on dev bot: channel create/update, forum+thread create/update, role create, invite create → all rows FK-correct (no `Guid.Empty`), all timeline rows landed, zero exceptions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)