### PR TITLE
fix: #314 stop EF logging handled 23505 upsert races as Error

### DIFF
--- a/src/DiscordEventService/Data/DiscordDbContext.cs
+++ b/src/DiscordEventService/Data/DiscordDbContext.cs
@@ -92,10 +92,11 @@ public sealed class DiscordDbContext(DbContextOptions<DiscordDbContext> options)
     // EF logs these two at Error from inside SaveChangesAsync — before the catch in
     // DbSetUpsertExtensions runs — so handled 23505 races surface as Errors nothing can
     // suppress (#314). Warning, not Debug: ConfigureWarnings cannot filter on SqlState, so
-    // this covers every command failure, and Debug would fall under the
-    // Microsoft.EntityFrameworkCore=Warning floor in appsettings.json — dropping EF's
-    // rendered SQL and parameters in prod, the fastest diagnostic on the backfill paths
-    // that swallow and continue. Set here, not in Program.cs, so jobs and tests inherit it.
+    // this covers every command failure, and Debug sits below every EF category floor this
+    // service runs with — dropping the events outright rather than downgrading them, and
+    // with them EF's rendered SQL and parameters, the fastest diagnostic on the backfill
+    // paths that swallow and continue. Set here, not in Program.cs, so jobs and tests
+    // inherit it.
     protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
     {
         base.OnConfiguring(optionsBuilder);

--- a/src/DiscordEventService/Data/DiscordDbContext.cs
+++ b/src/DiscordEventService/Data/DiscordDbContext.cs
@@ -2,6 +2,7 @@ using DiscordEventService.Data.Entities.Conversations;
 using DiscordEventService.Data.Entities.Core;
 using DiscordEventService.Data.Entities.Events;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Diagnostics;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 namespace DiscordEventService.Data;
@@ -87,6 +88,19 @@ public sealed class DiscordDbContext(DbContextOptions<DiscordDbContext> options)
 
     // Sent cost-cap alerts (#269) — the soft-cap dedup ledger + audit trail.
     public DbSet<UsageAlertEntity> UsageAlerts => Set<UsageAlertEntity>();
+
+    // EF logs these two at Error from inside SaveChangesAsync — before the catch in
+    // DbSetUpsertExtensions runs — so handled 23505 races surface as Errors nothing can
+    // suppress (#314). EventPipeline already logs real failures with the exception and a
+    // CorrelationId. Set here, not in Program.cs, so jobs and tests inherit it too.
+    protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
+    {
+        base.OnConfiguring(optionsBuilder);
+
+        optionsBuilder.ConfigureWarnings(w => w.Log(
+            (RelationalEventId.CommandError, LogLevel.Debug),
+            (CoreEventId.SaveChangesFailed, LogLevel.Debug)));
+    }
 
     protected override void OnModelCreating(ModelBuilder modelBuilder)
     {

--- a/src/DiscordEventService/Data/DiscordDbContext.cs
+++ b/src/DiscordEventService/Data/DiscordDbContext.cs
@@ -91,15 +91,18 @@ public sealed class DiscordDbContext(DbContextOptions<DiscordDbContext> options)
 
     // EF logs these two at Error from inside SaveChangesAsync — before the catch in
     // DbSetUpsertExtensions runs — so handled 23505 races surface as Errors nothing can
-    // suppress (#314). EventPipeline already logs real failures with the exception and a
-    // CorrelationId. Set here, not in Program.cs, so jobs and tests inherit it too.
+    // suppress (#314). Warning, not Debug: ConfigureWarnings cannot filter on SqlState, so
+    // this covers every command failure, and Debug would fall under the
+    // Microsoft.EntityFrameworkCore=Warning floor in appsettings.json — dropping EF's
+    // rendered SQL and parameters in prod, the fastest diagnostic on the backfill paths
+    // that swallow and continue. Set here, not in Program.cs, so jobs and tests inherit it.
     protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
     {
         base.OnConfiguring(optionsBuilder);
 
         optionsBuilder.ConfigureWarnings(w => w.Log(
-            (RelationalEventId.CommandError, LogLevel.Debug),
-            (CoreEventId.SaveChangesFailed, LogLevel.Debug)));
+            (RelationalEventId.CommandError, LogLevel.Warning),
+            (CoreEventId.SaveChangesFailed, LogLevel.Warning)));
     }
 
     protected override void OnModelCreating(ModelBuilder modelBuilder)

