### PR TITLE
fix: exclude TypingStarted from the ratio-drop check, drop dead EventSettings

### DIFF
--- a/src/DiscordEventService/Configuration/HealthCheckOptions.cs
+++ b/src/DiscordEventService/Configuration/HealthCheckOptions.cs
@@ -26,8 +26,9 @@ internal sealed class HealthCheckOptions
     // alerts — debounces transient lulls on a low-traffic server.
     public int EventRatioConsecutiveRuns { get; set; } = 3;
 
-    // Event types excluded from the ratio-drop check entirely. Voice traffic is
-    // naturally bursty (whole quiet days are normal), so it is excluded by default.
+    // Event types excluded from the ratio-drop check entirely. Voice and typing
+    // traffic is naturally bursty (whole quiet days are normal — attachment-only
+    // messages and bot embeds never fire TypingStarted), so both are excluded by default.
     public string[] EventRatioExcludedEventTypes { get; set; } =
-        ["VoiceStateUpdated", "VoiceServerUpdated"];
+        ["VoiceStateUpdated", "VoiceServerUpdated", "TypingStarted"];
 }

--- a/src/DiscordEventService/appsettings.json
+++ b/src/DiscordEventService/appsettings.json
@@ -20,10 +20,6 @@
     "Token": "",
     "CommandGuildId": null
   },
-  "EventSettings": {
-    "EnablePresenceEvents": true,
-    "EnableTypingEvents": false
-  },
   "OpenRouter": {
     "ApiKey": "",
     "Model": "google/gemini-3-flash-preview"
@@ -49,6 +45,6 @@
     "EventRatioMinWindowBaseline": 10,
     "EventRatioDropThreshold": 0.05,
     "EventRatioConsecutiveRuns": 3,
-    "EventRatioExcludedEventTypes": [ "VoiceStateUpdated", "VoiceServerUpdated" ]
+    "EventRatioExcludedEventTypes": [ "VoiceStateUpdated", "VoiceServerUpdated", "TypingStarted" ]
   }
 }

--- a/tests/DiscordEventService.Tests/DiscordEventService.Tests.csproj
+++ b/tests/DiscordEventService.Tests/DiscordEventService.Tests.csproj
@@ -14,6 +14,8 @@
     <PackageReference Include="xunit" Version="2.9.3" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" />
     <PackageReference Include="Testcontainers.PostgreSql" Version="4.1.0" />
+    <!-- Override Testcontainers' transitive SSH.NET 2024.1.0 — GHSA-q939-rpr3-3284 (NU1903 fails CI); patched in 2026.0.0 -->
+    <PackageReference Include="SSH.NET" Version="2026.0.0" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
## Why

The healthcheck spammed 17 `Event type ratio drop` alerts for `TypingStarted` in 48h (2026-08-12→13). Investigation against prod data showed a behavioral false positive, not an ingestion failure:

- Gateway healthy the whole time: PresenceUpdated/MessageCreated/reactions flowing, zero serialization failures, clean logs.
- Every message in the alert window was either an attachment-only meme (empty content), a pasted link, or a scheduled bot embed — none of these fire `TYPING_START`.
- Zero-typing days are the norm here: 5 of the last 10 days had 0 TypingStarted while messages still flowed.
- The ~15.9 baseline was a mean inflated by a single 63-event burst day (08-09).

## What

- Add `TypingStarted` to `EventRatioExcludedEventTypes` (appsettings + code default), same rationale as the existing voice exclusions: naturally bursty, whole quiet days are normal.
- Remove the `EventSettings` block from appsettings.json — never bound by any code since #45, both flags are no-ops (prod ingested 63 TypingStarted events on 08-09 with `EnableTypingEvents: false`).

The proper data-driven rework of the ratio check stays tracked in #215.

🤖 Generated with [Claude Code](https://claude.com/claude-code)