### PR TITLE
Closes #193: /health reports commit, build time, runtime and gateway state

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,6 +19,8 @@ jobs:
       dockerfile: src/DiscordEventService/Dockerfile
       # Repo root: the Dockerfile bundles the sibling src/Dashboard SPA.
       context: .
+      # #193: /health reports the deployed commit.
+      build-args: GIT_SHA=${{ github.sha }}
       deploy-compose-path: /home/ubuntu/docker/wojtusdiscord
       deploy-runner-labels: '["self-hosted", "homelab"]'
     secrets: inherit

--- a/src/DiscordEventService/DiscordEventService.csproj
+++ b/src/DiscordEventService/DiscordEventService.csproj
@@ -10,6 +10,13 @@
     <InternalsVisibleTo Include="DiscordEventService.Tests" />
   </ItemGroup>
 
+  <!-- #193: /health reports the deployed commit + build time. SourceRevisionId arrives only
+       from the Docker build (ARG GIT_SHA), so local builds bake nothing and stay
+       incremental — BuildInfo then degrades to "unknown". -->
+  <ItemGroup Condition="'$(SourceRevisionId)' != ''">
+    <AssemblyMetadata Include="BuildTimestampUtc" Value="$([System.DateTime]::UtcNow.ToString('yyyy-MM-ddTHH:mm:ssZ'))" />
+  </ItemGroup>
+
   <ItemGroup>
     <PackageReference Include="DotNetEnv" Version="3.1.1" />
     <PackageReference Include="DSharpPlus" Version="5.0.0-nightly-02485" />

--- a/src/DiscordEventService/Dockerfile
+++ b/src/DiscordEventService/Dockerfile
@@ -15,13 +15,16 @@ RUN npm run build -- --outDir=dist
 
 # Stage 2: Build the .NET backend
 FROM mcr.microsoft.com/dotnet/sdk:10.0 AS build
