### PR TITLE
DO NOT MERGE — throwaway: measure the format-split workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
   ci:
     # Format, build (-warnaserror), and run the xUnit + Testcontainers suite.
     # ubuntu-latest provides Docker for Testcontainers (Postgres 18).
-    uses: wiktorkowalski/github-workflows/.github/workflows/dotnet-ci.yml@master
+    uses: wiktorkowalski/github-workflows/.github/workflows/dotnet-ci.yml@perf/format-off-critical-path
     with:
       dotnet-version: "10.0.x"
     secrets: inherit


### PR DESCRIPTION
Throwaway branch to get a real wall-clock number for wiktorkowalski/github-workflows#9 instead of shipping a projection. Only change is `ci.yml`'s `uses:` ref. Will be closed and deleted once the run completes.