### PR TITLE
Closes #320: record DbUnreachable downtime from failed heartbeat writes

### DIFF
--- a/src/DiscordEventService/Data/Entities/Core/BotDowntimeIntervalEntity.cs
+++ b/src/DiscordEventService/Data/Entities/Core/BotDowntimeIntervalEntity.cs
@@ -31,5 +31,6 @@ public enum BotDowntimeDetectionMethod
     GracefulStop = 0,
     StartupGapInference = 1,
     GatewayEvent = 2,
-    Manual = 3
+    Manual = 3,
+    HeartbeatWriteFailure = 4
 }

--- a/src/DiscordEventService/Jobs/HealthCheckJob.cs
+++ b/src/DiscordEventService/Jobs/HealthCheckJob.cs
@@ -129,7 +129,9 @@ internal sealed class HealthCheckJob(
         var recentRestarts = await db.BotDowntimeIntervals
             .Where(d => d.StartedAtUtc > windowStart && d.EndedAtUtc != null
                 && d.Type != Data.Entities.Core.BotDowntimeType.GracefulShutdown
-                && d.Type != Data.Entities.Core.BotDowntimeType.Deploy)
+                && d.Type != Data.Entities.Core.BotDowntimeType.Deploy
+                // #320: a DbUnreachable interval is an outage the process survived, not a restart.
+                && d.Type != Data.Entities.Core.BotDowntimeType.DbUnreachable)
             .CountAsync(cancellationToken);
 
         if (recentRestarts < CrashLoopRestartThreshold)

--- a/src/DiscordEventService/Services/DowntimeTrackerService.cs
+++ b/src/DiscordEventService/Services/DowntimeTrackerService.cs
@@ -78,14 +78,16 @@ internal sealed class DowntimeTrackerService(DiscordDbContext db, ILogger<Downti
             EndedAtUtc = window.EndedAtUtc,
             Type = BotDowntimeType.DbUnreachable,
             DetectionMethod = BotDowntimeDetectionMethod.HeartbeatWriteFailure,
+            // "failed writes", not "ticks": a hung write can eat several tick periods, so
+            // the count is not duration/5s.
             Notes = $"Heartbeat writes failed for {(window.EndedAtUtc - window.StartedAtUtc).TotalSeconds:F0}s"
-                + $" ({window.FailedWriteCount} ticks) with the gateway connected"
+                + $" ({window.FailedWriteCount} failed writes) with the gateway connected"
         };
         db.BotDowntimeIntervals.Add(row);
         await db.SaveChangesAsync();
         logger.LogWarning(
-            "Recorded DbUnreachable downtime {DowntimeId}: writes failed for {DurationSeconds:F0}s over {FailedWriteCount} heartbeat ticks",
-            row.Id, (window.EndedAtUtc - window.StartedAtUtc).TotalSeconds, window.FailedWriteCount);
+            "Recorded DbUnreachable downtime {DowntimeId}: {FailedWriteCount} heartbeat writes failed over {DurationSeconds:F0}s",
+            row.Id, window.FailedWriteCount, (window.EndedAtUtc - window.StartedAtUtc).TotalSeconds);
         return row.Id;
     }
 

--- a/src/DiscordEventService/Services/DowntimeTrackerService.cs
+++ b/src/DiscordEventService/Services/DowntimeTrackerService.cs
@@ -68,6 +68,27 @@ internal sealed class DowntimeTrackerService(DiscordDbContext db, ILogger<Downti
         return affected;
     }
 
