### PR TITLE
perf(test): scale the Hangfire invisibility class to a 3s window

### DIFF
--- a/tests/DiscordEventService.Tests/HangfireSlidingInvisibilityTests.cs
+++ b/tests/DiscordEventService.Tests/HangfireSlidingInvisibilityTests.cs
@@ -11,14 +11,17 @@ namespace DiscordEventService.Tests;
 // outliving InvisibilityTimeout runs exactly once instead of being re-fetched as dead.
 public sealed class HangfireSlidingInvisibilityTests(PostgresFixture fixture) : IClassFixture<PostgresFixture>
 {
-    private static readonly TimeSpan InvisibilityTimeout = TimeSpan.FromSeconds(5);
+    // Floor, not a preference: PostgreSqlHeartbeatProcess ticks once per second, so a beat can
+    // never land more often than that however small InvisibilityTimeout/5 gets. Under 3s the beat
+    // gap approaches the window and test 1 starts seeing re-fetches under sliding mode.
+    private static readonly TimeSpan InvisibilityTimeout = TimeSpan.FromSeconds(3);
 
-    // Tuned against InvisibilityTimeout: the job must outlive several invisibility
-    // windows, and the waits must cover fetch + (for fixed mode) one re-fetch.
-    private const int JobRuntimeMs = 12_000;
-    private static readonly TimeSpan FirstExecutionTimeout = TimeSpan.FromSeconds(10);
-    private static readonly TimeSpan RefetchTimeout = TimeSpan.FromSeconds(20);
-    private static readonly TimeSpan SettleWindow = TimeSpan.FromSeconds(16);
+    // Multiples, not independent numbers — the proof holds at any scale where the job outlives
+    // several windows and the waits cover fetch plus (fixed mode) one re-fetch.
+    private static readonly int JobRuntimeMs = (int)(InvisibilityTimeout * 2.4).TotalMilliseconds;
+    private static readonly TimeSpan FirstExecutionTimeout = InvisibilityTimeout * 2;
+    private static readonly TimeSpan RefetchTimeout = InvisibilityTimeout * 4;
+    private static readonly TimeSpan SettleWindow = InvisibilityTimeout * 3.2;
     private static readonly TimeSpan PollDelay = TimeSpan.FromMilliseconds(100);
 
     [Fact]

--- a/tests/DiscordEventService.Tests/HangfireSlidingInvisibilityTests.cs
+++ b/tests/DiscordEventService.Tests/HangfireSlidingInvisibilityTests.cs
@@ -29,12 +29,21 @@ public sealed class HangfireSlidingInvisibilityTests(PostgresFixture fixture) : 
     {
         using var server = StartServer("hangfire_sliding", useSliding: true, out var storage);
 
-        new BackgroundJobClient(storage).Enqueue(() => SlowJobProbe.Run("sliding", JobRuntimeMs));
+        try
+        {
+            new BackgroundJobClient(storage).Enqueue(() => SlowJobProbe.Run("sliding", JobRuntimeMs));
 
-        Assert.True(await WaitForAsync(() => SlowJobProbe.ExecutionCount("sliding") >= 1, FirstExecutionTimeout));
-        await Task.Delay(SettleWindow);
+            Assert.True(await WaitForAsync(() => SlowJobProbe.ExecutionCount("sliding") >= 1, FirstExecutionTimeout));
+            await Task.Delay(SettleWindow);
 
-        Assert.Equal(1, SlowJobProbe.ExecutionCount("sliding"));
+            Assert.Equal(1, SlowJobProbe.ExecutionCount("sliding"));
+        }
+        finally
+        {
+            // Releases the probe's worker thread so a failed assert doesn't also burn the job's
+            // remaining runtime plus the server's full ShutdownTimeout on the way out.
+            SlowJobProbe.Stop("sliding");
+        }
     }
 
     [Fact]


### PR DESCRIPTION
Follow-up to #317. That PR measured where the suite's wall clock goes and shipped the template-DB fixture; the same measurement showed `HangfireSlidingInvisibilityTests` was **21.8s of 35.9s** — the suite's critical path, and the reason #317's local gain was capped.

## What changed

`InvisibilityTimeout` 5s → 3s, and every other wait is now expressed as a multiple of it rather than as an independent literal. Ratios are unchanged (`JobRuntime = 2.4×`, `Settle = 3.2×`, `FirstExecution = 2×`, `Refetch = 4×`), so both assertions are the same proof at a smaller scale: test 1 still asserts a job outliving the window runs *exactly once* under sliding mode, test 2 still asserts the fixed-mode control *is* re-fetched.

No `src/` change. Tests only.

## Why 3s and not 1s

The handoff assumed the constants were arbitrary and 1s was reachable. Reading Hangfire.PostgreSql 1.20.13 says otherwise:

- `PostgreSqlFetchedJob` sets the beat interval to `InvisibilityTimeout / 5` — **no floor**
- `PostgreSqlHeartbeatProcess.Execute` drives it with a hardcoded `cancellationToken.Wait(TimeSpan.FromSeconds(1))`

So **1 second is the real floor** on how often `fetchedat` can be refreshed, whatever the interval computes to. That makes 3s the interesting point rather than 1s:

| timeout | beat interval | beats per window | margin |
|---|---|---|---|
| 5s (before) | 1.0s — *exactly* the tick, so beats land every 1–2 ticks | 2.5–5 | 2.5× |
| **3s (now)** | 0.6s — under the tick, so every tick beats | 3 | **3×** |
| 1s | 0.2s, still floored at 1s | 1 | 1× — broken |

At 3s the ratio margin is slightly *better* than it was at 5s. Absolute stall headroom drops from 3s to 2s, which is the real trade and the reason this didn't go lower.

## Verification

The probe's counters are `static`, so an in-process repeat (`[Theory]`, a repeat attribute) accumulates and fails test 1 for reasons unrelated to timing. Verified over **20 separate test-host processes** instead:

- **20/20 green**, zero flakes
- class: **21.8s → 14.4s**
- suite: **35.9s → 30.2s** (364 passed, 1 skipped)

The class is still the longest single class (next is `DatabaseQueryServiceTests` at 2.1s) but the suite is now floor-bound by fixture setup rather than by it, so shrinking it further buys nothing.

⚠️ Local medians are from a 10-core Mac. `ubuntu-latest` is slower and jitterier, so **this PR's CI run is the real verification, not a formality.** If it flakes there the answer is 4s (interval 0.8s, still under the tick, 4× margin, class ~18s) — not back to 5s.

## Related, not in this PR

- **`dotnet format` is now the largest CI step** (42–63s). Split into its own concurrent job in wiktorkowalski/github-workflows#9 — same gate, off the critical path.
- **The #317 guidelines follow-up is done but is out-of-repo.** `~/.claude/skills/dotnet-guidelines/` isn't version controlled, so it can't be in this commit: rule 22 and `topics/testing.md` now sanction the shared-container/per-class-cloned-database shape, so `/dotnet-guidelines` stops re-flagging it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ff9ntQshFctPuzWAVQVPqz