### PR TITLE
test: architecture guard pinning upsert-seam callers

### DIFF
--- a/src/DiscordEventService/Services/EventHandlers/GuildEventHandler.cs
+++ b/src/DiscordEventService/Services/EventHandlers/GuildEventHandler.cs
@@ -1,5 +1,3 @@
-using DiscordEventService.Data;
-using DiscordEventService.Data.Entities.Core;
 using DiscordEventService.Services.Pipeline;
 using DSharpPlus;
 using DSharpPlus.Entities;
@@ -33,27 +31,15 @@ internal sealed class GuildEventHandler(EventPipeline pipeline) :
                     ctx.Db.ChangeTracker.Clear();
                     await using var tx = await ctx.Db.Database.BeginTransactionAsync();
 
-                    var guildGuid = await ctx.Db.Guilds.UpsertAsync(
-                        g => g.DiscordId == e.Guild.Id,
-                        s => s
-                            .SetProperty(g => g.Name, e.Guild.Name)
-                            .SetProperty(g => g.IconHash, e.Guild.IconHash)
-                            .SetProperty(g => g.OwnerId, e.Guild.OwnerId)
-                            .SetProperty(g => g.LeftAtUtc, (DateTime?)null),
-                        () => new GuildEntity
-                        {
-                            DiscordId = e.Guild.Id,
-                            Name = e.Guild.Name,
-                            IconHash = e.Guild.IconHash,
-                            OwnerId = e.Guild.OwnerId,
-                            LeftAtUtc = null,
-                        },
-                        g => g.Id);
+                    var guildResult = await ctx.Services.GetRequiredService<GuildUpsertService>()
+                        .UpsertGuildAsync(e.Guild);
+                    if (!guildResult.IsSuccess)
+                        return;
 
                     await UpsertChannelsAndRolesAsync(
                         ctx.Services.GetRequiredService<ChannelUpsertService>(),
                         ctx.Services.GetRequiredService<RoleUpsertService>(),
-                        e.Guild, guildGuid);
+                        e.Guild, guildResult.Value);
 
                     await tx.CommitAsync();
                 });