+    public async Task<Guid> RecordDbUnreachableAsync(UnwritableWindow window)
+    {
+        // Inserted already closed (like InferStartupGapAsync), never opened+closed: the
+        // open could not have been written while the DB was down (#320).
+        var row = new BotDowntimeIntervalEntity
+        {
+            StartedAtUtc = window.StartedAtUtc,
+            EndedAtUtc = window.EndedAtUtc,
+            Type = BotDowntimeType.DbUnreachable,
+            DetectionMethod = BotDowntimeDetectionMethod.HeartbeatWriteFailure,
+            Notes = $"Heartbeat writes failed for {(window.EndedAtUtc - window.StartedAtUtc).TotalSeconds:F0}s"
+                + $" ({window.FailedWriteCount} ticks) with the gateway connected"
+        };
+        db.BotDowntimeIntervals.Add(row);
+        await db.SaveChangesAsync();
+        logger.LogWarning(
+            "Recorded DbUnreachable downtime {DowntimeId}: writes failed for {DurationSeconds:F0}s over {FailedWriteCount} heartbeat ticks",
+            row.Id, (window.EndedAtUtc - window.StartedAtUtc).TotalSeconds, window.FailedWriteCount);
+        return row.Id;
+    }
+
     public async Task RecordHeartbeatAsync(
         DateTime nowUtc,
         bool? isGatewayConnected = null,

--- a/src/DiscordEventService/Services/HeartbeatBackgroundService.cs
+++ b/src/DiscordEventService/Services/HeartbeatBackgroundService.cs
@@ -9,6 +9,12 @@ internal sealed class HeartbeatBackgroundService(
 {
     private static readonly TimeSpan Interval = TimeSpan.FromSeconds(5);
 
+    // #320: only a failed-write streak at least this long becomes a DbUnreachable row —
+    // a single-tick flap is a transient the event-write retry layer already absorbs.
+    private static readonly TimeSpan MinRecordableOutage = TimeSpan.FromSeconds(30);
+
+    private readonly UnwritableWindowTracker _outage = new(MinRecordableOutage);
+
     // Only emit a Debug log on the first occurrence of each consecutive
     // failure streak — avoids per-tick log spam when DSharpPlus has been
     // disconnected for an extended period.
@@ -20,15 +26,34 @@ internal sealed class HeartbeatBackgroundService(
         using var timer = new PeriodicTimer(Interval);
         while (!stoppingToken.IsCancellationRequested)
         {
+            var nowUtc = DateTime.UtcNow;
+            var (isConnected, latencyMs) = ReadGatewayState();
             try
             {
-                var (isConnected, latencyMs) = ReadGatewayState();
                 using var scope = scopeFactory.CreateScope();
                 var tracker = scope.ServiceProvider.GetRequiredService<DowntimeTrackerService>();
-                await tracker.RecordHeartbeatAsync(DateTime.UtcNow, isConnected, latencyMs);
+                await tracker.RecordHeartbeatAsync(nowUtc, isConnected, latencyMs);
+
+                var hadPendingWindow = _outage.HasPendingWindow;
+                var window = _outage.OnWriteSucceeded(nowUtc);
+                if (window is not null)
+                {
+                    // The DB is writable again — persist the whole unwritable stretch as one
+                    // closed DbUnreachable interval (#320). Reset only after the commit, so a
+                    // failure here keeps the window pending and the next tick retries it.
+                    await tracker.RecordDbUnreachableAsync(window);
+                    _outage.Reset();
+                }
+                else if (hadPendingWindow)
+                {
+                    logger.LogDebug(
+                        "Heartbeat writes recovered within {ThresholdSeconds}s — transient, no downtime row",
+                        MinRecordableOutage.TotalSeconds);
+                }
             }
             catch (Exception ex)
             {
+                _outage.OnWriteFailed(nowUtc, isConnected);
                 logger.LogWarning(ex, "Heartbeat write failed; will retry next tick");
             }
 

--- a/src/DiscordEventService/Services/HeartbeatBackgroundService.cs
+++ b/src/DiscordEventService/Services/HeartbeatBackgroundService.cs
@@ -28,11 +28,13 @@ internal sealed class HeartbeatBackgroundService(
         {
             var nowUtc = DateTime.UtcNow;
             var (isConnected, latencyMs) = ReadGatewayState();
+            var heartbeatWritten = false;
             try
             {
                 using var scope = scopeFactory.CreateScope();
                 var tracker = scope.ServiceProvider.GetRequiredService<DowntimeTrackerService>();
                 await tracker.RecordHeartbeatAsync(nowUtc, isConnected, latencyMs);
+                heartbeatWritten = true;
 
                 var hadPendingWindow = _outage.HasPendingWindow;
                 var window = _outage.OnWriteSucceeded(nowUtc);
@@ -51,10 +53,16 @@ internal sealed class HeartbeatBackgroundService(
                         MinRecordableOutage.TotalSeconds);
                 }
             }
-            catch (Exception ex)
+            catch (Exception ex) when (!heartbeatWritten)
             {
+                // Only a failure of the heartbeat write itself counts toward the window —
+                // scope/persist failures on a tick whose heartbeat committed must not.
                 _outage.OnWriteFailed(nowUtc, isConnected);
                 logger.LogWarning(ex, "Heartbeat write failed; will retry next tick");
+            }
+            catch (Exception ex)
+            {
+                logger.LogWarning(ex, "Recording the DbUnreachable interval failed; will retry next tick");
             }
 
             try

--- a/src/DiscordEventService/Services/UnwritableWindowTracker.cs
+++ b/src/DiscordEventService/Services/UnwritableWindowTracker.cs
@@ -9,6 +9,7 @@ namespace DiscordEventService.Services;
 internal sealed class UnwritableWindowTracker(TimeSpan minRecordableWindow)
 {
     private DateTime? _sinceUtc;
+    private DateTime? _recoveredAtUtc;
     private int _failedWrites;
 
     public bool HasPendingWindow => _sinceUtc is not null;
@@ -18,7 +19,11 @@ internal sealed class UnwritableWindowTracker(TimeSpan minRecordableWindow)
         if (_sinceUtc is not null)
         {
             // Once open, the window is owned by this signal even if the gateway drops
-            // mid-outage — the whole unwritable stretch stays one interval.
+            // mid-outage — the whole unwritable stretch stays one interval. A new failure
+            // while a recovered window still awaits its persist re-opens it: the merged
+            // interval over-reports the writable gap between the two outages, but the
+            // alternative is losing the first outage entirely.
+            _recoveredAtUtc = null;
             _failedWrites++;
             return;
         }
@@ -41,13 +46,18 @@ internal sealed class UnwritableWindowTracker(TimeSpan minRecordableWindow)
         if (_sinceUtc is null)
             return null;
 
-        if (nowUtc - _sinceUtc.Value < minRecordableWindow)
+        // Pin the recovery instant to the FIRST successful write. A retry after a failed
+        // persist must not slide EndedAtUtc forward — the DB was writable for that
+        // stretch, and the successful heartbeat rows in it would contradict the interval.
+        _recoveredAtUtc ??= nowUtc;
+
+        if (_recoveredAtUtc.Value - _sinceUtc.Value < minRecordableWindow)
         {
             Reset();
             return null;
         }
 
-        return new UnwritableWindow(_sinceUtc.Value, nowUtc, _failedWrites);
+        return new UnwritableWindow(_sinceUtc.Value, _recoveredAtUtc.Value, _failedWrites);
     }
 
     // Deliberately NOT folded into OnWriteSucceeded for a recordable window: the caller
@@ -56,6 +66,7 @@ internal sealed class UnwritableWindowTracker(TimeSpan minRecordableWindow)
     public void Reset()
     {
         _sinceUtc = null;
+        _recoveredAtUtc = null;
         _failedWrites = 0;
     }
 }

--- a/src/DiscordEventService/Services/UnwritableWindowTracker.cs
+++ b/src/DiscordEventService/Services/UnwritableWindowTracker.cs
@@ -1,0 +1,63 @@
+namespace DiscordEventService.Services;
+
+// The in-memory state machine behind #320: heartbeat writes are the DB-liveness probe
+// (they tick every 5s regardless of Discord activity), so a streak of failed writes IS
+// the unwritable window. In-memory on purpose — during the outage the DB cannot hold
+// state, so the window is buffered here and persisted only after the first successful
+// write. A process restart mid-outage loses it; the startup gap inference then records
+// the tail as Inferred.
+internal sealed class UnwritableWindowTracker(TimeSpan minRecordableWindow)
+{
+    private DateTime? _sinceUtc;
+    private int _failedWrites;
+
+    public bool HasPendingWindow => _sinceUtc is not null;
+
+    public void OnWriteFailed(DateTime nowUtc, bool? gatewayConnected)
+    {
+        if (_sinceUtc is not null)
+        {
+            // Once open, the window is owned by this signal even if the gateway drops
+            // mid-outage — the whole unwritable stretch stays one interval.
+            _failedWrites++;
+            return;
+        }
+
+        // Only a failure with the gateway still up opens a window: with the gateway down
+        // (or unknown) the process is in a full outage the gateway-disconnect and
+        // startup-gap paths already own.
+        if (gatewayConnected != true)
+            return;
+
+        _sinceUtc = nowUtc;
+        _failedWrites = 1;
+    }
+
+    // The window to persist, or null when there is nothing recordable — a streak shorter
+    // than minRecordableWindow is a transient (the event-write layer already retries
+    // those) and is discarded here.
+    public UnwritableWindow? OnWriteSucceeded(DateTime nowUtc)
+    {
+        if (_sinceUtc is null)
+            return null;
+
+        if (nowUtc - _sinceUtc.Value < minRecordableWindow)
+        {
+            Reset();
+            return null;
+        }
+
+        return new UnwritableWindow(_sinceUtc.Value, nowUtc, _failedWrites);
+    }
+
+    // Deliberately NOT folded into OnWriteSucceeded for a recordable window: the caller
+    // resets only after the interval row is committed, so a failed persist keeps the
+    // window pending and the next successful write retries it.
+    public void Reset()
+    {
+        _sinceUtc = null;
+        _failedWrites = 0;
+    }
+}
+
+internal sealed record UnwritableWindow(DateTime StartedAtUtc, DateTime EndedAtUtc, int FailedWriteCount);

--- a/tests/DiscordEventService.Tests/DowntimeDbUnreachableTests.cs
+++ b/tests/DiscordEventService.Tests/DowntimeDbUnreachableTests.cs
@@ -1,0 +1,115 @@
+using System.Net;
+using DiscordEventService.Configuration;
+using DiscordEventService.Data;
+using DiscordEventService.Data.Entities.Core;
+using DiscordEventService.Jobs;
+using DiscordEventService.Services;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using Xunit;
+
+namespace DiscordEventService.Tests;
+
+// The persisted half of #320: the DbUnreachable row a recovered outage writes, and the
+// crash-loop alert NOT counting those rows as restarts.
+public sealed class DowntimeDbUnreachableTests(PostgresFixture fixture)
+    : IClassFixture<PostgresFixture>, IAsyncLifetime
+{
+    private DiscordDbContext _db = null!;
+
+    public async Task InitializeAsync()
+    {
+        _db = NewContext();
+        await _db.Database.MigrateAsync();
+        await _db.BotDowntimeIntervals.ExecuteDeleteAsync();
+    }
+
+    public Task DisposeAsync() => _db.DisposeAsync().AsTask();
+
+    [Fact]
+    public async Task RecordDbUnreachableAsync_WritesOneClosedIntervalCoveringTheWholeWindow()
+    {
+        var start = DateTime.UtcNow.AddMinutes(-8);
+        var end = DateTime.UtcNow;
+        var tracker = new DowntimeTrackerService(_db, NullLogger<DowntimeTrackerService>.Instance);
+
+        var id = await tracker.RecordDbUnreachableAsync(new UnwritableWindow(start, end, 96));
+
+        var row = await NewContext().BotDowntimeIntervals.SingleAsync(x => x.Id == id);
+        Assert.Equal(BotDowntimeType.DbUnreachable, row.Type);
+        Assert.Equal(BotDowntimeDetectionMethod.HeartbeatWriteFailure, row.DetectionMethod);
+        Assert.Equal(start, row.StartedAtUtc, TimeSpan.FromMilliseconds(1));
+        Assert.Equal(end, row.EndedAtUtc!.Value, TimeSpan.FromMilliseconds(1));
+        Assert.Contains("96 ticks", row.Notes);
+    }
+
+    [Fact]
+    public async Task CrashLoopAlert_IgnoresDbUnreachableIntervals_ButStillFiresOnRealRestarts()
+    {
+        var now = DateTime.UtcNow;
+        for (var i = 0; i < 3; i++)
+            _db.BotDowntimeIntervals.Add(Interval(BotDowntimeType.DbUnreachable, now.AddMinutes(-20 + i)));
+        await _db.SaveChangesAsync();
+
+        var handler = new CapturingHandler();
+        await using var provider = new ServiceCollection()
+            .AddDbContext<DiscordDbContext>(o => o
+                .UseNpgsql(fixture.ConnectionString)
+                .UseSnakeCaseNamingConvention())
+            .BuildServiceProvider();
+        var job = new HealthCheckJob(
+            provider.GetRequiredService<IServiceScopeFactory>(),
+            new StubHttpClientFactory(handler),
+            Options.Create(new HealthCheckOptions { WebhookUrl = "https://example.test/webhook" }),
+            NullLogger<HealthCheckJob>.Instance);
+
+        // Three surviving-process outages in the window — not a crash-loop.
+        await job.ExecuteAsync(CancellationToken.None);
+        Assert.DoesNotContain(handler.Bodies, body => body.Contains("crash-loop"));
+
+        for (var i = 0; i < 3; i++)
+            _db.BotDowntimeIntervals.Add(Interval(BotDowntimeType.GatewayDisconnect, now.AddMinutes(-10 + i)));
+        await _db.SaveChangesAsync();
+
+        // Three real restarts — the alert must still fire (the exclusion is type-scoped).
+        await job.ExecuteAsync(CancellationToken.None);
+        Assert.Contains(handler.Bodies, body => body.Contains("crash-loop"));
+    }
+
+    private static BotDowntimeIntervalEntity Interval(BotDowntimeType type, DateTime startedAtUtc) => new()
+    {
+        StartedAtUtc = startedAtUtc,
+        EndedAtUtc = startedAtUtc.AddSeconds(30),
+        Type = type,
+        DetectionMethod = BotDowntimeDetectionMethod.HeartbeatWriteFailure,
+    };
+
+    private DiscordDbContext NewContext()
+    {
+        var options = new DbContextOptionsBuilder<DiscordDbContext>()
+            .UseNpgsql(fixture.ConnectionString)
+            .UseSnakeCaseNamingConvention()
+            .Options;
+        return new DiscordDbContext(options);
+    }
+
+    private sealed class CapturingHandler : HttpMessageHandler
+    {
+        public List<string> Bodies { get; } = [];
+
+        protected override async Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            if (request.Content is not null)
+                Bodies.Add(await request.Content.ReadAsStringAsync(cancellationToken));
+            return new HttpResponseMessage(HttpStatusCode.OK);
+        }
+    }
+
+    private sealed class StubHttpClientFactory(HttpMessageHandler handler) : IHttpClientFactory
+    {
+        public HttpClient CreateClient(string name) => new HttpClient(handler, disposeHandler: false);
+    }
+}

--- a/tests/DiscordEventService.Tests/DowntimeDbUnreachableTests.cs
+++ b/tests/DiscordEventService.Tests/DowntimeDbUnreachableTests.cs
@@ -14,6 +14,7 @@ namespace DiscordEventService.Tests;
 
 // The persisted half of #320: the DbUnreachable row a recovered outage writes, and the
 // crash-loop alert NOT counting those rows as restarts.
+[Collection("HealthCheckJobStatics")]
 public sealed class DowntimeDbUnreachableTests(PostgresFixture fixture)
     : IClassFixture<PostgresFixture>, IAsyncLifetime
 {
@@ -42,7 +43,7 @@ public sealed class DowntimeDbUnreachableTests(PostgresFixture fixture)
         Assert.Equal(BotDowntimeDetectionMethod.HeartbeatWriteFailure, row.DetectionMethod);
         Assert.Equal(start, row.StartedAtUtc, TimeSpan.FromMilliseconds(1));
         Assert.Equal(end, row.EndedAtUtc!.Value, TimeSpan.FromMilliseconds(1));
-        Assert.Contains("96 ticks", row.Notes);
+        Assert.Contains("96 failed writes", row.Notes);
     }
 
     [Fact]

--- a/tests/DiscordEventService.Tests/HealthCheckEventRatioTests.cs
+++ b/tests/DiscordEventService.Tests/HealthCheckEventRatioTests.cs
@@ -11,6 +11,7 @@ using Xunit;
 
 namespace DiscordEventService.Tests;
 
+[Collection("HealthCheckJobStatics")]
 public sealed class HealthCheckEventRatioTests(PostgresFixture fixture)
     : IClassFixture<PostgresFixture>, IAsyncLifetime
 {

--- a/tests/DiscordEventService.Tests/HealthCheckJobStaticsCollection.cs
+++ b/tests/DiscordEventService.Tests/HealthCheckJobStaticsCollection.cs
@@ -1,0 +1,10 @@
+using Xunit;
+
+namespace DiscordEventService.Tests;
+
+// HealthCheckJob keeps its alert-cooldown and drop-streak debounce state in assembly-wide
+// statics, so every test class that calls ExecuteAsync mutates shared state (streaks are
+// wiped for event types not currently dropped). One non-parallel collection keeps those
+// classes from interleaving; PostgresFixture isolates only the database, not these statics.
+[CollectionDefinition("HealthCheckJobStatics", DisableParallelization = true)]
+public sealed class HealthCheckJobStaticsCollection;

--- a/tests/DiscordEventService.Tests/UnwritableWindowTrackerTests.cs
+++ b/tests/DiscordEventService.Tests/UnwritableWindowTrackerTests.cs
@@ -78,6 +78,36 @@ public sealed class UnwritableWindowTrackerTests
     }
 
     [Fact]
+    public void ARetryAfterAFailedPersist_DoesNotSlideTheRecoveryInstantForward()
+    {
+        _tracker.OnWriteFailed(T0, gatewayConnected: true);
+
+        var first = _tracker.OnWriteSucceeded(T0.AddSeconds(35));
+        // The persist failed; the retry a minute later must report the SAME window — the
+        // DB was writable in between and the heartbeat rows prove it.
+        var retry = _tracker.OnWriteSucceeded(T0.AddSeconds(95));
+
+        Assert.Equal(first!.EndedAtUtc, retry!.EndedAtUtc);
+        Assert.Equal(T0.AddSeconds(35), retry.EndedAtUtc);
+    }
+
+    [Fact]
+    public void ANewFailureWhileAPersistIsPending_ReopensTheWindow()
+    {
+        _tracker.OnWriteFailed(T0, gatewayConnected: true);
+        Assert.NotNull(_tracker.OnWriteSucceeded(T0.AddSeconds(35)));
+
+        // The DB went down again before the row could be committed — the merged window
+        // must extend to the new recovery, not stay pinned at the first one.
+        _tracker.OnWriteFailed(T0.AddSeconds(40), gatewayConnected: true);
+        var window = _tracker.OnWriteSucceeded(T0.AddSeconds(80));
+
+        Assert.Equal(T0, window!.StartedAtUtc);
+        Assert.Equal(T0.AddSeconds(80), window.EndedAtUtc);
+        Assert.Equal(2, window.FailedWriteCount);
+    }
+
+    [Fact]
     public void ASuccessWithNothingPending_ReturnsNull()
     {
         Assert.Null(_tracker.OnWriteSucceeded(T0));

--- a/tests/DiscordEventService.Tests/UnwritableWindowTrackerTests.cs
+++ b/tests/DiscordEventService.Tests/UnwritableWindowTrackerTests.cs
@@ -1,0 +1,85 @@
+using DiscordEventService.Services;
+using Xunit;
+
+namespace DiscordEventService.Tests;
+
+// The #320 state machine: a streak of failed heartbeat writes with the gateway up becomes
+// one DbUnreachable window, buffered in memory because the DB cannot hold state mid-outage.
+public sealed class UnwritableWindowTrackerTests
+{
+    private static readonly DateTime T0 = new(2026, 7, 25, 0, 39, 0, DateTimeKind.Utc);
+    private static readonly TimeSpan Threshold = TimeSpan.FromSeconds(30);
+
+    private readonly UnwritableWindowTracker _tracker = new(Threshold);
+
+    [Fact]
+    public void ASingleTransientFailure_IsDiscarded_AndTheStateClears()
+    {
+        _tracker.OnWriteFailed(T0, gatewayConnected: true);
+
+        Assert.Null(_tracker.OnWriteSucceeded(T0.AddSeconds(5)));
+        Assert.False(_tracker.HasPendingWindow);
+    }
+
+    [Fact]
+    public void AStreakPastTheThreshold_BecomesOneWindow_FromFirstFailureToRecovery()
+    {
+        // The 2026-07-25 shape: minutes of failed writes while the gateway stayed up.
+        for (var tick = 0; tick < 96; tick++)
+            _tracker.OnWriteFailed(T0.AddSeconds(tick * 5), gatewayConnected: true);
+
+        var window = _tracker.OnWriteSucceeded(T0.AddMinutes(8));
+
+        Assert.NotNull(window);
+        Assert.Equal(T0, window.StartedAtUtc);
+        Assert.Equal(T0.AddMinutes(8), window.EndedAtUtc);
+        Assert.Equal(96, window.FailedWriteCount);
+    }
+
+    [Theory]
+    [InlineData(false)]
+    [InlineData(null)]
+    public void AFailureWithTheGatewayDownOrUnknown_OpensNoWindow(bool? gatewayConnected)
+    {
+        // With the gateway down the process is in a full outage the gateway-disconnect
+        // and startup-gap paths already own.
+        _tracker.OnWriteFailed(T0, gatewayConnected);
+
+        Assert.False(_tracker.HasPendingWindow);
+        Assert.Null(_tracker.OnWriteSucceeded(T0.AddMinutes(5)));
+    }
+
+    [Fact]
+    public void AGatewayDropMidWindow_DoesNotSplitTheWindow()
+    {
+        _tracker.OnWriteFailed(T0, gatewayConnected: true);
+        _tracker.OnWriteFailed(T0.AddSeconds(5), gatewayConnected: false);
+        _tracker.OnWriteFailed(T0.AddSeconds(10), gatewayConnected: true);
+
+        var window = _tracker.OnWriteSucceeded(T0.AddSeconds(35));
+
+        Assert.NotNull(window);
+        Assert.Equal(3, window.FailedWriteCount);
+    }
+
+    [Fact]
+    public void ARecordableWindow_StaysPendingUntilReset_SoAFailedPersistRetries()
+    {
+        _tracker.OnWriteFailed(T0, gatewayConnected: true);
+
+        Assert.NotNull(_tracker.OnWriteSucceeded(T0.AddSeconds(35)));
+        // The caller could not commit the row — the window must survive for the next tick.
+        Assert.True(_tracker.HasPendingWindow);
+        Assert.NotNull(_tracker.OnWriteSucceeded(T0.AddSeconds(40)));
+
+        _tracker.Reset();
+        Assert.False(_tracker.HasPendingWindow);
+        Assert.Null(_tracker.OnWriteSucceeded(T0.AddSeconds(45)));
+    }
+
+    [Fact]
+    public void ASuccessWithNothingPending_ReturnsNull()
+    {
+        Assert.Null(_tracker.OnWriteSucceeded(T0));
+    }
+}


### PR DESCRIPTION
## Problem

`DbUnreachable = 4` and `HostDown = 2` existed in the enum but nothing ever wrote them automatically (#320). The 2026-07-25 outage (~8 min unwritable, 5 presence events lost) was recorded as 93 s of `Inferred` — under-reporting ~5x — and the window where data was actually dropped was invisible.

## Design

The heartbeat is the detector: `HeartbeatBackgroundService` already writes to the DB every 5 s regardless of Discord activity, so a streak of failed heartbeat writes **is** the unwritable window.

- **`UnwritableWindowTracker`** (new, pure state machine): a failed write with the gateway **connected** opens an in-memory window; further failures extend it (a mid-window gateway drop does not split it); the first successful write yields the window to persist. In-memory on purpose — during the outage the DB cannot hold state.
- **Threshold**: a window under **30 s** is discarded as a transient (the event-write retry layer already absorbs single flaps), so one failed tick never opens an interval.
- **Persist-after-recovery**: `DowntimeTrackerService.RecordDbUnreachableAsync` inserts the interval already **closed** (like the startup-gap inference — an open row could not have been written mid-outage), with new detection method `HeartbeatWriteFailure = 4` (additive enum value, no migration). The tracker resets only after the commit — a failed persist keeps the window pending and the next tick retries it.
- **Restart mid-outage**: the buffered window is lost; the existing startup-gap inference records the tail as `Inferred`. Documented, accepted.
- **Crash-loop alert**: `CheckCrashLoopAsync` now excludes `DbUnreachable` — an outage the process survived is not a restart, so the new rows can't make that alert noisy.

## HostDown decision (issue scope 2)

Stays **manual-only**. At startup there is no reliable in-process signal separating a host reboot from a container restart (both look like an unclean gap); an OS-uptime probe isn't worth the coupling. `Inferred` remains the automatic classification for unclean gaps.

## Acceptance mapping

- Simulated outage covering the whole window → `UnwritableWindowTrackerTests` replays the 2026-07-25 shape (96 failed ticks over 8 min) and asserts one window from first failure to recovery; `DowntimeDbUnreachableTests` asserts the persisted row's type/method/bounds/notes against real Postgres.
- Written without needing the DB during the outage → the tracker holds one `DateTime` + counter in memory; persistence happens after the first successful heartbeat write, with retry-until-committed semantics.
- Crash-loop unaffected → integration test seeds 3 `DbUnreachable` intervals (no alert), then 3 `GatewayDisconnect` intervals (alert fires).

Full suite: 373 passed, 1 skipped (paid live-API test).

Closes #320

🤖 Generated with [Claude Code](https://claude.com/claude-code)