--- a/tests/DiscordEventService.Tests/RecordingLogger.cs
+++ b/tests/DiscordEventService.Tests/RecordingLogger.cs
@@ -10,6 +10,10 @@ internal sealed class RecordingLogger
 
     public ILogger<T> For<T>() => new TypedLogger<T>(Entries);
 
+    // EF Core takes an ILoggerFactory (UseLoggerFactory), not an ILogger<T>, so tests that assert
+    // on EF's own diagnostic events (#314) need this façade over the same list.
+    public ILoggerFactory AsLoggerFactory() => new Factory(Entries);
+
     private sealed class TypedLogger<T>(List<(LogLevel, string)> entries) : ILogger<T>
     {
         public IDisposable? BeginScope<TState>(TState state) where TState : notnull => null;
@@ -18,5 +22,12 @@ internal sealed class RecordingLogger
         public void Log<TState>(LogLevel logLevel, EventId eventId, TState state,
             Exception? exception, Func<TState, Exception?, string> formatter)
             => entries.Add((logLevel, formatter(state, exception)));
+    }
+
+    private sealed class Factory(List<(LogLevel, string)> entries) : ILoggerFactory
+    {
+        public ILogger CreateLogger(string categoryName) => new TypedLogger<object>(entries);
+        public void AddProvider(ILoggerProvider provider) { }
+        public void Dispose() { }
     }
 }

--- a/tests/DiscordEventService.Tests/UpsertConflictLogLevelTests.cs
+++ b/tests/DiscordEventService.Tests/UpsertConflictLogLevelTests.cs
@@ -1,0 +1,85 @@
+using DiscordEventService.Data;
+using DiscordEventService.Data.Entities.Core;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
+using Xunit;
+
+namespace DiscordEventService.Tests;
+
+// Pins the #314 contract: a 23505 the upsert primitives handle by design must leave no Error
+// record behind, while staying traceable at Debug.
+public sealed class UpsertConflictLogLevelTests(PostgresFixture fixture)
+    : IClassFixture<PostgresFixture>, IAsyncLifetime
+{
+    private readonly RecordingLogger _log = new();
+
+    public async Task InitializeAsync()
+    {
+        await using var db = NewContext();
+        await db.Database.MigrateAsync();
+        await db.Guilds.ExecuteDeleteAsync();
+        _log.Entries.Clear();
+    }
+
+    public Task DisposeAsync() => Task.CompletedTask;
+
+    [Fact]
+    public async Task UpsertAsync_WhenInsertConflicts_LogsNoErrorAndKeepsDebugDiagnostic()
+    {
+        await SeedAsync(500UL);
+
+        await using var db = NewContext();
+        // The match never hits the seeded row, so ExecuteUpdate affects 0 rows and the insert
+        // path runs; the factory inserts the seeded DiscordId, colliding on the unique index.
+        var id = await db.Guilds.UpsertAsync(
+            g => g.DiscordId == 501UL,
+            s => s.SetProperty(g => g.Name, "Retry"),
+            () => new GuildEntity { DiscordId = 500UL, Name = "Conflict" },
+            g => g.Id);
+
+        Assert.Equal(Guid.Empty, id);
+        AssertConflictWasHandledQuietly();
+    }
+
+    [Fact]
+    public async Task GetOrInsertAsync_WhenInsertConflicts_LogsNoErrorAndKeepsDebugDiagnostic()
+    {
+        await SeedAsync(600UL);
+
+        await using var db = NewContext();
+        var (entity, inserted) = await db.Guilds.GetOrInsertAsync(
+            g => g.DiscordId == 600UL,
+            () => new GuildEntity { DiscordId = 600UL, Name = "Conflict" });
+
+        Assert.False(inserted);
+        Assert.Equal("Existing", entity?.Name);
+        AssertConflictWasHandledQuietly();
+    }
+
+    private void AssertConflictWasHandledQuietly()
+    {
+        Assert.DoesNotContain(_log.Entries, e => e.Level >= LogLevel.Error);
+
+        // Downgraded, not silenced: the failure is still traceable when Debug is enabled.
+        Assert.Contains(_log.Entries, e =>
+            e.Level == LogLevel.Debug && e.Message.Contains("23505", StringComparison.Ordinal));
+    }
+
+    private async Task SeedAsync(ulong discordId)
+    {
+        await using var db = NewContext();
+        db.Guilds.Add(new GuildEntity { DiscordId = discordId, Name = "Existing" });
+        await db.SaveChangesAsync();
+        _log.Entries.Clear();
+    }
+
+    private DiscordDbContext NewContext()
+    {
+        var options = new DbContextOptionsBuilder<DiscordDbContext>()
+            .UseNpgsql(fixture.Container.GetConnectionString())
+            .UseSnakeCaseNamingConvention()
+            .UseLoggerFactory(_log.AsLoggerFactory())
+            .Options;
+        return new DiscordDbContext(options);
+    }
+}

