### PR TITLE
spike: measure a template-DB test fixture (one container + one database per class)

### DIFF
--- a/tests/DiscordEventService.Tests/BackfillChainGuardTests.cs
+++ b/tests/DiscordEventService.Tests/BackfillChainGuardTests.cs
@@ -160,7 +160,7 @@ public sealed class BackfillChainGuardTests(PostgresFixture fixture)
     private DiscordDbContext NewContext()
     {
         var options = new DbContextOptionsBuilder<DiscordDbContext>()
-            .UseNpgsql(fixture.Container.GetConnectionString())
+            .UseNpgsql(fixture.ConnectionString)
             .UseSnakeCaseNamingConvention()
             .Options;
         return new DiscordDbContext(options);

--- a/tests/DiscordEventService.Tests/BackfillIterateWithCheckpointTests.cs
+++ b/tests/DiscordEventService.Tests/BackfillIterateWithCheckpointTests.cs
@@ -112,7 +112,7 @@ public sealed class BackfillIterateWithCheckpointTests(PostgresFixture fixture)
     private DiscordDbContext NewContext()
     {
         var options = new DbContextOptionsBuilder<DiscordDbContext>()
-            .UseNpgsql(fixture.Container.GetConnectionString())
+            .UseNpgsql(fixture.ConnectionString)
             .UseSnakeCaseNamingConvention()
             .Options;
         return new DiscordDbContext(options);

--- a/tests/DiscordEventService.Tests/BackfillJobExecutorTests.cs
+++ b/tests/DiscordEventService.Tests/BackfillJobExecutorTests.cs
@@ -25,7 +25,7 @@ public sealed class BackfillJobExecutorTests(PostgresFixture fixture)
 
         _provider = new ServiceCollection()
             .AddDbContext<DiscordDbContext>(o => o
-                .UseNpgsql(fixture.Container.GetConnectionString())
+                .UseNpgsql(fixture.ConnectionString)
                 .UseSnakeCaseNamingConvention())
             .BuildServiceProvider();
 
@@ -142,7 +142,7 @@ public sealed class BackfillJobExecutorTests(PostgresFixture fixture)
     private DiscordDbContext NewContext()
     {
         var options = new DbContextOptionsBuilder<DiscordDbContext>()
-            .UseNpgsql(fixture.Container.GetConnectionString())
+            .UseNpgsql(fixture.ConnectionString)
             .UseSnakeCaseNamingConvention()
             .Options;
         return new DiscordDbContext(options);

--- a/tests/DiscordEventService.Tests/BackfillStaleCheckpointTests.cs
+++ b/tests/DiscordEventService.Tests/BackfillStaleCheckpointTests.cs
@@ -39,7 +39,7 @@ public sealed class BackfillStaleCheckpointTests(PostgresFixture fixture)
         _jobClient = new RecordingJobClient();
         _provider = new ServiceCollection()
             .AddDbContext<DiscordDbContext>(o => o
-                .UseNpgsql(fixture.Container.GetConnectionString())
+                .UseNpgsql(fixture.ConnectionString)
                 .UseSnakeCaseNamingConvention())
             .AddSingleton<IBackgroundJobClient>(_jobClient)
             .AddScoped<GuildBackfillOrchestrator>()
@@ -121,7 +121,7 @@ public sealed class BackfillStaleCheckpointTests(PostgresFixture fixture)
     private DiscordDbContext NewContext()
     {
         var options = new DbContextOptionsBuilder<DiscordDbContext>()
-            .UseNpgsql(fixture.Container.GetConnectionString())
+            .UseNpgsql(fixture.ConnectionString)
             .UseSnakeCaseNamingConvention()
             .Options;
         return new DiscordDbContext(options);

--- a/tests/DiscordEventService.Tests/ChannelUpsertServiceTests.cs
+++ b/tests/DiscordEventService.Tests/ChannelUpsertServiceTests.cs
@@ -171,7 +171,7 @@ public sealed class ChannelUpsertServiceTests(PostgresFixture fixture) : IClassF
     private DiscordDbContext NewContext()
     {
         var options = new DbContextOptionsBuilder<DiscordDbContext>()
-            .UseNpgsql(fixture.Container.GetConnectionString())
+            .UseNpgsql(fixture.ConnectionString)
             .UseSnakeCaseNamingConvention()
             .Options;
         return new DiscordDbContext(options);

--- a/tests/DiscordEventService.Tests/CommunityStatsTests.cs
+++ b/tests/DiscordEventService.Tests/CommunityStatsTests.cs
@@ -176,7 +176,7 @@ public sealed class CommunityStatsTests(PostgresFixture fixture) : IClassFixture
     private DiscordDbContext NewContext()
     {
         var options = new DbContextOptionsBuilder<DiscordDbContext>()
-            .UseNpgsql(fixture.Container.GetConnectionString())
+            .UseNpgsql(fixture.ConnectionString)
             .UseSnakeCaseNamingConvention()
             .Options;
         return new DiscordDbContext(options);

--- a/tests/DiscordEventService.Tests/ConversationLiveApiTests.cs
+++ b/tests/DiscordEventService.Tests/ConversationLiveApiTests.cs
@@ -170,7 +170,7 @@ public sealed class ConversationLiveApiTests(PostgresFixture fixture)
     private DiscordDbContext NewContext()
     {
         var options = new DbContextOptionsBuilder<DiscordDbContext>()
-            .UseNpgsql(fixture.Container.GetConnectionString())
+            .UseNpgsql(fixture.ConnectionString)
             .UseSnakeCaseNamingConvention()
             .Options;
         return new DiscordDbContext(options);

--- a/tests/DiscordEventService.Tests/ConversationLoopTests.cs
+++ b/tests/DiscordEventService.Tests/ConversationLoopTests.cs
@@ -298,7 +298,7 @@ public sealed class ConversationLoopTests(PostgresFixture fixture)
     private DiscordDbContext NewContext()
     {
         var options = new DbContextOptionsBuilder<DiscordDbContext>()
-            .UseNpgsql(fixture.Container.GetConnectionString())
+            .UseNpgsql(fixture.ConnectionString)
             .UseSnakeCaseNamingConvention()
             .Options;
         return new DiscordDbContext(options);

--- a/tests/DiscordEventService.Tests/ConversationMemoryTests.cs
+++ b/tests/DiscordEventService.Tests/ConversationMemoryTests.cs
@@ -502,7 +502,7 @@ public sealed class ConversationMemoryTests(PostgresFixture fixture)
     private DiscordDbContext NewContext()
     {
         var options = new DbContextOptionsBuilder<DiscordDbContext>()
-            .UseNpgsql(fixture.Container.GetConnectionString())
+            .UseNpgsql(fixture.ConnectionString)
             .UseSnakeCaseNamingConvention()
             .Options;
         return new DiscordDbContext(options);

--- a/tests/DiscordEventService.Tests/ConversationRetryTests.cs
+++ b/tests/DiscordEventService.Tests/ConversationRetryTests.cs
@@ -313,7 +313,7 @@ public sealed class ConversationRetryTests(PostgresFixture fixture)
     private DiscordDbContext NewContext()
     {
         var options = new DbContextOptionsBuilder<DiscordDbContext>()
-            .UseNpgsql(fixture.Container.GetConnectionString())
+            .UseNpgsql(fixture.ConnectionString)
             .UseSnakeCaseNamingConvention()
             .Options;
         return new DiscordDbContext(options);

--- a/tests/DiscordEventService.Tests/ConversationWebSearchTests.cs
+++ b/tests/DiscordEventService.Tests/ConversationWebSearchTests.cs
@@ -262,7 +262,7 @@ public sealed class ConversationWebSearchTests(PostgresFixture fixture)
     private DiscordDbContext NewContext()
     {
         var options = new DbContextOptionsBuilder<DiscordDbContext>()
-            .UseNpgsql(fixture.Container.GetConnectionString())
+            .UseNpgsql(fixture.ConnectionString)
             .UseSnakeCaseNamingConvention()
             .Options;
         return new DiscordDbContext(options);

--- a/tests/DiscordEventService.Tests/DatabaseQueryServiceTests.cs
+++ b/tests/DiscordEventService.Tests/DatabaseQueryServiceTests.cs
@@ -230,7 +230,7 @@ public sealed class DatabaseQueryServiceTests(PostgresFixture fixture)
     private DiscordDbContext NewContext()
     {
         var options = new DbContextOptionsBuilder<DiscordDbContext>()
-            .UseNpgsql(fixture.Container.GetConnectionString())
+            .UseNpgsql(fixture.ConnectionString)
             .UseSnakeCaseNamingConvention()
             .Options;
         return new DiscordDbContext(options);

--- a/tests/DiscordEventService.Tests/EmoteUpsertServiceTests.cs
+++ b/tests/DiscordEventService.Tests/EmoteUpsertServiceTests.cs
@@ -152,7 +152,7 @@ public sealed class EmoteUpsertServiceTests(PostgresFixture fixture) : IClassFix
     private DiscordDbContext NewContext()
     {
         var options = new DbContextOptionsBuilder<DiscordDbContext>()
-            .UseNpgsql(fixture.Container.GetConnectionString())
+            .UseNpgsql(fixture.ConnectionString)
             .UseSnakeCaseNamingConvention()
             .Options;
         return new DiscordDbContext(options);

--- a/tests/DiscordEventService.Tests/EntitiesControllerTests.cs
+++ b/tests/DiscordEventService.Tests/EntitiesControllerTests.cs
@@ -124,7 +124,7 @@ public sealed class EntitiesControllerTests(PostgresFixture fixture) : IClassFix
     private DiscordDbContext NewContext()
     {
         var options = new DbContextOptionsBuilder<DiscordDbContext>()
-            .UseNpgsql(fixture.Container.GetConnectionString())
+            .UseNpgsql(fixture.ConnectionString)
             .UseSnakeCaseNamingConvention()
             .Options;
         return new DiscordDbContext(options);

--- a/tests/DiscordEventService.Tests/FailedEventResolveTests.cs
+++ b/tests/DiscordEventService.Tests/FailedEventResolveTests.cs
@@ -97,7 +97,7 @@ public sealed class FailedEventResolveTests(PostgresFixture fixture)
     private DiscordDbContext NewContext()
     {
         var options = new DbContextOptionsBuilder<DiscordDbContext>()
-            .UseNpgsql(fixture.Container.GetConnectionString())
+            .UseNpgsql(fixture.ConnectionString)
             .UseSnakeCaseNamingConvention()
             .Options;
         return new DiscordDbContext(options);

--- a/tests/DiscordEventService.Tests/FkResolverResolveTests.cs
+++ b/tests/DiscordEventService.Tests/FkResolverResolveTests.cs
@@ -168,7 +168,7 @@ public sealed class FkResolverResolveTests(PostgresFixture fixture) : IClassFixt
     private DiscordDbContext NewContext()
     {
         var options = new DbContextOptionsBuilder<DiscordDbContext>()
-            .UseNpgsql(fixture.Container.GetConnectionString())
+            .UseNpgsql(fixture.ConnectionString)
             .UseSnakeCaseNamingConvention()
             .Options;
         return new DiscordDbContext(options);

--- a/tests/DiscordEventService.Tests/GetOrInsertTests.cs
+++ b/tests/DiscordEventService.Tests/GetOrInsertTests.cs
@@ -86,7 +86,7 @@ public sealed class GetOrInsertTests(PostgresFixture fixture) : IClassFixture<Po
     private DiscordDbContext NewContext()
     {
         var options = new DbContextOptionsBuilder<DiscordDbContext>()
-            .UseNpgsql(fixture.Container.GetConnectionString())
+            .UseNpgsql(fixture.ConnectionString)
             .UseSnakeCaseNamingConvention()
             .Options;
         return new DiscordDbContext(options);

--- a/tests/DiscordEventService.Tests/GuildControllerTests.cs
+++ b/tests/DiscordEventService.Tests/GuildControllerTests.cs
@@ -129,7 +129,7 @@ public sealed class GuildControllerTests(PostgresFixture fixture) : IClassFixtur
     private DiscordDbContext NewContext()
     {
         var options = new DbContextOptionsBuilder<DiscordDbContext>()
-            .UseNpgsql(fixture.Container.GetConnectionString())
+            .UseNpgsql(fixture.ConnectionString)
             .UseSnakeCaseNamingConvention()
             .Options;
         return new DiscordDbContext(options);

--- a/tests/DiscordEventService.Tests/GuildStatsServiceTests.cs
+++ b/tests/DiscordEventService.Tests/GuildStatsServiceTests.cs
@@ -138,7 +138,7 @@ public sealed class GuildStatsServiceTests(PostgresFixture fixture) : IClassFixt
     private DiscordDbContext NewContext()
     {
         var options = new DbContextOptionsBuilder<DiscordDbContext>()
-            .UseNpgsql(fixture.Container.GetConnectionString())
+            .UseNpgsql(fixture.ConnectionString)
             .UseSnakeCaseNamingConvention()
             .Options;
         return new DiscordDbContext(options);

--- a/tests/DiscordEventService.Tests/GuildUpsertServiceTests.cs
+++ b/tests/DiscordEventService.Tests/GuildUpsertServiceTests.cs
@@ -92,7 +92,7 @@ public sealed class GuildUpsertServiceTests(PostgresFixture fixture) : IClassFix
     private DiscordDbContext NewContext()
     {
         var options = new DbContextOptionsBuilder<DiscordDbContext>()
-            .UseNpgsql(fixture.Container.GetConnectionString())
+            .UseNpgsql(fixture.ConnectionString)
             .UseSnakeCaseNamingConvention()
             .Options;
         return new DiscordDbContext(options);

--- a/tests/DiscordEventService.Tests/GuildUpsertTests.cs
+++ b/tests/DiscordEventService.Tests/GuildUpsertTests.cs
@@ -1,22 +1,9 @@
 using DiscordEventService.Data;
 using DiscordEventService.Data.Entities.Core;
 using Microsoft.EntityFrameworkCore;
-using Testcontainers.PostgreSql;
 using Xunit;
 
 namespace DiscordEventService.Tests;
-
-public sealed class PostgresFixture : IAsyncLifetime
-{
-    // uuidv7() default value SQL in the migrations requires PostgreSQL 18.
-    public PostgreSqlContainer Container { get; } = new PostgreSqlBuilder()
-        .WithImage("postgres:18")
-        .Build();
-
-    public Task InitializeAsync() => Container.StartAsync();
-
-    public Task DisposeAsync() => Container.DisposeAsync().AsTask();
-}
 
 public sealed class GuildUpsertTests(PostgresFixture fixture) : IClassFixture<PostgresFixture>, IAsyncLifetime
 {
@@ -115,7 +102,7 @@ public sealed class GuildUpsertTests(PostgresFixture fixture) : IClassFixture<Po
     private DiscordDbContext NewContext()
     {
         var options = new DbContextOptionsBuilder<DiscordDbContext>()
-            .UseNpgsql(fixture.Container.GetConnectionString())
+            .UseNpgsql(fixture.ConnectionString)
             .UseSnakeCaseNamingConvention()
             .Options;
         return new DiscordDbContext(options);

--- a/tests/DiscordEventService.Tests/HangfireSlidingInvisibilityTests.cs
+++ b/tests/DiscordEventService.Tests/HangfireSlidingInvisibilityTests.cs
@@ -62,7 +62,7 @@ public sealed class HangfireSlidingInvisibilityTests(PostgresFixture fixture) : 
             InvisibilityTimeout = InvisibilityTimeout,
             QueuePollInterval = TimeSpan.FromMilliseconds(250)
         };
-        storage = new PostgreSqlStorage(new NpgsqlConnectionFactory(fixture.Container.GetConnectionString(), options), options);
+        storage = new PostgreSqlStorage(new NpgsqlConnectionFactory(fixture.ConnectionString, options), options);
 
         return new BackgroundJobServer(
             new BackgroundJobServerOptions

--- a/tests/DiscordEventService.Tests/HealthCheckEventRatioTests.cs
+++ b/tests/DiscordEventService.Tests/HealthCheckEventRatioTests.cs
@@ -53,7 +53,7 @@ public sealed class HealthCheckEventRatioTests(PostgresFixture fixture)
         var handler = new CapturingHandler();
         await using var provider = new ServiceCollection()
             .AddDbContext<DiscordDbContext>(o => o
-                .UseNpgsql(fixture.Container.GetConnectionString())
+                .UseNpgsql(fixture.ConnectionString)
                 .UseSnakeCaseNamingConvention())
             .BuildServiceProvider();
 
@@ -86,7 +86,7 @@ public sealed class HealthCheckEventRatioTests(PostgresFixture fixture)
     private DiscordDbContext NewContext()
     {
         var options = new DbContextOptionsBuilder<DiscordDbContext>()
-            .UseNpgsql(fixture.Container.GetConnectionString())
+            .UseNpgsql(fixture.ConnectionString)
             .UseSnakeCaseNamingConvention()
             .Options;
         return new DiscordDbContext(options);

--- a/tests/DiscordEventService.Tests/LifecycleFactConstraintTests.cs
+++ b/tests/DiscordEventService.Tests/LifecycleFactConstraintTests.cs
@@ -106,7 +106,7 @@ public sealed class LifecycleFactConstraintTests(PostgresFixture fixture)
     private DiscordDbContext NewContext()
     {
         var options = new DbContextOptionsBuilder<DiscordDbContext>()
-            .UseNpgsql(fixture.Container.GetConnectionString())
+            .UseNpgsql(fixture.ConnectionString)
             .UseSnakeCaseNamingConvention()
             .Options;
         return new DiscordDbContext(options);

--- a/tests/DiscordEventService.Tests/MemeIndexLiveAndSweepTests.cs
+++ b/tests/DiscordEventService.Tests/MemeIndexLiveAndSweepTests.cs
@@ -267,7 +267,7 @@ public sealed class MemeIndexLiveAndSweepTests(PostgresFixture fixture) : IClass
         var services = new ServiceCollection();
         services.AddLogging();
         services.AddDbContext<DiscordDbContext>(o => o
-            .UseNpgsql(fixture.Container.GetConnectionString())
+            .UseNpgsql(fixture.ConnectionString)
             .UseSnakeCaseNamingConvention());
         services.Configure<MemeIndexOptions>(o => o.ChannelIds = channelIds ?? [ChannelDiscordId]);
         services.Configure<OpenRouterOptions>(o =>
@@ -331,7 +331,7 @@ public sealed class MemeIndexLiveAndSweepTests(PostgresFixture fixture) : IClass
     private DiscordDbContext NewContext()
     {
         var options = new DbContextOptionsBuilder<DiscordDbContext>()
-            .UseNpgsql(fixture.Container.GetConnectionString())
+            .UseNpgsql(fixture.ConnectionString)
             .UseSnakeCaseNamingConvention()
             .Options;
         return new DiscordDbContext(options);

--- a/tests/DiscordEventService.Tests/MemeIndexSchemaTests.cs
+++ b/tests/DiscordEventService.Tests/MemeIndexSchemaTests.cs
@@ -154,7 +154,7 @@ public sealed class MemeIndexSchemaTests(PostgresFixture fixture) : IClassFixtur
 
     private async Task<List<long>> SearchByVectorAsync(string query)
     {
-        await using var connection = new NpgsqlConnection(fixture.Container.GetConnectionString());
+        await using var connection = new NpgsqlConnection(fixture.ConnectionString);
         await connection.OpenAsync();
         await using var command = connection.CreateCommand();
         // Raw SQL: LINQ cannot express the custom public.f_unaccent function or
@@ -170,7 +170,7 @@ public sealed class MemeIndexSchemaTests(PostgresFixture fixture) : IClassFixtur
 
     private async Task<List<long>> SearchByTrigramAsync(string query)
     {
-        await using var connection = new NpgsqlConnection(fixture.Container.GetConnectionString());
+        await using var connection = new NpgsqlConnection(fixture.ConnectionString);
         await connection.OpenAsync();
         await using var command = connection.CreateCommand();
         // Raw SQL: LINQ cannot express the custom public.f_unaccent / word_similarity
@@ -226,7 +226,7 @@ public sealed class MemeIndexSchemaTests(PostgresFixture fixture) : IClassFixtur
     private DiscordDbContext NewContext()
     {
         var options = new DbContextOptionsBuilder<DiscordDbContext>()
-            .UseNpgsql(fixture.Container.GetConnectionString())
+            .UseNpgsql(fixture.ConnectionString)
             .UseSnakeCaseNamingConvention()
             .Options;
         return new DiscordDbContext(options);

--- a/tests/DiscordEventService.Tests/MemeIndexingJobTests.cs
+++ b/tests/DiscordEventService.Tests/MemeIndexingJobTests.cs
@@ -431,7 +431,7 @@ public sealed class MemeIndexingJobTests(PostgresFixture fixture) : IClassFixtur
         var services = new ServiceCollection();
         services.AddLogging();
         services.AddDbContext<DiscordDbContext>(o => o
-            .UseNpgsql(fixture.Container.GetConnectionString())
+            .UseNpgsql(fixture.ConnectionString)
             .UseSnakeCaseNamingConvention());
         services.Configure<MemeIndexOptions>(o =>
         {
@@ -488,7 +488,7 @@ public sealed class MemeIndexingJobTests(PostgresFixture fixture) : IClassFixtur
     private DiscordDbContext NewContext()
     {
         var options = new DbContextOptionsBuilder<DiscordDbContext>()
-            .UseNpgsql(fixture.Container.GetConnectionString())
+            .UseNpgsql(fixture.ConnectionString)
             .UseSnakeCaseNamingConvention()
             .Options;
         return new DiscordDbContext(options);

--- a/tests/DiscordEventService.Tests/MemeSampleServiceTests.cs
+++ b/tests/DiscordEventService.Tests/MemeSampleServiceTests.cs
@@ -127,7 +127,7 @@ public sealed class MemeSampleServiceTests(PostgresFixture fixture) : IClassFixt
     private DiscordDbContext NewContext()
     {
         var options = new DbContextOptionsBuilder<DiscordDbContext>()
-            .UseNpgsql(fixture.Container.GetConnectionString())
+            .UseNpgsql(fixture.ConnectionString)
             .UseSnakeCaseNamingConvention()
             .Options;
         return new DiscordDbContext(options);

--- a/tests/DiscordEventService.Tests/MemeSearchServiceTests.cs
+++ b/tests/DiscordEventService.Tests/MemeSearchServiceTests.cs
@@ -260,7 +260,7 @@ public sealed class MemeSearchServiceTests(PostgresFixture fixture) : IClassFixt
     private DiscordDbContext NewContext()
     {
         var options = new DbContextOptionsBuilder<DiscordDbContext>()
-            .UseNpgsql(fixture.Container.GetConnectionString())
+            .UseNpgsql(fixture.ConnectionString)
             .UseSnakeCaseNamingConvention()
             .Options;
         return new DiscordDbContext(options);

--- a/tests/DiscordEventService.Tests/PostgresFixture.cs
+++ b/tests/DiscordEventService.Tests/PostgresFixture.cs
@@ -14,9 +14,12 @@ public sealed class PostgresFixture : IAsyncLifetime
 {
     private const string TemplateDatabase = "migrated_template";
 
-    // uuidv7() default value SQL in the migrations requires PostgreSQL 18.
+    // uuidv7() default value SQL in the migrations requires PostgreSQL 18. Every class now shares
+    // one server's connection budget instead of having a private one, so raise it well clear of the
+    // measured peak (63 backends) rather than sitting two thirds into the default 100.
     private static readonly PostgreSqlContainer Container = new PostgreSqlBuilder()
         .WithImage("postgres:18")
+        .WithCommand("-c", "max_connections=300")
         .Build();
 
     private static readonly Lazy<Task<string>> Template = new(EnsureTemplateAsync);
@@ -49,7 +52,14 @@ public sealed class PostgresFixture : IAsyncLifetime
 
     // The container outlives every fixture instance, so it is not disposed here; Testcontainers'
     // reaper removes it when the test process exits. Cloned databases die with the container.
-    public Task DisposeAsync() => Task.CompletedTask;
+    // The pool is cleared, though: Npgsql keys pools by connection string and holds physical
+    // connections for ConnectionIdleLifetime (300s, longer than the whole suite), so without this
+    // the live count grows with total classes rather than concurrent ones.
+    public Task DisposeAsync()
+    {
+        NpgsqlConnection.ClearPool(new NpgsqlConnection(ConnectionString));
+        return Task.CompletedTask;
+    }
 
     private static async Task<string> EnsureTemplateAsync()
     {

--- a/tests/DiscordEventService.Tests/PostgresFixture.cs
+++ b/tests/DiscordEventService.Tests/PostgresFixture.cs
@@ -57,6 +57,12 @@ public sealed class PostgresFixture : IAsyncLifetime
     // the live count grows with total classes rather than concurrent ones.
     public Task DisposeAsync()
     {
+        // xUnit still disposes a fixture whose InitializeAsync faulted, and there is no pool to
+        // clear in that case; returning early keeps a real startup failure from being buried under
+        // 43 secondary exceptions.
+        if (ConnectionString is null)
+            return Task.CompletedTask;
+
         NpgsqlConnection.ClearPool(new NpgsqlConnection(ConnectionString));
         return Task.CompletedTask;
     }

--- a/tests/DiscordEventService.Tests/PostgresFixture.cs
+++ b/tests/DiscordEventService.Tests/PostgresFixture.cs
@@ -1,0 +1,91 @@
+using DiscordEventService.Data;
+using Microsoft.EntityFrameworkCore;
+using Npgsql;
+using Testcontainers.PostgreSql;
+using Xunit;
+
+namespace DiscordEventService.Tests;
+
+// One container for the suite, one database per class: cloning a pre-migrated template is a file
+// copy rather than a 29-migration replay, and keeping a database per class is what lets the
+// truncation-based isolation and whole-table assertions stay correct under xUnit's parallelism.
+// Public because the public test classes name it in IClassFixture<>.
+public sealed class PostgresFixture : IAsyncLifetime
+{
+    private const string TemplateDatabase = "migrated_template";
+
+    // uuidv7() default value SQL in the migrations requires PostgreSQL 18.
+    private static readonly PostgreSqlContainer Container = new PostgreSqlBuilder()
+        .WithImage("postgres:18")
+        .Build();
+
+    private static readonly Lazy<Task<string>> Template = new(EnsureTemplateAsync);
+
+    // Postgres refuses to clone a template that has an open session, so clones cannot overlap.
+    private static readonly SemaphoreSlim CloneGate = new(1, 1);
+
+    private static int _databaseCounter;
+
+    // Points at this class's own cloned database, not the container's default one.
+    public string ConnectionString { get; private set; } = null!;
+
+    public async Task InitializeAsync()
+    {
+        var admin = await Template.Value;
+        var database = $"test_{Interlocked.Increment(ref _databaseCounter)}";
+
+        await CloneGate.WaitAsync();
+        try
+        {
+            await ExecuteAsync(admin, $"CREATE DATABASE {database} TEMPLATE {TemplateDatabase}");
+        }
+        finally
+        {
+            CloneGate.Release();
+        }
+
+        ConnectionString = WithDatabase(admin, database);
+    }
+
+    // The container outlives every fixture instance, so it is not disposed here; Testcontainers'
+    // reaper removes it when the test process exits. Cloned databases die with the container.
+    public Task DisposeAsync() => Task.CompletedTask;
+
+    private static async Task<string> EnsureTemplateAsync()
+    {
+        await Container.StartAsync();
+        var admin = Container.GetConnectionString();
+        await ExecuteAsync(admin, $"CREATE DATABASE {TemplateDatabase}");
+
+        // Pooling=false: a pooled connection outlives the DbContext and would make every later
+        // CREATE DATABASE ... TEMPLATE fail with "source database is being accessed by other users".
+        var options = new DbContextOptionsBuilder<DiscordDbContext>()
+            .UseNpgsql(WithDatabase(admin, TemplateDatabase, pooling: false))
+            .UseSnakeCaseNamingConvention()
+            .Options;
+        await using (var db = new DiscordDbContext(options))
+        {
+            await db.Database.MigrateAsync();
+        }
+
+        NpgsqlConnection.ClearAllPools();
+
+        // Nothing may connect to the template again. Without this, a stray connection turns into
+        // an intermittent clone failure; with it, the mistake fails loudly and immediately.
+        await ExecuteAsync(admin, $"ALTER DATABASE {TemplateDatabase} WITH ALLOW_CONNECTIONS false");
+
+        return admin;
+    }
+
+    private static string WithDatabase(string connectionString, string database, bool pooling = true) =>
+        new NpgsqlConnectionStringBuilder(connectionString) { Database = database, Pooling = pooling }
+            .ConnectionString;
+
+    private static async Task ExecuteAsync(string connectionString, string sql)
+    {
+        await using var connection = new NpgsqlConnection(connectionString);
+        await connection.OpenAsync();
+        await using var command = new NpgsqlCommand(sql, connection);
+        await command.ExecuteNonQueryAsync();
+    }
+}

--- a/tests/DiscordEventService.Tests/ProfileTests.cs
+++ b/tests/DiscordEventService.Tests/ProfileTests.cs
@@ -177,7 +177,7 @@ public sealed class ProfileTests(PostgresFixture fixture) : IClassFixture<Postgr
     private DiscordDbContext NewContext()
     {
         var options = new DbContextOptionsBuilder<DiscordDbContext>()
-            .UseNpgsql(fixture.Container.GetConnectionString())
+            .UseNpgsql(fixture.ConnectionString)
             .UseSnakeCaseNamingConvention()
             .Options;
         return new DiscordDbContext(options);

--- a/tests/DiscordEventService.Tests/RawEventSerializationTests.cs
+++ b/tests/DiscordEventService.Tests/RawEventSerializationTests.cs
@@ -97,7 +97,7 @@ public sealed class RawEventLogPersistenceTests(PostgresFixture fixture)
     private DiscordDbContext NewContext()
     {
         var options = new DbContextOptionsBuilder<DiscordDbContext>()
-            .UseNpgsql(fixture.Container.GetConnectionString())
+            .UseNpgsql(fixture.ConnectionString)
             .UseSnakeCaseNamingConvention()
             .Options;
         return new DiscordDbContext(options);

--- a/tests/DiscordEventService.Tests/RawEventsControllerTests.cs
+++ b/tests/DiscordEventService.Tests/RawEventsControllerTests.cs
@@ -106,7 +106,7 @@ public sealed class RawEventsControllerTests(PostgresFixture fixture) : IClassFi
     private DiscordDbContext NewContext()
     {
         var options = new DbContextOptionsBuilder<DiscordDbContext>()
-            .UseNpgsql(fixture.Container.GetConnectionString())
+            .UseNpgsql(fixture.ConnectionString)
             .UseSnakeCaseNamingConvention()
             .Options;
         return new DiscordDbContext(options);

--- a/tests/DiscordEventService.Tests/RoleUpsertServiceTests.cs
+++ b/tests/DiscordEventService.Tests/RoleUpsertServiceTests.cs
@@ -138,7 +138,7 @@ public sealed class RoleUpsertServiceTests(PostgresFixture fixture) : IClassFixt
     private DiscordDbContext NewContext()
     {
         var options = new DbContextOptionsBuilder<DiscordDbContext>()
-            .UseNpgsql(fixture.Container.GetConnectionString())
+            .UseNpgsql(fixture.ConnectionString)
             .UseSnakeCaseNamingConvention()
             .Options;
         return new DiscordDbContext(options);

--- a/tests/DiscordEventService.Tests/SpotifyStatsTests.cs
+++ b/tests/DiscordEventService.Tests/SpotifyStatsTests.cs
@@ -108,7 +108,7 @@ public sealed class SpotifyStatsTests(PostgresFixture fixture) : IClassFixture<P
     private DiscordDbContext NewContext()
     {
         var options = new DbContextOptionsBuilder<DiscordDbContext>()
-            .UseNpgsql(fixture.Container.GetConnectionString())
+            .UseNpgsql(fixture.ConnectionString)
             .UseSnakeCaseNamingConvention()
             .Options;
         return new DiscordDbContext(options);

--- a/tests/DiscordEventService.Tests/StartupBackfillSweepTests.cs
+++ b/tests/DiscordEventService.Tests/StartupBackfillSweepTests.cs
@@ -28,7 +28,7 @@ public sealed class StartupBackfillSweepTests(PostgresFixture fixture)
         _jobClient = new RecordingJobClient();
         _provider = new ServiceCollection()
             .AddDbContext<DiscordDbContext>(o => o
-                .UseNpgsql(fixture.Container.GetConnectionString())
+                .UseNpgsql(fixture.ConnectionString)
                 .UseSnakeCaseNamingConvention())
             .BuildServiceProvider();
     }
@@ -137,7 +137,7 @@ public sealed class StartupBackfillSweepTests(PostgresFixture fixture)
     private DiscordDbContext NewContext()
     {
         var options = new DbContextOptionsBuilder<DiscordDbContext>()
-            .UseNpgsql(fixture.Container.GetConnectionString())
+            .UseNpgsql(fixture.ConnectionString)
             .UseSnakeCaseNamingConvention()
             .Options;
         return new DiscordDbContext(options);

--- a/tests/DiscordEventService.Tests/StatsControllerTests.cs
+++ b/tests/DiscordEventService.Tests/StatsControllerTests.cs
@@ -238,7 +238,7 @@ public sealed class StatsControllerTests(PostgresFixture fixture) : IClassFixtur
     private DiscordDbContext NewContext()
     {
         var options = new DbContextOptionsBuilder<DiscordDbContext>()
-            .UseNpgsql(fixture.Container.GetConnectionString())
+            .UseNpgsql(fixture.ConnectionString)
             .UseSnakeCaseNamingConvention()
             .Options;
         return new DiscordDbContext(options);

--- a/tests/DiscordEventService.Tests/StickerUpsertServiceTests.cs
+++ b/tests/DiscordEventService.Tests/StickerUpsertServiceTests.cs
@@ -175,7 +175,7 @@ public sealed class StickerUpsertServiceTests(PostgresFixture fixture) : IClassF
     private DiscordDbContext NewContext()
     {
         var options = new DbContextOptionsBuilder<DiscordDbContext>()
-            .UseNpgsql(fixture.Container.GetConnectionString())
+            .UseNpgsql(fixture.ConnectionString)
             .UseSnakeCaseNamingConvention()
             .Options;
         return new DiscordDbContext(options);

--- a/tests/DiscordEventService.Tests/TablesControllerTests.cs
+++ b/tests/DiscordEventService.Tests/TablesControllerTests.cs
@@ -150,7 +150,7 @@ public sealed class TablesControllerTests(PostgresFixture fixture) : IClassFixtu
     private DiscordDbContext NewContext()
     {
         var options = new DbContextOptionsBuilder<DiscordDbContext>()
-            .UseNpgsql(fixture.Container.GetConnectionString())
+            .UseNpgsql(fixture.ConnectionString)
             .UseSnakeCaseNamingConvention()
             .Options;
         return new DiscordDbContext(options);

--- a/tests/DiscordEventService.Tests/TimelineControllerTests.cs
+++ b/tests/DiscordEventService.Tests/TimelineControllerTests.cs
@@ -136,7 +136,7 @@ public sealed class TimelineControllerTests(PostgresFixture fixture) : IClassFix
     private DiscordDbContext NewContext()
     {
         var options = new DbContextOptionsBuilder<DiscordDbContext>()
-            .UseNpgsql(fixture.Container.GetConnectionString())
+            .UseNpgsql(fixture.ConnectionString)
             .UseSnakeCaseNamingConvention()
             .Options;
         return new DiscordDbContext(options);

--- a/tests/DiscordEventService.Tests/UpsertConflictLogLevelTests.cs
+++ b/tests/DiscordEventService.Tests/UpsertConflictLogLevelTests.cs
@@ -78,7 +78,7 @@ public sealed class UpsertConflictLogLevelTests(PostgresFixture fixture)
     private DiscordDbContext NewContext()
     {
         var options = new DbContextOptionsBuilder<DiscordDbContext>()
-            .UseNpgsql(fixture.Container.GetConnectionString())
+            .UseNpgsql(fixture.ConnectionString)
             .UseSnakeCaseNamingConvention()
             .UseLoggerFactory(_log.AsLoggerFactory())
             .Options;

--- a/tests/DiscordEventService.Tests/UsageAlertTests.cs
+++ b/tests/DiscordEventService.Tests/UsageAlertTests.cs
@@ -306,7 +306,7 @@ public sealed class UsageAlertTests(PostgresFixture fixture)
     private DiscordDbContext NewContext()
     {
         var options = new DbContextOptionsBuilder<DiscordDbContext>()
-            .UseNpgsql(fixture.Container.GetConnectionString())
+            .UseNpgsql(fixture.ConnectionString)
             .UseSnakeCaseNamingConvention()
             .Options;
         return new DiscordDbContext(options);

--- a/tests/DiscordEventService.Tests/UserUpsertTests.cs
+++ b/tests/DiscordEventService.Tests/UserUpsertTests.cs
@@ -130,7 +130,7 @@ public sealed class UserUpsertTests(PostgresFixture fixture) : IClassFixture<Pos
     private DiscordDbContext NewContext()
     {
         var options = new DbContextOptionsBuilder<DiscordDbContext>()
-            .UseNpgsql(fixture.Container.GetConnectionString())
+            .UseNpgsql(fixture.ConnectionString)
             .UseSnakeCaseNamingConvention()
             .Options;
         return new DiscordDbContext(options);

--- a/tests/DiscordEventService.Tests/VoiceDowntimeAndDailyTests.cs
+++ b/tests/DiscordEventService.Tests/VoiceDowntimeAndDailyTests.cs
@@ -148,7 +148,7 @@ public sealed class VoiceDowntimeAndDailyTests(PostgresFixture fixture) : IClass
     private DiscordDbContext NewContext()
     {
         var options = new DbContextOptionsBuilder<DiscordDbContext>()
-            .UseNpgsql(fixture.Container.GetConnectionString())
+            .UseNpgsql(fixture.ConnectionString)
             .UseSnakeCaseNamingConvention()
             .Options;
         return new DiscordDbContext(options);


### PR DESCRIPTION
**This PR exists to harvest one CI measurement.** Merging is a separate decision — see the open question at the bottom.

## What it does

Replaces the container-per-class `PostgresFixture` with one container per test process plus a per-class database cloned from a pre-migrated template.

```
once per suite:  start Postgres -> CREATE DATABASE template -> MigrateAsync
once per class:  CREATE DATABASE test_<n> TEMPLATE template
```

Every class keeps its own database, so the 137 `ExecuteDeleteAsync` isolation sites and 45 whole-table assertions (`Assert.Equal(1, await db.Guilds.CountAsync())`) stay byte-identical. No test body changed. The 43 touched files are one mechanical rename: `fixture.Container.GetConnectionString()` -> `fixture.ConnectionString`.

`PostgresFixture` also moves out of `GuildUpsertTests.cs` into its own file.

## Measured

Synthetic fixture overhead for 43 classes, median of 3 reps:

| shape | P=4 | P=10 |
|---|---|---|
| container-per-class (today) | 26.0s | 28.8s |
| template clone (this PR) | **3.74s** | **3.54s** |
| shared container, migrate per DB | 10.4s | 11.9s |

The third row is the control: cost splits roughly half container-start, half 29-migration replay. Only the template clone removes both while keeping per-class database isolation.

End-to-end locally, exact CI flags, 3 reps:

| | before | after |
|---|---|---|
| default parallelism | 41 / 60 / 56s | 40 / 41 / 36s |
| `MaxParallelThreads=4` | 49 / 65 / 54s | 42 / 39 / 39s |

The honest read is variance collapse (41-65s -> 36-42s) plus a median gain between 1s and 16s. The local box drifts under container churn, which is why the CI number is the one that matters.

## Context that caps the win

- CI's ~3m17s splits as restore 11s + **format 63s** + build 30s + **test 93s median** (last 12 runs: 89-108s). Only the test step is reachable from here.
- `HangfireSlidingInvisibilityTests` is 21.8s of 35.9s total test time — it sleeps by design and is the critical path regardless of fixture shape.

## Correctness

364 passed / 1 skipped / 0 failed across every run, identical to baseline. Containers reap ~6s after process exit (verified explicitly — the container outlives every fixture instance and Testcontainers' reaper removes it; teardown therefore depends on the reaper, so `TESTCONTAINERS_RYUK_DISABLED=true` environments would leak one container per run).

`DisposeAsync` clears the finished class's Npgsql pool. Measured with `pg_stat_activity` sampled through a full run: peak **63** client backends before that fix (out of a default 100, climbing monotonically and never released), **24** after, with `max_connections=300` on the container for headroom.

## Known constraints, handled

- Postgres refuses to clone a template with an open session, so clones serialise behind a `SemaphoreSlim` and the template is migrated with `Pooling=false` followed by `ClearAllPools()`.
- `ALTER DATABASE ... ALLOW_CONNECTIONS false` on the template turns a would-be intermittent clone failure into an immediate loud one.

## Open question

`dotnet-guidelines` rule 22 prescribes a shared container *and* a shared database. This satisfies the shared container but deliberately keeps a database per class, because sharing one database across parallel classes would trade slow tests for flaky ones given the truncation-based isolation. If this merges, that divergence should be recorded in the guidelines so it stops being re-flagged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