--- a/src/DiscordEventService/Services/GuildUpsertService.cs
+++ b/src/DiscordEventService/Services/GuildUpsertService.cs
@@ -8,12 +8,15 @@ internal sealed class GuildUpsertService(DiscordDbContext db, ILogger<GuildUpser
 {
     public async Task<UpsertResult<Guid>> UpsertGuildAsync(DiscordGuild guild)
     {
+        // Every caller upserts because the bot just observed the guild live (boot sync, a
+        // gateway event from it, or FK resolution) — so any stale "left" marker is wrong here.
         var id = await db.Guilds.UpsertAsync(
             g => g.DiscordId == guild.Id,
             s => s
                 .SetProperty(g => g.Name, guild.Name)
                 .SetProperty(g => g.IconHash, guild.IconHash)
-                .SetProperty(g => g.OwnerId, guild.OwnerId),
+                .SetProperty(g => g.OwnerId, guild.OwnerId)
+                .SetProperty(g => g.LeftAtUtc, (DateTime?)null),
             () => new GuildEntity
             {
                 DiscordId = guild.Id,

--- a/tests/DiscordEventService.Tests/GuildUpsertServiceTests.cs
+++ b/tests/DiscordEventService.Tests/GuildUpsertServiceTests.cs
@@ -1,0 +1,100 @@
+using DiscordEventService.Data;
+using DiscordEventService.Data.Entities.Core;
+using DiscordEventService.Services;
+using DSharpPlus.Entities;
+using Microsoft.EntityFrameworkCore;
+using Newtonsoft.Json;
+using Xunit;
+
+namespace DiscordEventService.Tests;
+
+// Contract tests for the single guild-write seam: every writer (GuildCreated/GuildAvailable,
+// boot cold-sync, FkResolver, sticker/emoji/automod handlers) goes through GuildUpsertService,
+// so the full column map — including clearing a stale LeftAtUtc marker — is pinned here once.
+public sealed class GuildUpsertServiceTests(PostgresFixture fixture) : IClassFixture<PostgresFixture>, IAsyncLifetime
+{
+    private DiscordDbContext _db = null!;
+    private RecordingLogger _logger = null!;
+    private GuildUpsertService _service = null!;
+
+    public async Task InitializeAsync()
+    {
+        _db = NewContext();
+        await _db.Database.MigrateAsync();
+        await _db.Guilds.ExecuteDeleteAsync();
+
+        _logger = new RecordingLogger();
+        _service = new GuildUpsertService(_db, _logger.For<GuildUpsertService>());
+    }
+
+    public Task DisposeAsync() => _db.DisposeAsync().AsTask();
+
+    [Fact]
+    public async Task UpsertGuildAsync_WhenNew_InsertsFullColumnMap()
+    {
+        var guild = Guild(id: 10, name: "Alpha", iconHash: "abc123", ownerId: 42);
+
+        var result = await _service.UpsertGuildAsync(guild);
+
+        Assert.True(result.IsSuccess);
+        await using var verify = NewContext();
+        var row = await verify.Guilds.SingleAsync(g => g.DiscordId == 10UL);
+        Assert.Equal(result.Value, row.Id);
+        Assert.Equal("Alpha", row.Name);
+        Assert.Equal("abc123", row.IconHash);
+        Assert.Equal(42UL, row.OwnerId);
+        Assert.Null(row.LeftAtUtc);
+    }
+
+    [Fact]
+    public async Task UpsertGuildAsync_WhenExists_UpdatesEveryMappedColumnAndClearsLeftAtUtc()
+    {
+        _db.Guilds.Add(new GuildEntity
+        {
+            DiscordId = 20UL,
+            Name = "Before",
+            IconHash = "old",
+            OwnerId = 1UL,
+            LeftAtUtc = new DateTime(2026, 1, 1, 0, 0, 0, DateTimeKind.Utc),
+        });
+        await _db.SaveChangesAsync();
+        var originalId = await _db.Guilds.Where(g => g.DiscordId == 20UL).Select(g => g.Id).SingleAsync();
+        _db.ChangeTracker.Clear();
+
+        var guild = Guild(id: 20, name: "After", iconHash: "new", ownerId: 2);
+
+        var result = await _service.UpsertGuildAsync(guild);
+
+        Assert.True(result.IsSuccess);
+        Assert.Equal(originalId, result.Value);
+        await using var verify = NewContext();
+        var row = await verify.Guilds.SingleAsync(g => g.DiscordId == 20UL);
+        Assert.Equal("After", row.Name);
+        Assert.Equal("new", row.IconHash);
+        Assert.Equal(2UL, row.OwnerId);
+        // Upserting means the bot just observed the guild live — a stale "left" marker must clear.
+        Assert.Null(row.LeftAtUtc);
+    }
+
+    private static DiscordGuild Guild(ulong id, string name, string? iconHash = null, ulong ownerId = 0)
+    {
+        var json = JsonConvert.SerializeObject(new Dictionary<string, object?>
+        {
+            ["id"] = id.ToString(),
+            ["name"] = name,
+            ["icon"] = iconHash,
+            ["owner_id"] = ownerId.ToString(),
+        });
+        return JsonConvert.DeserializeObject<DiscordGuild>(json)
+            ?? throw new InvalidOperationException("DiscordGuild deserialization returned null");
+    }
+
+    private DiscordDbContext NewContext()
+    {
+        var options = new DbContextOptionsBuilder<DiscordDbContext>()
+            .UseNpgsql(fixture.Container.GetConnectionString())
+            .UseSnakeCaseNamingConvention()
+            .Options;
+        return new DiscordDbContext(options);
+    }
+}

--- a/tests/DiscordEventService.Tests/UpsertSeamArchitectureTests.cs
+++ b/tests/DiscordEventService.Tests/UpsertSeamArchitectureTests.cs
@@ -1,0 +1,95 @@
+using System.Text.RegularExpressions;
+using Xunit;
+
+namespace DiscordEventService.Tests;
+
+// Architecture guard: the raw upsert primitives (UpsertAsync/GetOrInsertAsync) on seam-owned
+// DbSets may only be called from the service that owns that entity's column map. Anything else
+// re-inlines a column map the seam exists to centralize — the drift these seams were built to
+// prevent (#290, #304, #306).
+public sealed class UpsertSeamArchitectureTests
+{
+    // DbSet name → the single file allowed to call upsert primitives on it.
+    private static readonly IReadOnlyDictionary<string, string> SeamOwners = new Dictionary<string, string>
+    {
+        ["Guilds"] = "GuildUpsertService.cs",
+        ["Channels"] = "ChannelUpsertService.cs",
+        ["Roles"] = "RoleUpsertService.cs",
+        ["Emotes"] = "EmoteUpsertService.cs",
+        ["Stickers"] = "StickerUpsertService.cs",
+        ["Users"] = "UserService.cs",
+        ["Members"] = "UserService.cs",
+    };
+
+    private static readonly Regex SeamOwnedUpsertCall = new(
+        @"\.(?<set>Guilds|Channels|Roles|Emotes|Stickers|Users|Members)\s*\.\s*(?:UpsertAsync|GetOrInsertAsync)\s*\(",
+        RegexOptions.Compiled);
+
+    [Fact]
+    public void SeamOwnedUpserts_AreOnlyCalledFromTheirOwningService()
+    {
+        List<string> violations = [];
+
+        foreach (var (file, text) in EnumerateSourceFiles())
+        {
+            var fileName = Path.GetFileName(file);
+            // Explicit Match: MatchCollection's foreach enumerator is the non-generic one, so var infers object.
+            foreach (Match match in SeamOwnedUpsertCall.Matches(text))
+            {
+                var owner = SeamOwners[match.Groups["set"].Value];
+                if (!string.Equals(fileName, owner, StringComparison.Ordinal))
+                {
+                    var line = text.AsSpan(0, match.Index).Count('\n') + 1;
+                    violations.Add($"{file}:{line} calls an upsert primitive on db.{match.Groups["set"].Value}; route it through {owner}");
+                }
+            }
+        }
+
+        Assert.True(violations.Count == 0,
+            "Seam-owned DbSets must be written only via their upsert service:\n" + string.Join('\n', violations));
+    }
+
+    // Guards the guard: every seam file must still match the regex at least once, so a rename of
+    // a DbSet, seam service, or the upsert extensions can't turn the rule above vacuously green.
+    [Fact]
+    public void EverySeamService_StillContainsAMatchableUpsertCall()
+    {
+        var matchedFiles = EnumerateSourceFiles()
+            .Where(f => SeamOwnedUpsertCall.IsMatch(f.Text))
+            .Select(f => Path.GetFileName(f.File))
+            .ToHashSet(StringComparer.Ordinal);
+
+        var silentSeams = SeamOwners.Values.Distinct().Where(owner => !matchedFiles.Contains(owner)).ToList();
+
+        Assert.True(silentSeams.Count == 0,
+            "Seam services with no matchable upsert call (renamed set/service/extension? update SeamOwners and the regex):\n"
+            + string.Join('\n', silentSeams));
+    }
+
+    private static IEnumerable<(string File, string Text)> EnumerateSourceFiles()
+    {
+        var srcRoot = Path.Combine(FindRepoRoot(), "src");
+        foreach (var file in Directory.EnumerateFiles(srcRoot, "*.cs", SearchOption.AllDirectories))
+        {
+            var relative = Path.GetRelativePath(srcRoot, file);
+            var segments = relative.Split(Path.DirectorySeparatorChar);
+            if (segments.Contains("obj") || segments.Contains("bin") || segments.Contains("Migrations"))
+                continue;
+
+            yield return (relative, File.ReadAllText(file));
+        }
+    }
+
+    private static string FindRepoRoot()
+    {
+        var dir = new DirectoryInfo(AppContext.BaseDirectory);
+        while (dir is not null)
+        {
+            if (File.Exists(Path.Combine(dir.FullName, "WojtusDiscord.slnx")))
+                return dir.FullName;
+            dir = dir.Parent;
+        }
+
+        throw new InvalidOperationException("Could not locate the repo root (WojtusDiscord.slnx) above the test bin directory.");
+    }
+}


### PR DESCRIPTION
## What

- **New `UpsertSeamArchitectureTests`**: a source-scan test asserting the raw upsert primitives (`UpsertAsync`/`GetOrInsertAsync`) on seam-owned DbSets (`Guilds`, `Channels`, `Roles`, `Emotes`, `Stickers`, `Users`, `Members`) are called only from their owning upsert service. A second guard-the-guard test requires every seam file to still match the regex, so a DbSet/service/extension rename can't turn the rule vacuously green.
- **Fixes the one violation the rule found**: `GuildEventHandler` upserted guilds inline — and its column map had already drifted from `GuildUpsertService` (the inline copy reset `LeftAtUtc` on rejoin; the seam didn't). The handler now routes through `GuildUpsertService`, and the `LeftAtUtc = null` reset moves into the seam — correct for every caller (boot sync, FkResolver, sticker/emoji/automod handlers), since each upsert means the bot just observed the guild live.
- **New `GuildUpsertServiceTests`** (Testcontainers): pins the guild column map incl. the `LeftAtUtc` revival contract.

## Why

Carried since #304: nothing pinned that handlers/jobs actually route through the upsert seams (#290) — a future writer could re-inline a column map and no test would fail. The drift this prevents wasn't hypothetical: the guild map had already forked.

## Testing

- Full suite: 316 passed, 1 skipped (live-API test, expected).
- Live-verified on the dev bot: pre-marked the dev guild `left_at_utc` in local DB, booted → `GuildAvailable` routed through the seam, marker cleared, 72 channels + 11 roles synced with the seam-returned Guid, no 23505/disposed/lost-row lines in the log.

🤖 Generated with [Claude Code](https://claude.com/claude-code)