+# #193: the workflow passes the commit sha so /health can report what is deployed;
+# an empty value leaves SourceRevisionId unset and the endpoint says "unknown".
+ARG GIT_SHA
 WORKDIR /src
 COPY src/DiscordEventService/*.csproj ./
 RUN dotnet restore
 COPY src/DiscordEventService/ ./
 # Bundle the built SPA so the .NET host serves it from wwwroot.
 COPY --from=frontend-build /app/frontend/dist ./wwwroot
-RUN dotnet publish -c Release -o /app/publish /p:UseAppHost=false /p:EnforceCodeStyleInBuild=false /p:RunAnalyzers=false
+RUN dotnet publish -c Release -o /app/publish /p:UseAppHost=false /p:EnforceCodeStyleInBuild=false /p:RunAnalyzers=false /p:SourceRevisionId=$GIT_SHA
 
 # Stage 3: Runtime
 FROM mcr.microsoft.com/dotnet/aspnet:10.0 AS final

--- a/src/DiscordEventService/Infrastructure/BuildInfo.cs
+++ b/src/DiscordEventService/Infrastructure/BuildInfo.cs
@@ -1,0 +1,34 @@
+using System.Reflection;
+
+namespace DiscordEventService.Infrastructure;
+
+// What /health reports about the running binary (#193). Resolved once at registration —
+// assembly attributes never change at runtime. The commit rides in InformationalVersion
+// as "1.0.0+<sha>" (the SDK appends SourceRevisionId, passed by the Docker build); the
+// timestamp is the BuildTimestampUtc assembly metadata the csproj bakes alongside it.
+// Local builds carry neither and degrade to "unknown" instead of crashing.
+internal sealed record BuildInfo(
+    string Commit, string CommitShort, string InformationalVersion, string BuildTimestampUtc)
+{
+    private const int ShortShaLength = 7;
+    private const string Unknown = "unknown";
+
+    public static BuildInfo FromEntryAssembly()
+    {
+        var assembly = Assembly.GetEntryAssembly();
+        return Parse(
+            assembly?.GetCustomAttribute<AssemblyInformationalVersionAttribute>()?.InformationalVersion,
+            assembly?.GetCustomAttributes<AssemblyMetadataAttribute>()
+                .FirstOrDefault(a => string.Equals(a.Key, "BuildTimestampUtc", StringComparison.Ordinal))?.Value);
+    }
+
+    internal static BuildInfo Parse(string? informationalVersion, string? buildTimestampUtc)
+    {
+        var informational = string.IsNullOrWhiteSpace(informationalVersion) ? Unknown : informationalVersion;
+        var plus = informational.IndexOf('+');
+        var commit = plus >= 0 && plus < informational.Length - 1 ? informational[(plus + 1)..] : Unknown;
+        var commitShort = commit.Length > ShortShaLength ? commit[..ShortShaLength] : commit;
+        var timestamp = string.IsNullOrWhiteSpace(buildTimestampUtc) ? Unknown : buildTimestampUtc;
+        return new BuildInfo(commit, commitShort, informational, timestamp);
+    }
+}

--- a/src/DiscordEventService/Infrastructure/HealthResponseWriter.cs
+++ b/src/DiscordEventService/Infrastructure/HealthResponseWriter.cs
@@ -12,6 +12,11 @@ internal static class HealthResponseWriter
 {
     private static readonly JsonSerializerOptions Json = new(JsonSerializerDefaults.Web) { WriteIndented = true };
 
+    // Read once — the value can't change, per-probe Process allocations would pile up for
+    // the finalizer, and an unguarded StartTime throw would 500 every /health and flip
+    // the container unhealthy. Falls back to "since first probe" if the read fails.
+    private static readonly DateTime StartedAtUtc = ReadProcessStartTimeUtc();
+
     public static Task WriteAsync(HttpContext context, HealthReport report)
     {
         var build = context.RequestServices.GetRequiredService<BuildInfo>();
@@ -20,7 +25,7 @@ internal static class HealthResponseWriter
 
         var payload = BuildPayload(
             report, build, environment.EnvironmentName,
-            Process.GetCurrentProcess().StartTime.ToUniversalTime(), DateTime.UtcNow,
+            StartedAtUtc, DateTime.UtcNow,
             connected, latencyMs);
 
         context.Response.ContentType = "application/json";
@@ -52,6 +57,19 @@ internal static class HealthResponseWriter
                 gatewayLatencyMs,
             },
         };
+
+    private static DateTime ReadProcessStartTimeUtc()
+    {
+        try
+        {
+            using var process = Process.GetCurrentProcess();
+            return process.StartTime.ToUniversalTime();
+        }
+        catch (Exception)
+        {
+            return DateTime.UtcNow;
+        }
+    }
 
     private static (bool? Connected, int? LatencyMs) ReadGatewayState(DiscordClientAccessor accessor)
     {

--- a/src/DiscordEventService/Infrastructure/HealthResponseWriter.cs
+++ b/src/DiscordEventService/Infrastructure/HealthResponseWriter.cs
@@ -1,0 +1,80 @@
+using System.Diagnostics;
+using System.Text.Json;
+using DiscordEventService.Services.Conversation;
+using Microsoft.Extensions.Diagnostics.HealthChecks;
+
+namespace DiscordEventService.Infrastructure;
+
+// The /health payload (#193): "what's running and is it healthy" from one endpoint.
+// Everything added here is in-memory state — the only I/O in a /health request stays the
+// EF liveness check the pipeline already ran, so the 30s Docker HEALTHCHECK stays cheap.
+internal static class HealthResponseWriter
+{
+    private static readonly JsonSerializerOptions Json = new(JsonSerializerDefaults.Web) { WriteIndented = true };
+
+    public static Task WriteAsync(HttpContext context, HealthReport report)
+    {
+        var build = context.RequestServices.GetRequiredService<BuildInfo>();
+        var environment = context.RequestServices.GetRequiredService<IHostEnvironment>();
+        var (connected, latencyMs) = ReadGatewayState(context.RequestServices.GetRequiredService<DiscordClientAccessor>());
+
+        var payload = BuildPayload(
+            report, build, environment.EnvironmentName,
+            Process.GetCurrentProcess().StartTime.ToUniversalTime(), DateTime.UtcNow,
+            connected, latencyMs);
+
+        context.Response.ContentType = "application/json";
+        return context.Response.WriteAsync(JsonSerializer.Serialize(payload, Json));
+    }
+
+    internal static object BuildPayload(
+        HealthReport report, BuildInfo build, string environmentName,
+        DateTime startedAtUtc, DateTime nowUtc, bool? gatewayConnected, int? gatewayLatencyMs) => new
+        {
+            status = report.Status.ToString(),
+            checks = report.Entries.ToDictionary(e => e.Key, e => e.Value.Status.ToString(), StringComparer.Ordinal),
+            version = new
+            {
+                commit = build.Commit,
+                commitShort = build.CommitShort,
+                informationalVersion = build.InformationalVersion,
+                buildTimestampUtc = build.BuildTimestampUtc,
+            },
+            runtime = new
+            {
+                environment = environmentName,
+                startedAtUtc,
+                uptime = (nowUtc - startedAtUtc).ToString(@"d\.hh\:mm\:ss"),
+            },
+            discord = new
+            {
+                connected = gatewayConnected,
+                gatewayLatencyMs,
+            },
+        };
+
+    private static (bool? Connected, int? LatencyMs) ReadGatewayState(DiscordClientAccessor accessor)
+    {
+        // The accessor throws until Program.cs sets it just before app.Run — a probe that
+        // races boot (Docker HEALTHCHECK starts at 5s) reports connected=null, not a 500.
+        bool? connected = null;
+        int? latencyMs = null;
+        try
+        {
+            var client = accessor.Client;
+            connected = client.AllShardsConnected;
+
+            // Separate guard: DSharpPlus can throw here mid-reconnect-handshake while
+            // AllShardsConnected already answered — keep the connected flag we have.
+            var firstGuildId = client.Guilds.Keys.FirstOrDefault();
+            if (firstGuildId != 0)
+                latencyMs = (int)client.GetConnectionLatency(firstGuildId).TotalMilliseconds;
+        }
+        catch (Exception)
+        {
+            // Informational fields only — never fail the health response over them.
+        }
+
+        return (connected, latencyMs);
+    }
+}

--- a/src/DiscordEventService/Program.cs
+++ b/src/DiscordEventService/Program.cs
@@ -102,6 +102,9 @@ builder.Services.AddScoped<MessageMentionsBackfillService>();
 builder.Services.AddHealthChecks()
     .AddDbContextCheck<DiscordDbContext>();
 
+// #193: /health reports the deployed commit + runtime state; resolved once, immutable.
+builder.Services.AddSingleton(BuildInfo.FromEntryAssembly());
+
 // Dashboard read API (MVC controllers under Controllers/). Controllers are
 // auto-discovered by MapControllers(); no per-controller registration needed.
 // Snowflakes serialize as strings (JS number precision) for the whole API.
@@ -252,7 +255,12 @@ app.UseStaticFiles();
 
 app.MapControllers();
 
-app.MapHealthChecks("/health");
+// #193: structured JSON with build/version + runtime diagnostics instead of the bare
+// "Healthy" text; same pipeline, so the Docker HEALTHCHECK's status-code contract holds.
+app.MapHealthChecks("/health", new Microsoft.AspNetCore.Diagnostics.HealthChecks.HealthCheckOptions
+{
+    ResponseWriter = HealthResponseWriter.WriteAsync,
+});
 
 app.MapHangfireDashboard("/hangfire");
 

--- a/tests/DiscordEventService.Tests/BuildInfoTests.cs
+++ b/tests/DiscordEventService.Tests/BuildInfoTests.cs
@@ -1,0 +1,63 @@
+using System.Text.Json;
+using DiscordEventService.Infrastructure;
+using Microsoft.Extensions.Diagnostics.HealthChecks;
+using Xunit;
+
+namespace DiscordEventService.Tests;
+
+// The #193 /health payload: commit parsing out of InformationalVersion and the JSON shape
+// the endpoint serves. The sha ride-along is "1.0.0+<sha>" — the SDK appends
+// SourceRevisionId after '+'; local builds have neither sha nor timestamp.
+public sealed class BuildInfoTests
+{
+    [Fact]
+    public void ADockerBuild_YieldsTheFullAndShortCommit()
+    {
+        var info = BuildInfo.Parse("1.0.0+f82efc8badc0ffee00d1e5c0ffeec0de5eed1234", "2026-08-16T12:00:00Z");
+
+        Assert.Equal("f82efc8badc0ffee00d1e5c0ffeec0de5eed1234", info.Commit);
+        Assert.Equal("f82efc8", info.CommitShort);
+        Assert.Equal("2026-08-16T12:00:00Z", info.BuildTimestampUtc);
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("1.0.0")]
+    [InlineData("1.0.0+")]
+    public void ALocalBuild_DegradesToUnknown_InsteadOfCrashing(string? informationalVersion)
+    {
+        var info = BuildInfo.Parse(informationalVersion, null);
+
+        Assert.Equal("unknown", info.Commit);
+        Assert.Equal("unknown", info.CommitShort);
+        Assert.Equal("unknown", info.BuildTimestampUtc);
+    }
+
+    [Fact]
+    public void TheHealthPayload_CarriesStatusChecksVersionRuntimeAndDiscord()
+    {
+        var report = new HealthReport(
+            new Dictionary<string, HealthReportEntry>
+            {
+                ["DiscordDbContext"] = new(HealthStatus.Healthy, null, TimeSpan.Zero, null, null),
+            },
+            TimeSpan.Zero);
+        var build = BuildInfo.Parse("1.0.0+abcdef1234", "2026-08-16T12:00:00Z");
+        var started = new DateTime(2026, 8, 16, 10, 0, 0, DateTimeKind.Utc);
+
+        var json = JsonSerializer.Serialize(HealthResponseWriter.BuildPayload(
+            report, build, "Production", started, started.AddHours(2), gatewayConnected: true, gatewayLatencyMs: 42));
+
+        using var doc = JsonDocument.Parse(json);
+        var root = doc.RootElement;
+        Assert.Equal("Healthy", root.GetProperty("status").GetString());
+        Assert.Equal("Healthy", root.GetProperty("checks").GetProperty("DiscordDbContext").GetString());
+        Assert.Equal("abcdef1234", root.GetProperty("version").GetProperty("commit").GetString());
+        Assert.Equal("abcdef1", root.GetProperty("version").GetProperty("commitShort").GetString());
+        Assert.Equal("Production", root.GetProperty("runtime").GetProperty("environment").GetString());
+        Assert.Equal("0.02:00:00", root.GetProperty("runtime").GetProperty("uptime").GetString());
+        Assert.True(root.GetProperty("discord").GetProperty("connected").GetBoolean());
+        Assert.Equal(42, root.GetProperty("discord").GetProperty("gatewayLatencyMs").GetInt32());
+    }
+}


### PR DESCRIPTION
## Change

`/health` now answers "what's running and is it healthy" with structured JSON instead of bare `Healthy`:

```jsonc
{
  "status": "Healthy",
  "checks": { "DiscordDbContext": "Healthy" },
  "version": { "commit": "37e2a81…", "commitShort": "37e2a81", "informationalVersion": "1.0.0+37e2a81…", "buildTimestampUtc": "…" },
  "runtime": { "environment": "Development", "startedAtUtc": "…", "uptime": "0.00:00:19" },
  "discord": { "connected": true, "gatewayLatencyMs": 0 }
}
```

## How the sha gets in

- `build.yml` passes `build-args: GIT_SHA=${{ github.sha }}` — the reusable workflow **already supports** the `build-args` input and forwards it to docker/build-push-action, so no prerequisite change in `github-workflows`.
- Dockerfile: `ARG GIT_SHA` → `dotnet publish /p:SourceRevisionId=$GIT_SHA`; the SDK appends it to `InformationalVersion` after `+`.
- csproj bakes `BuildTimestampUtc` assembly metadata **only when `SourceRevisionId` is set as a global property** (the Docker build), so local incremental builds don't churn.
- `BuildInfo.Parse` splits the version; anything missing degrades to `"unknown"` instead of crashing.

## Kept cheap

Everything added to the response is in-memory state (assembly attributes, process start, `DiscordClientAccessor` reads) — the only I/O per request stays the existing EF liveness check, so the 30 s Docker `HEALTHCHECK` and its status-code contract are unchanged. The gateway read is guarded: a probe racing boot (accessor unset, `HEALTHCHECK` starts at 5 s) reports `connected: null`, not a 500.

## Verified

- 6 unit tests: sha parsing (docker/local/degenerate) + full payload shape.
- **Live on the dev bot**: booted locally, `curl /health` → the JSON above, HTTP 200, log clean. Bonus found in testing: local builds get the sha for free via the SDK's SourceLink integration (`.git` present), with timestamp `"unknown"` as designed.
- Post-merge check: `curl https://wojtusdiscord.home.vicio.ovh/health` must report the deployed `github.sha`.

Full suite: 370 passed, 1 skipped (paid live-API test).

Closes #193

🤖 Generated with [Claude Code](https://claude.com/claude-code)