--- a/tests/DiscordEventService.Tests/UpsertConflictLogLevelTests.cs
+++ b/tests/DiscordEventService.Tests/UpsertConflictLogLevelTests.cs
@@ -25,7 +25,7 @@ public sealed class UpsertConflictLogLevelTests(PostgresFixture fixture)
     public Task DisposeAsync() => Task.CompletedTask;
 
     [Fact]
-    public async Task UpsertAsync_WhenInsertConflicts_LogsNoErrorAndKeepsDebugDiagnostic()
+    public async Task UpsertAsync_WhenInsertConflicts_LogsNoErrorAndKeepsWarningDiagnostic()
     {
         await SeedAsync(500UL);
 
@@ -43,7 +43,7 @@ public sealed class UpsertConflictLogLevelTests(PostgresFixture fixture)
     }
 
     [Fact]
-    public async Task GetOrInsertAsync_WhenInsertConflicts_LogsNoErrorAndKeepsDebugDiagnostic()
+    public async Task GetOrInsertAsync_WhenInsertConflicts_LogsNoErrorAndKeepsWarningDiagnostic()
     {
         await SeedAsync(600UL);
 

--- a/tests/DiscordEventService.Tests/UpsertConflictLogLevelTests.cs
+++ b/tests/DiscordEventService.Tests/UpsertConflictLogLevelTests.cs
@@ -61,8 +61,8 @@ public sealed class UpsertConflictLogLevelTests(PostgresFixture fixture)
     {
         Assert.DoesNotContain(_log.Entries, e => e.Level >= LogLevel.Error);
 
-        // Downgraded, not silenced — Warning clears the appsettings.json floor for EF, so this
-        // assertion describes prod behaviour and not just the always-enabled test logger.
+        // Downgraded, not silenced — Warning clears every EF category floor this service runs
+        // with, so this describes prod behaviour and not just the always-enabled test logger.
         Assert.Contains(_log.Entries, e =>
             e.Level == LogLevel.Warning && e.Message.Contains("23505", StringComparison.Ordinal));
     }

--- a/tests/DiscordEventService.Tests/UpsertConflictLogLevelTests.cs
+++ b/tests/DiscordEventService.Tests/UpsertConflictLogLevelTests.cs
@@ -7,7 +7,8 @@ using Xunit;
 namespace DiscordEventService.Tests;
 
 // Pins the #314 contract: a 23505 the upsert primitives handle by design must leave no Error
-// record behind, while staying traceable at Debug.
+// record behind, while staying visible at Warning — above the prod category floor, so the SQL
+// and parameters EF renders on a real failure survive too.
 public sealed class UpsertConflictLogLevelTests(PostgresFixture fixture)
     : IClassFixture<PostgresFixture>, IAsyncLifetime
 {
@@ -60,9 +61,10 @@ public sealed class UpsertConflictLogLevelTests(PostgresFixture fixture)
     {
         Assert.DoesNotContain(_log.Entries, e => e.Level >= LogLevel.Error);
 
-        // Downgraded, not silenced: the failure is still traceable when Debug is enabled.
+        // Downgraded, not silenced — Warning clears the appsettings.json floor for EF, so this
+        // assertion describes prod behaviour and not just the always-enabled test logger.
         Assert.Contains(_log.Entries, e =>
-            e.Level == LogLevel.Debug && e.Message.Contains("23505", StringComparison.Ordinal));
+            e.Level == LogLevel.Warning && e.Message.Contains("23505", StringComparison.Ordinal));
     }
 
     private async Task SeedAsync(ulong discordId)


### PR DESCRIPTION
Closes #314.

## The problem, corrected

The issue originally proposed catching the 23505 at the upsert seam. **That catch already exists** — `DbSetUpsertExtensions.UpsertAsync` (`:31`) and `GetOrInsertAsync` (`:61`) both handle the conflict, which is exactly why prod data has always been correct. Adding another catch would have been a no-op.

The Error lines never came from our code. EF emits them from *inside* `SaveChangesAsync`, before the caller's `catch` runs:

| event | logger category | default level |
|---|---|---|
| `RelationalEventId.CommandError` | `Microsoft.EntityFrameworkCore.Database.Command` | Error |
| `CoreEventId.SaveChangesFailed` | `Microsoft.EntityFrameworkCore.Update` | Error |

No `try`/`catch` can suppress those — which is why the noise survived a seam that already handled the race.

## The fix

`ConfigureWarnings` downgrading those two event IDs to Warning, in `DiscordDbContext.OnConfiguring` rather than `Program.cs` so the setting travels with the context — Hangfire jobs, the dashboard and the Testcontainers tests all inherit it (a `Program.cs`-only change would have left the behaviour untestable).

Warning rather than Debug: `ConfigureWarnings` cannot filter on `SqlState`, so this covers every command failure, and Debug would fall under the `"Microsoft.EntityFrameworkCore": "Warning"` floor in `appsettings.json` — silencing EF's rendered SQL and parameters in prod on the backfill paths that catch and continue outside `EventPipeline`. Warning kills the Error-level noise #314 is about while staying above that floor, at ~2 Warning lines a week.

**Real failures are unaffected.** `EventPipeline.cs:63` catches every handler exception, logs it at Error with the exception and a `CorrelationId` scope, and records a `FailedEvent` row that `HealthCheckJob` alerts on. EF's own line was a duplicate on the failure path and a false positive on the handled path.

## Rejected alternative

Rewriting the primitives to raw `INSERT ... ON CONFLICT DO NOTHING` so the exception never happens. Correct in principle, disproportionate in practice: 14 call sites across 11 entity types (including the `Messages` hot path), and hand-rolled SQL would bypass the `ITimestamped` stamping hook in `SaveChangesAsync` plus the snowflake value converters — a regression risk on every write path, traded for two log lines a week.

## Verification

- `UpsertConflictLogLevelTests` forces a real 23505 through **both** primitives against Testcontainers Postgres, asserting no `LogLevel.Error` record survives *and* that the diagnostic is still present at Warning (downgraded, not silenced).
- **Negative-checked**: with the `ConfigureWarnings` call removed, both tests fail on the exact `Error, "Failed executing DbCommand"` entry. The test is not vacuous.
- Full suite: 364 passed, 1 skipped (live OpenRouter), 0 failed. `dotnet format --verify-no-changes` clean.

## Prod state at time of fix

7-day Loki window over `discord-event-service`: 4 log lines total at Warning-or-above = 2 error events, both this same race, zero warnings. Channels have no duplicate `discord_id`, 0 placeholder rows, 0 serialization failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
